### PR TITLE
fix(ci): skip Cypress binary download to prevent flaky installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,8 @@ jobs:
 
     - name: Install dependencies
       run: npm ci
+      env:
+        CYPRESS_INSTALL_BINARY: 0
 
     - name: Setup Supabase CLI
       uses: supabase/setup-cli@v1


### PR DESCRIPTION
## Summary
- Sets `CYPRESS_INSTALL_BINARY=0` during the `npm ci` step in the e2e job
- The `cypress-io/github-action` step handles the Cypress binary installation with better retry logic, so the manual `npm ci` step doesn't need to download it
- Prevents transient network failures during binary download from failing the e2e matrix jobs

## Root cause
The `e2e (2)` job on main failed when Cypress 15.8.1 binary download timed out/failed during `npm ci`. The `e2e (1)` job succeeded on the same run, confirming this is a flaky network issue rather than a real problem.