### PR TITLE
fix(layout): move MantineProvider above ErrorBoundary

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -108,19 +108,19 @@ export default function RootLayout({
             </head>
             <body className={`${geist.variable} ${geistMono.variable} ${playfair.variable} ${greatVibes.variable} antialiased`} style={{ colorScheme: 'light', display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
                 <PostHogProvider>
-                    <ErrorBoundary>
-                        <Suspense fallback={null}>
-                            <PageViewTracker />
-                        </Suspense>
-                        <MantineProvider theme={theme} forceColorScheme="light">
+                    <MantineProvider theme={theme} forceColorScheme="light">
+                        <ErrorBoundary>
+                            <Suspense fallback={null}>
+                                <PageViewTracker />
+                            </Suspense>
                             <AuthProvider>
                                 <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
                                     {children}
                                 </div>
                                 <Footer />
                             </AuthProvider>
-                        </MantineProvider>
-                    </ErrorBoundary>
+                        </ErrorBoundary>
+                    </MantineProvider>
                 </PostHogProvider>
                 <Analytics />
                 <SpeedInsights />


### PR DESCRIPTION
## Root cause

The `ErrorBoundary` was wrapping `MantineProvider` in the root layout. Its fallback UI imports and renders Mantine components (`Container`, `Title`, `Text`, `Button`, `Stack`, `Paper`, `Code`), but since the ErrorBoundary sat _above_ MantineProvider, those components had no provider in scope when the fallback rendered.

**Provider tree before:**
```
PostHogProvider
  └── ErrorBoundary            ← catches errors
        └── MantineProvider    ← inside ErrorBoundary
              └── ...children
```

When any JS error was caught, the fallback rendered Mantine components outside the provider, throwing:
> `@mantine/core: MantineProvider was not found in component tree`

This secondary error masked the original error. The iOS Safari report was because something on that platform triggered the ErrorBoundary first.

## Fix

Move `MantineProvider` above `ErrorBoundary` so the fallback UI is always within the provider tree:

```
PostHogProvider
  └── MantineProvider          ← always in scope
        └── ErrorBoundary      ← fallback renders inside provider
              └── ...children
```

## Test plan
- [ ] Verify the app loads normally
- [ ] Verify an artificially triggered error shows the ErrorBoundary fallback correctly (no secondary Mantine error)