### PR TITLE
Fix: 404 page button text visibility

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -44,7 +44,24 @@ export default function NotFound() {
                                 The page might have been moved or doesn&apos;t exist. If you followed a link from
                                 your invitation, please check the URL and try again.
                             </Text>
-                            <Button component={Link} href="/" size="lg" color="#8b7355">
+                            <Button
+                                component={Link}
+                                href="/"
+                                size="lg"
+                                variant="filled"
+                                className="primary-cta-button"
+                                style={{
+                                    backgroundColor: "#8b7355",
+                                    borderColor: "#8b7355",
+                                    color: "#ffffff",
+                                    borderRadius: 30,
+                                    padding: "12px 30px",
+                                    fontSize: "18px",
+                                    fontWeight: 600,
+                                    boxShadow: "0 4px 16px rgba(139, 115, 85, 0.3)",
+                                    transition: "all 0.2s ease",
+                                }}
+                            >
                                 Go to Homepage
                             </Button>
                         </Stack>


### PR DESCRIPTION
## Summary
Fixes #27 

The button text on the 404 page was not visible until hovering over it due to missing explicit text color styling.

## Changes
- Updated button to use consistent primary CTA button styling
- Added explicit white text color ()
- Added gold background color ()
- Applied consistent styling with other primary buttons across the site

## Test Plan
- [x] Navigate to a non-existent page (e.g., /nonexistent)
- [x] Verify button text "Go to Homepage" is visible without hovering
- [x] Verify button hover effects work correctly
- [x] Confirm styling matches other primary CTA buttons on the site

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns the 404 CTA with site-wide primary button styles and fixes text visibility.
> 
> - Updates `Button` on `src/app/not-found.tsx` to `variant="filled"` with `className="primary-cta-button"`
> - Adds explicit inline styles (white text, gold background/border `#8b7355`, radius, padding, font size/weight, shadow, transition) for consistent appearance
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d719765a512e9aacf23344e0e0638248e0c66308. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->