### PR TITLE
feat(schedule): add event times and Cava reception

### DIFF
--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -39,7 +39,7 @@ const schedule: DaySchedule[] = [
         events: [
             { time: "14:00", title: "Check in for staying guests", icon: <IconDoorEnter size={20} /> },
             { title: "Pool Bar & BBQ", icon: <IconPool size={20} /> },
-            { title: "Evening dinner", icon: <IconToolsKitchen2 size={20} /> },
+            { time: "19:00", title: "Tapas", icon: <IconToolsKitchen2 size={20} /> },
             { title: "Live entertainment", icon: <IconMusic size={20} /> },
         ],
     },
@@ -50,9 +50,10 @@ const schedule: DaySchedule[] = [
         bgColor: "linear-gradient(135deg, #fdfcfa 0%, #f5f0e8 100%)",
         accentColor: "var(--gold-dark)",
         events: [
-            { title: "Breakfast", icon: <IconChefHat size={20} /> },
-            { title: "Pre-Ceremony appetisers", icon: <IconGlass size={20} /> },
-            { title: "The Ceremony", icon: <IconHeart size={20} /> },
+            { time: "09:00", title: "Breakfast", icon: <IconChefHat size={20} /> },
+            { time: "12:00", title: "Pre-Ceremony appetisers", icon: <IconGlass size={20} /> },
+            { time: "14:30", title: "Cava reception", icon: <IconGlass size={20} /> },
+            { time: "15:00", title: "The Ceremony", icon: <IconHeart size={20} /> },
             { title: "Reception Dinner", icon: <IconToolsKitchen2 size={20} /> },
             { title: "Live band at Laguna Stage", icon: <IconMicrophone2 size={20} /> },
             { title: "DJ & dancing", icon: <IconMusic size={20} /> },
@@ -66,8 +67,8 @@ const schedule: DaySchedule[] = [
         accentColor: "var(--gold)",
         events: [
             { title: "Breakfast", icon: <IconChefHat size={20} /> },
-            { title: "Pool party & BBQ lunch", icon: <IconPool size={20} /> },
-            { time: "Afternoon", title: "Check out", icon: <IconDoor size={20} /> },
+            { time: "11:00", title: "Check out", icon: <IconDoor size={20} /> },
+            { time: "until 13:00", title: "Pool party & BBQ lunch", icon: <IconPool size={20} /> },
         ],
     },
 ];


### PR DESCRIPTION
## Summary

- Add times to schedule events across all three days
- Rename Friday "Evening dinner" to "Tapas" (19:00)
- Add Saturday times: breakfast 09:00, appetisers 12:00, ceremony 15:00
- Add new Cava reception event at 14:30 on Saturday
- Update Sunday check out from "Afternoon" to 11:00
- Add "until 13:00" time to Sunday pool party & BBQ lunch
- Reorder Sunday events so check out appears before pool party

## Test plan

- [ ] Visit /schedule and verify times display correctly for all three days
- [ ] Confirm Cava reception appears between appetisers and ceremony on Saturday
- [ ] Confirm Sunday check out shows 11:00 and pool shows "until 13:00"