### PR TITLE
Fix PostHog CSP violations by adding assets domain

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,7 @@ const localSupabaseUrls = isProduction
     : " http://127.0.0.1:54321 http://127.0.0.1:54421";
 
 // Only include PostHog in production
-const posthogUrls = isProduction ? " https://eu.i.posthog.com" : "";
+const posthogUrls = isProduction ? " https://eu.i.posthog.com https://eu-assets.i.posthog.com" : "";
 
 const nextConfig = {
     images: {


### PR DESCRIPTION
## Summary
- Adds `https://eu-assets.i.posthog.com` to the CSP whitelist in production
- Fixes Content Security Policy violations preventing PostHog from loading scripts and making API calls

## Details
PostHog requires two domains to be whitelisted:
- `https://eu.i.posthog.com` (already included)
- `https://eu-assets.i.posthog.com` (now added)

The assets domain is used for loading:
- Configuration scripts
- Feature scripts (lazy-recorder, dead-clicks-autocapture, surveys, web-vitals)
- API connections

## Test plan
- [ ] Verify no CSP violations in browser console on production
- [ ] Confirm PostHog scripts load successfully
- [ ] Check that PostHog analytics are working correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures PostHog can load required assets in production by expanding the CSP allowlist.
> 
> - Updates `next.config.js` to include `https://eu-assets.i.posthog.com` in `posthogUrls`
> - Extends CSP `script-src`, `script-src-elem`, and `connect-src` to permit the PostHog assets domain in production
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 931b2b56a02f1f1d3a3ff9e110a7c5241061eda4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->