### PR TITLE
feat(seat-finder): add seat finder page with name autocomplete

### DIFF
--- a/cypress/e2e/seat-finder.cy.ts
+++ b/cypress/e2e/seat-finder.cy.ts
@@ -1,0 +1,103 @@
+/// <reference types="cypress" />
+
+/**
+ * Seat Finder E2E Tests
+ *
+ * Today is 2026-05-01, which is before the public release date of 2026-05-22.
+ * The seat finder page is therefore auth-gated: unauthenticated visitors are
+ * redirected to /login.
+ *
+ * The seed data has no seat/table assignments by default, so search results
+ * will be empty — tests cover the empty-state gracefully rather than asserting
+ * on specific seat data.
+ */
+
+describe("Seat Finder", () => {
+    beforeEach(() => {
+        cy.resetDb();
+    });
+
+    describe("Auth gate (before May 22nd 2026)", () => {
+        it("redirects unauthenticated users from /seat-finder to /login", () => {
+            cy.visit("/seat-finder");
+            cy.url({ timeout: 8000 }).should("include", "/login");
+        });
+
+        it("redirects unauthenticated users and preserves the return path", () => {
+            cy.visit("/seat-finder");
+            cy.url({ timeout: 8000 }).should("include", "redirectedFrom");
+        });
+    });
+
+    describe("Authenticated access", () => {
+        beforeEach(() => {
+            cy.login("admin@wedding.test", "TestPassword123!");
+        });
+
+        it("allows a logged-in user to access /seat-finder", () => {
+            cy.visit("/seat-finder");
+            cy.url({ timeout: 8000 }).should("include", "/seat-finder");
+        });
+
+        it("renders the Seat Finder heading", () => {
+            cy.visit("/seat-finder");
+            cy.contains("h1", "Seat Finder", { timeout: 8000 }).should("be.visible");
+        });
+
+        it("renders the name search input", () => {
+            cy.visit("/seat-finder");
+            cy.get("input[placeholder*='Search']", { timeout: 8000 }).should("be.visible");
+        });
+
+        it("renders the SVG seating map on page load", () => {
+            cy.visit("/seat-finder");
+            cy.get('svg[aria-label="Venue seating map"]', { timeout: 8000 }).should("be.visible");
+        });
+
+        it("shows a loader when typing 2+ characters into the search box", () => {
+            cy.visit("/seat-finder");
+
+            const searchInput = cy.get("input[placeholder*='Search']", { timeout: 8000 });
+            searchInput.type("Jo");
+
+            // A Mantine Loader (svg) appears inside the left section of the input while searching
+            cy.get(".mantine-Autocomplete-section svg", { timeout: 5000 }).should("exist");
+        });
+
+        it("shows no crash and no results card for a name that does not exist", () => {
+            cy.visit("/seat-finder");
+
+            cy.get("input[placeholder*='Search']", { timeout: 8000 }).type("Zzznotaguest");
+
+            // Wait for debounce + API round-trip
+            cy.wait(600);
+
+            // The page must still be standing — heading still visible
+            cy.contains("h1", "Seat Finder").should("be.visible");
+
+            // No party results card should appear (it only renders after a name is selected)
+            cy.contains("Table", { timeout: 1000 }).should("not.exist");
+        });
+
+        it("typing fewer than 2 characters does not trigger a search or show results", () => {
+            cy.visit("/seat-finder");
+
+            cy.get("input[placeholder*='Search']", { timeout: 8000 }).type("A");
+
+            // The search icon (not loader) should still be shown — no loader for <2 chars
+            cy.wait(400);
+            cy.get(".mantine-Autocomplete-section svg").should("exist");
+            // Page stays intact
+            cy.contains("h1", "Seat Finder").should("be.visible");
+        });
+
+        it("maintains the SVG map while a search is in progress", () => {
+            cy.visit("/seat-finder");
+
+            cy.get("input[placeholder*='Search']", { timeout: 8000 }).type("Ma");
+
+            // SVG should still be present while loading
+            cy.get('svg[aria-label="Venue seating map"]').should("be.visible");
+        });
+    });
+});

--- a/src/app/api/seat-finder/party/__tests__/route.test.ts
+++ b/src/app/api/seat-finder/party/__tests__/route.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+
+const mockFrom = vi.fn();
+const mockSupabaseClient = {
+    from: mockFrom,
+    auth: { getUser: vi.fn() },
+};
+
+vi.mock("@/utils/supabase/server", () => ({
+    createClient: vi.fn(() => Promise.resolve(mockSupabaseClient)),
+}));
+
+vi.mock("@/utils/api/rateLimit", () => ({
+    checkRateLimit: vi.fn(() => ({ success: true })),
+    rateLimitedResponse: vi.fn(),
+    RATE_LIMITS: { GENERAL: {} },
+}));
+
+const makeRequest = (id: string) =>
+    new NextRequest(`http://localhost:3907/api/seat-finder/party?id=${encodeURIComponent(id)}`);
+
+const makeNoIdRequest = () =>
+    new NextRequest("http://localhost:3907/api/seat-finder/party");
+
+/** Build a per-call mock: first call uses singleResult, second call uses listResult. */
+const setupTwoCalls = (
+    singleResult: object,
+    listResult: object
+) => {
+    const singleChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue(singleResult),
+    };
+
+    const listChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        not: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        // make thenable so the route can await it directly
+        then: (resolve: (v: object) => void) => Promise.resolve(listResult).then(resolve),
+    };
+
+    mockFrom
+        .mockReturnValueOnce(singleChain)
+        .mockReturnValueOnce(listChain);
+
+    return { singleChain, listChain };
+};
+
+describe("GET /api/seat-finder/party", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe("validation", () => {
+        it("returns 400 when id param is missing", async () => {
+            const res = await GET(makeNoIdRequest());
+            expect(res.status).toBe(400);
+            expect((await res.json()).error).toBe("Invalid id");
+        });
+
+        it("returns 400 when id param is blank whitespace", async () => {
+            const res = await GET(makeRequest("   "));
+            expect(res.status).toBe(400);
+            expect((await res.json()).error).toBe("Invalid id");
+        });
+    });
+
+    describe("invitee lookup", () => {
+        it("returns 404 when the invitee is not found", async () => {
+            const singleChain = {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({ data: null, error: { code: "PGRST116" } }),
+            };
+            mockFrom.mockReturnValueOnce(singleChain);
+
+            const res = await GET(makeRequest("nonexistent-id"));
+            expect(res.status).toBe(404);
+            expect((await res.json()).error).toBe("Guest not found");
+        });
+
+        it("returns 404 when the database returns an error on the first query", async () => {
+            const singleChain = {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({ data: null, error: { message: "query error" } }),
+            };
+            mockFrom.mockReturnValueOnce(singleChain);
+
+            const res = await GET(makeRequest("123"));
+            expect(res.status).toBe(404);
+        });
+    });
+
+    describe("successful party fetch", () => {
+        it("returns party members for a valid invitee id", async () => {
+            const partyMembers = [
+                {
+                    id: "1",
+                    first_name: "Alice",
+                    last_name: "Smith",
+                    is_primary: true,
+                    table_number: "3",
+                    seat_number: 2,
+                },
+                {
+                    id: "2",
+                    first_name: "Bob",
+                    last_name: "Smith",
+                    is_primary: false,
+                    table_number: "3",
+                    seat_number: 3,
+                },
+            ];
+
+            setupTwoCalls(
+                { data: { invitation_id: "inv-abc" }, error: null },
+                { data: partyMembers, error: null }
+            );
+
+            const res = await GET(makeRequest("1"));
+            expect(res.status).toBe(200);
+            const body = await res.json();
+            expect(body.party).toEqual(partyMembers);
+        });
+
+        it("uses the invitation_id from the first query to fetch party members", async () => {
+            const { singleChain, listChain } = setupTwoCalls(
+                { data: { invitation_id: "inv-xyz" }, error: null },
+                { data: [], error: null }
+            );
+
+            await GET(makeRequest("1"));
+
+            expect(singleChain.eq).toHaveBeenCalledWith("id", "1");
+            expect(listChain.eq).toHaveBeenCalledWith("invitation_id", "inv-xyz");
+        });
+
+        it("filters party members by coming=true and seat_number not null", async () => {
+            const { listChain } = setupTwoCalls(
+                { data: { invitation_id: "inv-abc" }, error: null },
+                { data: [], error: null }
+            );
+
+            await GET(makeRequest("1"));
+
+            expect(listChain.eq).toHaveBeenCalledWith("coming", true);
+            expect(listChain.not).toHaveBeenCalledWith("seat_number", "is", null);
+        });
+
+        it("returns empty party array when no seated members exist", async () => {
+            setupTwoCalls(
+                { data: { invitation_id: "inv-abc" }, error: null },
+                { data: [], error: null }
+            );
+
+            const res = await GET(makeRequest("1"));
+            expect(res.status).toBe(200);
+            expect((await res.json()).party).toEqual([]);
+        });
+    });
+
+    describe("error handling", () => {
+        it("returns 500 when the party query fails", async () => {
+            const singleChain = {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                single: vi.fn().mockResolvedValue({ data: { invitation_id: "inv-abc" }, error: null }),
+            };
+            const listChain = {
+                select: vi.fn().mockReturnThis(),
+                eq: vi.fn().mockReturnThis(),
+                not: vi.fn().mockReturnThis(),
+                order: vi.fn().mockReturnThis(),
+                then: (resolve: (v: object) => void) =>
+                    Promise.resolve({ data: null, error: { message: "db failure" } }).then(resolve),
+            };
+
+            mockFrom
+                .mockReturnValueOnce(singleChain)
+                .mockReturnValueOnce(listChain);
+
+            const res = await GET(makeRequest("1"));
+            expect(res.status).toBe(500);
+            expect((await res.json()).error).toBe("Internal server error");
+        });
+    });
+
+    describe("rate limiting", () => {
+        it("returns rate-limited response when limit is exceeded", async () => {
+            const { checkRateLimit, rateLimitedResponse } = await import("@/utils/api/rateLimit");
+            vi.mocked(checkRateLimit).mockReturnValueOnce({ success: false } as ReturnType<typeof checkRateLimit>);
+            const mockLimitedRes = new Response(null, { status: 429 });
+            const typed = mockLimitedRes as ReturnType<typeof rateLimitedResponse>;
+            vi.mocked(rateLimitedResponse).mockReturnValueOnce(typed);
+
+            const res = await GET(makeRequest("1"));
+            expect(res.status).toBe(429);
+        });
+    });
+});

--- a/src/app/api/seat-finder/party/__tests__/route.test.ts
+++ b/src/app/api/seat-finder/party/__tests__/route.test.ts
@@ -5,7 +5,7 @@ import { GET } from "../route";
 const mockFrom = vi.fn();
 const mockSupabaseClient = {
     from: mockFrom,
-    auth: { getUser: vi.fn() },
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: "test-user" } }, error: null }) },
 };
 
 vi.mock("@/utils/supabase/server", () => ({

--- a/src/app/api/seat-finder/party/route.ts
+++ b/src/app/api/seat-finder/party/route.ts
@@ -14,6 +14,12 @@ export async function GET(request: NextRequest) {
 
     const supabase = await createClient();
 
+    const SEAT_FINDER_PUBLIC_DATE = new Date("2026-05-22T00:00:00Z");
+    if (new Date() < SEAT_FINDER_PUBLIC_DATE) {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     // Look up the invitee to get their invitation_id
     const { data: invitee, error: inviteeError } = await supabase
         .from("invitees")

--- a/src/app/api/seat-finder/party/route.ts
+++ b/src/app/api/seat-finder/party/route.ts
@@ -6,10 +6,9 @@ export async function GET(request: NextRequest) {
     const rateLimit = checkRateLimit(request, RATE_LIMITS.GENERAL);
     if (!rateLimit.success) return rateLimitedResponse(rateLimit);
 
-    const idParam = request.nextUrl.searchParams.get("id");
-    const inviteeId = idParam ? parseInt(idParam, 10) : NaN;
+    const inviteeId = request.nextUrl.searchParams.get("id")?.trim() ?? "";
 
-    if (isNaN(inviteeId)) {
+    if (!inviteeId) {
         return NextResponse.json({ error: "Invalid id" }, { status: 400 });
     }
 
@@ -31,6 +30,8 @@ export async function GET(request: NextRequest) {
         .from("invitees")
         .select("id, first_name, last_name, is_primary, table_number, seat_number")
         .eq("invitation_id", invitee.invitation_id)
+        .eq("coming", true)
+        .not("seat_number", "is", null)
         .order("is_primary", { ascending: false })
         .order("first_name");
 

--- a/src/app/api/seat-finder/party/route.ts
+++ b/src/app/api/seat-finder/party/route.ts
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
     // Fetch all members of the same invitation
     const { data: party, error: partyError } = await supabase
         .from("invitees")
-        .select("id, first_name, last_name, is_primary")
+        .select("id, first_name, last_name, is_primary, table_number, seat_number")
         .eq("invitation_id", invitee.invitation_id)
         .order("is_primary", { ascending: false })
         .order("first_name");

--- a/src/app/api/seat-finder/party/route.ts
+++ b/src/app/api/seat-finder/party/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/utils/supabase/server";
+import { checkRateLimit, rateLimitedResponse, RATE_LIMITS } from "@/utils/api/rateLimit";
+
+export async function GET(request: NextRequest) {
+    const rateLimit = checkRateLimit(request, RATE_LIMITS.GENERAL);
+    if (!rateLimit.success) return rateLimitedResponse(rateLimit);
+
+    const idParam = request.nextUrl.searchParams.get("id");
+    const inviteeId = idParam ? parseInt(idParam, 10) : NaN;
+
+    if (isNaN(inviteeId)) {
+        return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+    }
+
+    const supabase = await createClient();
+
+    // Look up the invitee to get their invitation_id
+    const { data: invitee, error: inviteeError } = await supabase
+        .from("invitees")
+        .select("invitation_id")
+        .eq("id", inviteeId)
+        .single();
+
+    if (inviteeError || !invitee) {
+        return NextResponse.json({ error: "Guest not found" }, { status: 404 });
+    }
+
+    // Fetch all members of the same invitation
+    const { data: party, error: partyError } = await supabase
+        .from("invitees")
+        .select("id, first_name, last_name, is_primary")
+        .eq("invitation_id", invitee.invitation_id)
+        .order("is_primary", { ascending: false })
+        .order("first_name");
+
+    if (partyError) {
+        console.error("Seat finder party error:", partyError);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+
+    return NextResponse.json({ party: party ?? [] });
+}

--- a/src/app/api/seat-finder/search/__tests__/route.test.ts
+++ b/src/app/api/seat-finder/search/__tests__/route.test.ts
@@ -5,7 +5,7 @@ import { GET } from "../route";
 const mockFrom = vi.fn();
 const mockSupabaseClient = {
     from: mockFrom,
-    auth: { getUser: vi.fn() },
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: "test-user" } }, error: null }) },
 };
 
 vi.mock("@/utils/supabase/server", () => ({

--- a/src/app/api/seat-finder/search/__tests__/route.test.ts
+++ b/src/app/api/seat-finder/search/__tests__/route.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+
+const mockFrom = vi.fn();
+const mockSupabaseClient = {
+    from: mockFrom,
+    auth: { getUser: vi.fn() },
+};
+
+vi.mock("@/utils/supabase/server", () => ({
+    createClient: vi.fn(() => Promise.resolve(mockSupabaseClient)),
+}));
+
+vi.mock("@/utils/api/rateLimit", () => ({
+    checkRateLimit: vi.fn(() => ({ success: true })),
+    rateLimitedResponse: vi.fn(),
+    RATE_LIMITS: { GENERAL: {} },
+}));
+
+const createChain = (resolveWith: object) => {
+    const chain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        not: vi.fn().mockReturnThis(),
+        or: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue(resolveWith),
+    };
+    return chain;
+};
+
+const makeRequest = (q: string) =>
+    new NextRequest(`http://localhost:3907/api/seat-finder/search?q=${encodeURIComponent(q)}`);
+
+describe("GET /api/seat-finder/search", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe("input sanitisation", () => {
+        it("returns empty array when q is absent", async () => {
+            const req = new NextRequest("http://localhost:3907/api/seat-finder/search");
+            const res = await GET(req);
+            expect(res.status).toBe(200);
+            expect(await res.json()).toEqual([]);
+        });
+
+        it("returns empty array when q is a single character", async () => {
+            const res = await GET(makeRequest("A"));
+            expect(res.status).toBe(200);
+            expect(await res.json()).toEqual([]);
+        });
+
+        it("returns empty array when q becomes < 2 chars after stripping disallowed chars", async () => {
+            // "1a" — the digit is stripped, leaving just "a" (1 char)
+            const res = await GET(makeRequest("1a"));
+            expect(res.status).toBe(200);
+            expect(await res.json()).toEqual([]);
+        });
+
+        it("strips non-alpha/space/hyphen/apostrophe characters before querying", async () => {
+            const chain = createChain({ data: [], error: null });
+            mockFrom.mockReturnValue(chain);
+
+            // "Jo123hn" — digits stripped, leaving "John" (4 chars) which is valid
+            const res = await GET(makeRequest("Jo123hn"));
+            expect(res.status).toBe(200);
+            // The or() call should have used the sanitised value
+            expect(chain.or).toHaveBeenCalledWith(
+                expect.stringContaining("John")
+            );
+            expect(chain.or).not.toHaveBeenCalledWith(
+                expect.stringContaining("123")
+            );
+        });
+
+        it("allows hyphens and apostrophes through", async () => {
+            const chain = createChain({ data: [], error: null });
+            mockFrom.mockReturnValue(chain);
+
+            await GET(makeRequest("O'Brien"));
+            expect(chain.or).toHaveBeenCalledWith(
+                expect.stringContaining("O'Brien")
+            );
+        });
+    });
+
+    describe("successful search", () => {
+        it("returns mapped results for a valid query", async () => {
+            const dbRows = [
+                { id: "1", first_name: "Alice", last_name: "Smith" },
+                { id: "2", first_name: "Alan",  last_name: "Jones" },
+            ];
+            const chain = createChain({ data: dbRows, error: null });
+            mockFrom.mockReturnValue(chain);
+
+            const res = await GET(makeRequest("Al"));
+            expect(res.status).toBe(200);
+            expect(await res.json()).toEqual([
+                { id: "1", name: "Alice Smith" },
+                { id: "2", name: "Alan Jones"  },
+            ]);
+        });
+
+        it("queries the invitees table with coming=true and seat_number not null filters", async () => {
+            const chain = createChain({ data: [], error: null });
+            mockFrom.mockReturnValue(chain);
+
+            await GET(makeRequest("Jo"));
+
+            expect(mockFrom).toHaveBeenCalledWith("invitees");
+            expect(chain.eq).toHaveBeenCalledWith("coming", true);
+            expect(chain.not).toHaveBeenCalledWith("seat_number", "is", null);
+        });
+
+        it("returns empty array when no matches found", async () => {
+            const chain = createChain({ data: [], error: null });
+            mockFrom.mockReturnValue(chain);
+
+            const res = await GET(makeRequest("Zzz"));
+            expect(res.status).toBe(200);
+            expect(await res.json()).toEqual([]);
+        });
+    });
+
+    describe("error handling", () => {
+        it("returns 500 when the database returns an error", async () => {
+            const chain = createChain({ data: null, error: { message: "db failure" } });
+            mockFrom.mockReturnValue(chain);
+
+            const res = await GET(makeRequest("Jo"));
+            expect(res.status).toBe(500);
+            const body = await res.json();
+            expect(body.error).toBe("Internal server error");
+        });
+    });
+
+    describe("rate limiting", () => {
+        it("returns the rate-limited response when the limit is exceeded", async () => {
+            const { checkRateLimit, rateLimitedResponse } = await import("@/utils/api/rateLimit");
+            vi.mocked(checkRateLimit).mockReturnValueOnce({ success: false } as ReturnType<typeof checkRateLimit>);
+            const mockLimitedRes = new Response(null, { status: 429 });
+            const typed = mockLimitedRes as ReturnType<typeof rateLimitedResponse>;
+            vi.mocked(rateLimitedResponse).mockReturnValueOnce(typed);
+
+            const res = await GET(makeRequest("Jo"));
+            expect(res.status).toBe(429);
+        });
+    });
+});

--- a/src/app/api/seat-finder/search/route.ts
+++ b/src/app/api/seat-finder/search/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/utils/supabase/server";
+import { checkRateLimit, rateLimitedResponse, RATE_LIMITS } from "@/utils/api/rateLimit";
+
+export async function GET(request: NextRequest) {
+    const rateLimit = checkRateLimit(request, RATE_LIMITS.GENERAL);
+    if (!rateLimit.success) return rateLimitedResponse(rateLimit);
+
+    const q = request.nextUrl.searchParams.get("q")?.trim() ?? "";
+
+    if (q.length < 2) {
+        return NextResponse.json([]);
+    }
+
+    const supabase = await createClient();
+
+    const { data, error } = await supabase
+        .from("invitees")
+        .select("id, first_name, last_name")
+        .or(`first_name.ilike.%${q}%,last_name.ilike.%${q}%`)
+        .order("first_name")
+        .limit(10);
+
+    if (error) {
+        console.error("Seat finder search error:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+
+    const results = (data ?? []).map((invitee) => ({
+        id: invitee.id,
+        name: `${invitee.first_name} ${invitee.last_name}`,
+    }));
+
+    return NextResponse.json(results);
+}

--- a/src/app/api/seat-finder/search/route.ts
+++ b/src/app/api/seat-finder/search/route.ts
@@ -6,7 +6,9 @@ export async function GET(request: NextRequest) {
     const rateLimit = checkRateLimit(request, RATE_LIMITS.GENERAL);
     if (!rateLimit.success) return rateLimitedResponse(rateLimit);
 
-    const q = request.nextUrl.searchParams.get("q")?.trim() ?? "";
+    const raw = request.nextUrl.searchParams.get("q")?.trim() ?? "";
+    // Strip characters that could distort PostgREST filter strings
+    const q = raw.replace(/[^a-zA-Z\s\-']/g, "").trim();
 
     if (q.length < 2) {
         return NextResponse.json([]);

--- a/src/app/api/seat-finder/search/route.ts
+++ b/src/app/api/seat-finder/search/route.ts
@@ -16,6 +16,12 @@ export async function GET(request: NextRequest) {
 
     const supabase = await createClient();
 
+    const SEAT_FINDER_PUBLIC_DATE = new Date("2026-05-22T00:00:00Z");
+    if (new Date() < SEAT_FINDER_PUBLIC_DATE) {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     const { data, error } = await supabase
         .from("invitees")
         .select("id, first_name, last_name")

--- a/src/app/api/seat-finder/seats/__tests__/route.test.ts
+++ b/src/app/api/seat-finder/seats/__tests__/route.test.ts
@@ -5,7 +5,7 @@ import { GET } from "../route";
 const mockFrom = vi.fn();
 const mockSupabaseClient = {
     from: mockFrom,
-    auth: { getUser: vi.fn() },
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: "test-user" } }, error: null }) },
 };
 
 vi.mock("@/utils/supabase/server", () => ({

--- a/src/app/api/seat-finder/seats/__tests__/route.test.ts
+++ b/src/app/api/seat-finder/seats/__tests__/route.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+
+const mockFrom = vi.fn();
+const mockSupabaseClient = {
+    from: mockFrom,
+    auth: { getUser: vi.fn() },
+};
+
+vi.mock("@/utils/supabase/server", () => ({
+    createClient: vi.fn(() => Promise.resolve(mockSupabaseClient)),
+}));
+
+vi.mock("@/utils/api/rateLimit", () => ({
+    checkRateLimit: vi.fn(() => ({ success: true })),
+    rateLimitedResponse: vi.fn(),
+    RATE_LIMITS: { GENERAL: {} },
+}));
+
+const createChain = (resolveWith: object) => {
+    const chain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        not: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        // The route calls .order() twice — the second call resolves
+        then: (resolve: (v: object) => void) => Promise.resolve(resolveWith).then(resolve),
+    };
+    return chain;
+};
+
+const makeRequest = () =>
+    new NextRequest("http://localhost:3907/api/seat-finder/seats");
+
+describe("GET /api/seat-finder/seats", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe("successful response", () => {
+        it("returns all seated invitees mapped to { tableNumber, seatNumber, name }", async () => {
+            const dbRows = [
+                { first_name: "Alice", last_name: "Smith", table_number: "1", seat_number: 1 },
+                { first_name: "Bob",   last_name: "Jones", table_number: "1", seat_number: 2 },
+                { first_name: "Carol", last_name: "White", table_number: "2", seat_number: 1 },
+            ];
+            mockFrom.mockReturnValue(createChain({ data: dbRows, error: null }));
+
+            const res = await GET(makeRequest());
+            expect(res.status).toBe(200);
+            expect(await res.json()).toEqual([
+                { tableNumber: "1", seatNumber: 1, name: "Alice Smith" },
+                { tableNumber: "1", seatNumber: 2, name: "Bob Jones" },
+                { tableNumber: "2", seatNumber: 1, name: "Carol White" },
+            ]);
+        });
+
+        it("returns an empty array when there are no seated invitees", async () => {
+            mockFrom.mockReturnValue(createChain({ data: [], error: null }));
+
+            const res = await GET(makeRequest());
+            expect(res.status).toBe(200);
+            expect(await res.json()).toEqual([]);
+        });
+
+        it("queries invitees with coming=true and seat_number not null filters", async () => {
+            const chain = createChain({ data: [], error: null });
+            mockFrom.mockReturnValue(chain);
+
+            await GET(makeRequest());
+
+            expect(mockFrom).toHaveBeenCalledWith("invitees");
+            expect(chain.eq).toHaveBeenCalledWith("coming", true);
+            expect(chain.not).toHaveBeenCalledWith("seat_number", "is", null);
+        });
+
+        it("orders results by table_number then seat_number", async () => {
+            const chain = createChain({ data: [], error: null });
+            mockFrom.mockReturnValue(chain);
+
+            await GET(makeRequest());
+
+            expect(chain.order).toHaveBeenCalledWith("table_number");
+            expect(chain.order).toHaveBeenCalledWith("seat_number");
+        });
+    });
+
+    describe("error handling", () => {
+        it("returns 500 when the database returns an error", async () => {
+            mockFrom.mockReturnValue(createChain({ data: null, error: { message: "connection refused" } }));
+
+            const res = await GET(makeRequest());
+            expect(res.status).toBe(500);
+            expect((await res.json()).error).toBe("Internal server error");
+        });
+    });
+
+    describe("rate limiting", () => {
+        it("returns rate-limited response when limit is exceeded", async () => {
+            const { checkRateLimit, rateLimitedResponse } = await import("@/utils/api/rateLimit");
+            vi.mocked(checkRateLimit).mockReturnValueOnce({ success: false } as ReturnType<typeof checkRateLimit>);
+            const mockLimitedRes = new Response(null, { status: 429 });
+            const typed = mockLimitedRes as ReturnType<typeof rateLimitedResponse>;
+            vi.mocked(rateLimitedResponse).mockReturnValueOnce(typed);
+
+            const res = await GET(makeRequest());
+            expect(res.status).toBe(429);
+        });
+    });
+});

--- a/src/app/api/seat-finder/seats/route.ts
+++ b/src/app/api/seat-finder/seats/route.ts
@@ -6,34 +6,26 @@ export async function GET(request: NextRequest) {
     const rateLimit = checkRateLimit(request, RATE_LIMITS.GENERAL);
     if (!rateLimit.success) return rateLimitedResponse(rateLimit);
 
-    const raw = request.nextUrl.searchParams.get("q")?.trim() ?? "";
-    // Strip characters that could distort PostgREST filter strings
-    const q = raw.replace(/[^a-zA-Z\s\-']/g, "").trim();
-
-    if (q.length < 2) {
-        return NextResponse.json([]);
-    }
-
     const supabase = await createClient();
 
     const { data, error } = await supabase
         .from("invitees")
-        .select("id, first_name, last_name")
-        .or(`first_name.ilike.%${q}%,last_name.ilike.%${q}%`)
+        .select("first_name, last_name, table_number, seat_number")
         .eq("coming", true)
         .not("seat_number", "is", null)
-        .order("first_name")
-        .limit(10);
+        .order("table_number")
+        .order("seat_number");
 
     if (error) {
-        console.error("Seat finder search error:", error);
+        console.error("Seat finder seats error:", error);
         return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 
-    const results = (data ?? []).map((invitee) => ({
-        id: invitee.id,
-        name: `${invitee.first_name} ${invitee.last_name}`,
+    const seats = (data ?? []).map((r) => ({
+        tableNumber: r.table_number as string,
+        seatNumber: r.seat_number as number,
+        name: `${r.first_name} ${r.last_name}`,
     }));
 
-    return NextResponse.json(results);
+    return NextResponse.json(seats);
 }

--- a/src/app/api/seat-finder/seats/route.ts
+++ b/src/app/api/seat-finder/seats/route.ts
@@ -8,6 +8,12 @@ export async function GET(request: NextRequest) {
 
     const supabase = await createClient();
 
+    const SEAT_FINDER_PUBLIC_DATE = new Date("2026-05-22T00:00:00Z");
+    if (new Date() < SEAT_FINDER_PUBLIC_DATE) {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     const { data, error } = await supabase
         .from("invitees")
         .select("first_name, last_name, table_number, seat_number")

--- a/src/app/seat-finder/SeatingMap.tsx
+++ b/src/app/seat-finder/SeatingMap.tsx
@@ -160,7 +160,11 @@ export function SeatingMap({ allSeats = [], highlightedSeats = [], onSeatClick }
                         stroke={isOwn ? "#6d5a44" : isParty ? "#c9a84c" : "rgba(139,115,85,0.3)"}
                         strokeWidth={isOwn ? 2.5 : isParty ? 2 : 1}
                         style={clickable ? { cursor: "pointer" } : undefined}
-                        onClick={clickable ? () => onSeatClick?.(clickable) : undefined}
+                        onClick={clickable ? () => onSeatClick?.({
+                            name: clickable.name,
+                            tableNumber: clickable.tableNumber,
+                            seatNumber: clickable.seatNumber,
+                        }) : undefined}
                     />
                 );
             })}

--- a/src/app/seat-finder/SeatingMap.tsx
+++ b/src/app/seat-finder/SeatingMap.tsx
@@ -2,99 +2,135 @@ interface HighlightedSeat {
     tableNumber: string;
     seatNumber: number;
     isOwn: boolean;
+    name: string;
+}
+
+interface SeatClickInfo {
+    name: string;
+    tableNumber: string;
+    seatNumber: number;
 }
 
 interface SeatingMapProps {
+    allSeats?: SeatClickInfo[];
     highlightedSeats?: HighlightedSeat[];
+    onSeatClick?: (info: SeatClickInfo) => void;
 }
 
-const R = 14;
+// Bride at right end of table 1, groom at left end of table 2, adjacent at the shared edge
+// Positions 6 and 7 in the 12-seat row (45px spacing from 153)
+const COUPLE_SEATS = [
+    { key: "bride", x: 378, y: 92, label: "Bride" },
+    { key: "groom", x: 423, y: 92, label: "Groom" },
+];
+
+// Layout constants — edges meet to form a connected U-shape
+const LX   = 148;   // left outer edge (L1 left, L3/L5 left)
+const RX   = 652;   // right outer edge (L2 right, L4/L6 right)
+const SW   = 88;    // side table column width
+const TY   = 110;   // top of L1/L2
+const TH   = 56;    // height of L1/L2
+const SY   = TY + TH;   // 166 — side tables start here
+const DY   = 382;   // dividing line between L3/L4 and L5/L6
+const BY   = 596;   // bottom of L5/L6
+const GAP  = 0;     // tables 1 and 2 share an edge
+const MID  = (LX + RX) / 2;  // 400
+
+// Pill dimensions: "v" = tall (top-row seats), "h" = wide (side seats)
+const VW = 15, VH = 21;
+const HW = 21, HH = 15;
 
 const TABLES = [
-    { id: "L1", x: 170, y: 112, w: 172, h: 58 },
-    { id: "L2", x: 458, y: 112, w: 172, h: 58 },
-    { id: "L3", x: 152, y: 192, w: 92, h: 184 },
-    { id: "L4", x: 556, y: 192, w: 92, h: 184 },
-    { id: "L5", x: 152, y: 400, w: 92, h: 192 },
-    { id: "L6", x: 556, y: 400, w: 92, h: 192 },
+    { id: "1", x: LX,        y: TY, w: MID - LX - GAP / 2,   h: TH },
+    { id: "2", x: MID + GAP / 2, y: TY, w: RX - MID - GAP / 2, h: TH },
+    { id: "3", x: LX,        y: SY, w: SW, h: DY - SY },
+    { id: "4", x: RX - SW,   y: SY, w: SW, h: DY - SY },
+    { id: "5", x: LX,        y: DY, w: SW, h: BY - DY },
+    { id: "6", x: RX - SW,   y: DY, w: SW, h: BY - DY },
 ];
 
-// Seat positions match the physical chart layout.
-// L1/L2: seats along north edge. L3/L5: west=outside, east=inside.
-// L4/L6: west=inside, east=outside.
 const SEATS = [
-    { t: "L1", s: 1,  x: 148, y: 90  },
-    { t: "L1", s: 2,  x: 213, y: 90  },
-    { t: "L1", s: 3,  x: 251, y: 90  },
-    { t: "L1", s: 4,  x: 289, y: 90  },
-    { t: "L1", s: 5,  x: 327, y: 90  },
-    { t: "L2", s: 1,  x: 473, y: 90  },
-    { t: "L2", s: 2,  x: 511, y: 90  },
-    { t: "L2", s: 3,  x: 549, y: 90  },
-    { t: "L2", s: 4,  x: 587, y: 90  },
-    { t: "L2", s: 5,  x: 652, y: 90  },
-    { t: "L3", s: 1,  x: 120, y: 213 },
-    { t: "L3", s: 2,  x: 120, y: 250 },
-    { t: "L3", s: 3,  x: 120, y: 287 },
-    { t: "L3", s: 4,  x: 120, y: 324 },
-    { t: "L3", s: 5,  x: 120, y: 361 },
-    { t: "L3", s: 6,  x: 261, y: 228 },
-    { t: "L3", s: 7,  x: 261, y: 283 },
-    { t: "L3", s: 8,  x: 261, y: 338 },
-    { t: "L4", s: 1,  x: 539, y: 228 },
-    { t: "L4", s: 2,  x: 539, y: 283 },
-    { t: "L4", s: 3,  x: 539, y: 338 },
-    { t: "L4", s: 4,  x: 680, y: 213 },
-    { t: "L4", s: 5,  x: 680, y: 250 },
-    { t: "L4", s: 6,  x: 680, y: 287 },
-    { t: "L4", s: 7,  x: 680, y: 324 },
-    { t: "L4", s: 8,  x: 680, y: 361 },
-    { t: "L5", s: 1,  x: 120, y: 420 },
-    { t: "L5", s: 2,  x: 120, y: 459 },
-    { t: "L5", s: 3,  x: 120, y: 498 },
-    { t: "L5", s: 4,  x: 120, y: 537 },
-    { t: "L5", s: 5,  x: 120, y: 576 },
-    { t: "L5", s: 6,  x: 261, y: 420 },
-    { t: "L5", s: 7,  x: 261, y: 459 },
-    { t: "L5", s: 8,  x: 261, y: 498 },
-    { t: "L5", s: 9,  x: 261, y: 537 },
-    { t: "L5", s: 10, x: 261, y: 576 },
-    { t: "L6", s: 1,  x: 539, y: 420 },
-    { t: "L6", s: 2,  x: 539, y: 459 },
-    { t: "L6", s: 3,  x: 539, y: 498 },
-    { t: "L6", s: 4,  x: 539, y: 537 },
-    { t: "L6", s: 5,  x: 539, y: 576 },
-    { t: "L6", s: 6,  x: 680, y: 420 },
-    { t: "L6", s: 7,  x: 680, y: 459 },
-    { t: "L6", s: 8,  x: 680, y: 498 },
-    { t: "L6", s: 9,  x: 680, y: 537 },
-    { t: "L6", s: 10, x: 680, y: 576 },
+    // 1 — 12-seat row at 45px spacing across both tables; T1 seats occupy positions 1-5
+    { t: "1", s: 1,  x: 153, y: 92,  o: "v" },
+    { t: "1", s: 2,  x: 198, y: 92,  o: "v" },
+    { t: "1", s: 3,  x: 243, y: 92,  o: "v" },
+    { t: "1", s: 4,  x: 288, y: 92,  o: "v" },
+    { t: "1", s: 5,  x: 333, y: 92,  o: "v" },
+    // 2 — T2 seats occupy positions 8-12
+    { t: "2", s: 1,  x: 468, y: 92,  o: "v" },
+    { t: "2", s: 2,  x: 513, y: 92,  o: "v" },
+    { t: "2", s: 3,  x: 558, y: 92,  o: "v" },
+    { t: "2", s: 4,  x: 603, y: 92,  o: "v" },
+    { t: "2", s: 5,  x: 648, y: 92,  o: "v" },
+    // 3 — west (outer) and east (inner)
+    { t: "3", s: 1,  x: 128, y: 192, o: "h" },
+    { t: "3", s: 2,  x: 128, y: 232, o: "h" },
+    { t: "3", s: 3,  x: 128, y: 275, o: "h" },
+    { t: "3", s: 4,  x: 128, y: 322, o: "h" },
+    { t: "3", s: 5,  x: 128, y: 360, o: "h" },
+    { t: "3", s: 6,  x: 252, y: 275, o: "h" },
+    { t: "3", s: 7,  x: 252, y: 322, o: "h" },
+    { t: "3", s: 8,  x: 252, y: 360, o: "h" },
+    // 4 — west (inner) and east (outer)
+    { t: "4", s: 1,  x: 548, y: 275, o: "h" },
+    { t: "4", s: 2,  x: 548, y: 322, o: "h" },
+    { t: "4", s: 3,  x: 548, y: 360, o: "h" },
+    { t: "4", s: 4,  x: 672, y: 192, o: "h" },
+    { t: "4", s: 5,  x: 672, y: 232, o: "h" },
+    { t: "4", s: 6,  x: 672, y: 275, o: "h" },
+    { t: "4", s: 7,  x: 672, y: 322, o: "h" },
+    { t: "4", s: 8,  x: 672, y: 360, o: "h" },
+    // 5 — west (outer) and east (inner)
+    { t: "5", s: 1,  x: 128, y: 400, o: "h" },
+    { t: "5", s: 2,  x: 128, y: 442, o: "h" },
+    { t: "5", s: 3,  x: 128, y: 486, o: "h" },
+    { t: "5", s: 4,  x: 128, y: 532, o: "h" },
+    { t: "5", s: 5,  x: 128, y: 572, o: "h" },
+    { t: "5", s: 6,  x: 252, y: 400, o: "h" },
+    { t: "5", s: 7,  x: 252, y: 442, o: "h" },
+    { t: "5", s: 8,  x: 252, y: 486, o: "h" },
+    { t: "5", s: 9,  x: 252, y: 532, o: "h" },
+    { t: "5", s: 10, x: 252, y: 572, o: "h" },
+    // 6 — west (inner) and east (outer)
+    { t: "6", s: 1,  x: 548, y: 400, o: "h" },
+    { t: "6", s: 2,  x: 548, y: 442, o: "h" },
+    { t: "6", s: 3,  x: 548, y: 486, o: "h" },
+    { t: "6", s: 4,  x: 548, y: 532, o: "h" },
+    { t: "6", s: 5,  x: 548, y: 572, o: "h" },
+    { t: "6", s: 6,  x: 672, y: 400, o: "h" },
+    { t: "6", s: 7,  x: 672, y: 442, o: "h" },
+    { t: "6", s: 8,  x: 672, y: 486, o: "h" },
+    { t: "6", s: 9,  x: 672, y: 532, o: "h" },
+    { t: "6", s: 10, x: 672, y: 572, o: "h" },
 ];
 
-export function SeatingMap({ highlightedSeats = [] }: SeatingMapProps) {
+export function SeatingMap({ allSeats = [], highlightedSeats = [], onSeatClick }: SeatingMapProps) {
+    const all = new Map(
+        allSeats.map((s) => [`${s.tableNumber}-${s.seatNumber}`, s])
+    );
     const highlights = new Map(
-        highlightedSeats.map((h) => [`${h.tableNumber}-${h.seatNumber}`, h.isOwn])
+        highlightedSeats.map((h) => [`${h.tableNumber}-${h.seatNumber}`, h])
     );
 
     return (
         <svg
-            viewBox="0 0 800 610"
+            viewBox="0 0 800 620"
             width="100%"
             style={{ display: "block" }}
             aria-label="Venue seating map"
         >
-            <rect width="800" height="610" fill="#f0ebe0" rx="8" />
+            <rect width="800" height="620" fill="#f0ebe0" rx="8" />
 
             {TABLES.map((t) => (
                 <g key={t.id}>
                     <rect
                         x={t.x} y={t.y} width={t.w} height={t.h}
-                        rx={3} fill="white"
+                        fill="white"
                         stroke="rgba(139,115,85,0.4)" strokeWidth={1.5}
                     />
                     <text
-                        x={t.x + t.w / 2} y={t.y + t.h / 2 + 6}
-                        textAnchor="middle" fontSize={15}
+                        x={t.x + t.w / 2} y={t.y + t.h / 2 + 8}
+                        textAnchor="middle" fontSize={22}
                         fill="rgba(109,90,68,0.65)"
                         fontFamily="Georgia, serif" fontWeight="500"
                     >
@@ -105,19 +141,43 @@ export function SeatingMap({ highlightedSeats = [] }: SeatingMapProps) {
 
             {SEATS.map((seat) => {
                 const key = `${seat.t}-${seat.s}`;
-                const state = highlights.get(key);
-                const isOwn = state === true;
-                const isParty = state === false;
+                const highlight = highlights.get(key);
+                const isOwn   = highlight?.isOwn === true;
+                const isParty = highlight !== undefined && !isOwn;
+
+                const w = seat.o === "v" ? VW : HW;
+                const h = seat.o === "v" ? VH : HH;
+                const r = Math.min(w, h) / 2;
+
+                const clickable = highlight ?? all.get(key);
+
                 return (
-                    <circle
+                    <rect
                         key={key}
-                        cx={seat.x} cy={seat.y} r={R}
+                        x={seat.x - w / 2} y={seat.y - h / 2}
+                        width={w} height={h} rx={r}
                         fill={isOwn ? "#c9a84c" : isParty ? "rgba(201,168,76,0.4)" : "#e4ddd0"}
                         stroke={isOwn ? "#6d5a44" : isParty ? "#c9a84c" : "rgba(139,115,85,0.3)"}
                         strokeWidth={isOwn ? 2.5 : isParty ? 2 : 1}
+                        style={clickable ? { cursor: "pointer" } : undefined}
+                        onClick={clickable ? () => onSeatClick?.(clickable) : undefined}
                     />
                 );
             })}
+
+            {/* Bride & groom — positioned in the gap between tables 1 and 2 */}
+            {COUPLE_SEATS.map((s) => (
+                <rect
+                    key={s.key}
+                    x={s.x - VW / 2} y={s.y - VH / 2}
+                    width={VW} height={VH} rx={VW / 2}
+                    fill="#e4ddd0"
+                    stroke="rgba(139,115,85,0.3)"
+                    strokeWidth={1}
+                    style={{ cursor: "pointer" }}
+                    onClick={() => onSeatClick?.({ name: s.label, tableNumber: "", seatNumber: 0 })}
+                />
+            ))}
         </svg>
     );
 }

--- a/src/app/seat-finder/SeatingMap.tsx
+++ b/src/app/seat-finder/SeatingMap.tsx
@@ -1,0 +1,123 @@
+interface HighlightedSeat {
+    tableNumber: string;
+    seatNumber: number;
+    isOwn: boolean;
+}
+
+interface SeatingMapProps {
+    highlightedSeats?: HighlightedSeat[];
+}
+
+const R = 14;
+
+const TABLES = [
+    { id: "L1", x: 170, y: 112, w: 172, h: 58 },
+    { id: "L2", x: 458, y: 112, w: 172, h: 58 },
+    { id: "L3", x: 152, y: 192, w: 92, h: 184 },
+    { id: "L4", x: 556, y: 192, w: 92, h: 184 },
+    { id: "L5", x: 152, y: 400, w: 92, h: 192 },
+    { id: "L6", x: 556, y: 400, w: 92, h: 192 },
+];
+
+// Seat positions match the physical chart layout.
+// L1/L2: seats along north edge. L3/L5: west=outside, east=inside.
+// L4/L6: west=inside, east=outside.
+const SEATS = [
+    { t: "L1", s: 1,  x: 148, y: 90  },
+    { t: "L1", s: 2,  x: 213, y: 90  },
+    { t: "L1", s: 3,  x: 251, y: 90  },
+    { t: "L1", s: 4,  x: 289, y: 90  },
+    { t: "L1", s: 5,  x: 327, y: 90  },
+    { t: "L2", s: 1,  x: 473, y: 90  },
+    { t: "L2", s: 2,  x: 511, y: 90  },
+    { t: "L2", s: 3,  x: 549, y: 90  },
+    { t: "L2", s: 4,  x: 587, y: 90  },
+    { t: "L2", s: 5,  x: 652, y: 90  },
+    { t: "L3", s: 1,  x: 120, y: 213 },
+    { t: "L3", s: 2,  x: 120, y: 250 },
+    { t: "L3", s: 3,  x: 120, y: 287 },
+    { t: "L3", s: 4,  x: 120, y: 324 },
+    { t: "L3", s: 5,  x: 120, y: 361 },
+    { t: "L3", s: 6,  x: 261, y: 228 },
+    { t: "L3", s: 7,  x: 261, y: 283 },
+    { t: "L3", s: 8,  x: 261, y: 338 },
+    { t: "L4", s: 1,  x: 539, y: 228 },
+    { t: "L4", s: 2,  x: 539, y: 283 },
+    { t: "L4", s: 3,  x: 539, y: 338 },
+    { t: "L4", s: 4,  x: 680, y: 213 },
+    { t: "L4", s: 5,  x: 680, y: 250 },
+    { t: "L4", s: 6,  x: 680, y: 287 },
+    { t: "L4", s: 7,  x: 680, y: 324 },
+    { t: "L4", s: 8,  x: 680, y: 361 },
+    { t: "L5", s: 1,  x: 120, y: 420 },
+    { t: "L5", s: 2,  x: 120, y: 459 },
+    { t: "L5", s: 3,  x: 120, y: 498 },
+    { t: "L5", s: 4,  x: 120, y: 537 },
+    { t: "L5", s: 5,  x: 120, y: 576 },
+    { t: "L5", s: 6,  x: 261, y: 420 },
+    { t: "L5", s: 7,  x: 261, y: 459 },
+    { t: "L5", s: 8,  x: 261, y: 498 },
+    { t: "L5", s: 9,  x: 261, y: 537 },
+    { t: "L5", s: 10, x: 261, y: 576 },
+    { t: "L6", s: 1,  x: 539, y: 420 },
+    { t: "L6", s: 2,  x: 539, y: 459 },
+    { t: "L6", s: 3,  x: 539, y: 498 },
+    { t: "L6", s: 4,  x: 539, y: 537 },
+    { t: "L6", s: 5,  x: 539, y: 576 },
+    { t: "L6", s: 6,  x: 680, y: 420 },
+    { t: "L6", s: 7,  x: 680, y: 459 },
+    { t: "L6", s: 8,  x: 680, y: 498 },
+    { t: "L6", s: 9,  x: 680, y: 537 },
+    { t: "L6", s: 10, x: 680, y: 576 },
+];
+
+export function SeatingMap({ highlightedSeats = [] }: SeatingMapProps) {
+    const highlights = new Map(
+        highlightedSeats.map((h) => [`${h.tableNumber}-${h.seatNumber}`, h.isOwn])
+    );
+
+    return (
+        <svg
+            viewBox="0 0 800 610"
+            width="100%"
+            style={{ display: "block" }}
+            aria-label="Venue seating map"
+        >
+            <rect width="800" height="610" fill="#f0ebe0" rx="8" />
+
+            {TABLES.map((t) => (
+                <g key={t.id}>
+                    <rect
+                        x={t.x} y={t.y} width={t.w} height={t.h}
+                        rx={3} fill="white"
+                        stroke="rgba(139,115,85,0.4)" strokeWidth={1.5}
+                    />
+                    <text
+                        x={t.x + t.w / 2} y={t.y + t.h / 2 + 6}
+                        textAnchor="middle" fontSize={15}
+                        fill="rgba(109,90,68,0.65)"
+                        fontFamily="Georgia, serif" fontWeight="500"
+                    >
+                        {t.id}
+                    </text>
+                </g>
+            ))}
+
+            {SEATS.map((seat) => {
+                const key = `${seat.t}-${seat.s}`;
+                const state = highlights.get(key);
+                const isOwn = state === true;
+                const isParty = state === false;
+                return (
+                    <circle
+                        key={key}
+                        cx={seat.x} cy={seat.y} r={R}
+                        fill={isOwn ? "#c9a84c" : isParty ? "rgba(201,168,76,0.4)" : "#e4ddd0"}
+                        stroke={isOwn ? "#6d5a44" : isParty ? "#c9a84c" : "rgba(139,115,85,0.3)"}
+                        strokeWidth={isOwn ? 2.5 : isParty ? 2 : 1}
+                    />
+                );
+            })}
+        </svg>
+    );
+}

--- a/src/app/seat-finder/__tests__/SeatingMap.test.tsx
+++ b/src/app/seat-finder/__tests__/SeatingMap.test.tsx
@@ -1,0 +1,253 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MantineProvider } from "@mantine/core";
+import { SeatingMap } from "../SeatingMap";
+
+const renderMap = (props: React.ComponentProps<typeof SeatingMap> = {}) =>
+    render(
+        <MantineProvider>
+            <SeatingMap {...props} />
+        </MantineProvider>
+    );
+
+describe("SeatingMap", () => {
+    describe("rendering", () => {
+        it("renders an SVG element", () => {
+            renderMap();
+            expect(document.querySelector("svg")).toBeInTheDocument();
+        });
+
+        it("renders table labels 1 through 6", () => {
+            renderMap();
+            for (const label of ["1", "2", "3", "4", "5", "6"]) {
+                // There will be text nodes with the table number inside the SVG
+                const nodes = document.querySelectorAll("text");
+                const found = Array.from(nodes).some((n) => n.textContent === label);
+                expect(found, `Table label "${label}" should be present`).toBe(true);
+            }
+        });
+
+        it("renders the correct number of regular seat rects", () => {
+            renderMap();
+            const svg = document.querySelector("svg")!;
+            // Count all <rect> children inside the SVG (background + tables + seats + couple seats)
+            // We just verify the SVG itself has multiple rects rendered
+            const rects = svg.querySelectorAll("rect");
+            // background(1) + 6 tables + 46 SEATS + 2 couple seats = 55 minimum
+            expect(rects.length).toBeGreaterThanOrEqual(55);
+        });
+
+        it("renders bride and groom couple seats", () => {
+            const onSeatClick = vi.fn();
+            renderMap({ onSeatClick });
+
+            // The couple seats are always rendered with cursor:pointer and fire onSeatClick
+            // Click all pointer-cursor rects — the bride/groom ones will call onSeatClick
+            // with tableNumber="" and seatNumber=0
+            const svg = document.querySelector("svg")!;
+            const pointerRects = Array.from(svg.querySelectorAll<SVGRectElement>("rect")).filter(
+                (r) => r.style.cursor === "pointer"
+            );
+
+            // There should be at least 2 couple seats with cursor:pointer even with no props
+            expect(pointerRects.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+
+    describe("seat highlighting", () => {
+        it("applies gold fill (#c9a84c) to an own seat", () => {
+            renderMap({
+                highlightedSeats: [
+                    { tableNumber: "1", seatNumber: 1, isOwn: true, name: "Alice Smith" },
+                ],
+            });
+
+            const svg = document.querySelector("svg")!;
+            const goldRects = Array.from(svg.querySelectorAll<SVGRectElement>("rect")).filter(
+                (r) => r.getAttribute("fill") === "#c9a84c"
+            );
+            expect(goldRects.length).toBe(1);
+        });
+
+        it("applies translucent gold fill to a party (non-own) seat", () => {
+            renderMap({
+                highlightedSeats: [
+                    { tableNumber: "1", seatNumber: 2, isOwn: false, name: "Bob Smith" },
+                ],
+            });
+
+            const svg = document.querySelector("svg")!;
+            const partyRects = Array.from(svg.querySelectorAll<SVGRectElement>("rect")).filter(
+                (r) => r.getAttribute("fill") === "rgba(201,168,76,0.4)"
+            );
+            expect(partyRects.length).toBe(1);
+        });
+
+        it("renders multiple highlighted seats with correct fills", () => {
+            renderMap({
+                highlightedSeats: [
+                    { tableNumber: "1", seatNumber: 1, isOwn: true,  name: "Alice Smith" },
+                    { tableNumber: "1", seatNumber: 2, isOwn: false, name: "Bob Smith" },
+                    { tableNumber: "1", seatNumber: 3, isOwn: false, name: "Carol Smith" },
+                ],
+            });
+
+            const svg = document.querySelector("svg")!;
+            const ownRects = Array.from(svg.querySelectorAll<SVGRectElement>("rect")).filter(
+                (r) => r.getAttribute("fill") === "#c9a84c"
+            );
+            const partyRects = Array.from(svg.querySelectorAll<SVGRectElement>("rect")).filter(
+                (r) => r.getAttribute("fill") === "rgba(201,168,76,0.4)"
+            );
+            expect(ownRects.length).toBe(1);
+            expect(partyRects.length).toBe(2);
+        });
+    });
+
+    describe("seat click interactions", () => {
+        it("calls onSeatClick with correct info when clicking a highlighted seat", async () => {
+            const user = userEvent.setup();
+            const onSeatClick = vi.fn();
+
+            renderMap({
+                highlightedSeats: [
+                    { tableNumber: "1", seatNumber: 1, isOwn: true, name: "Alice Smith" },
+                ],
+                onSeatClick,
+            });
+
+            const svg = document.querySelector("svg")!;
+            // The own seat has fill="#c9a84c"
+            const ownRect = Array.from(svg.querySelectorAll<SVGRectElement>("rect")).find(
+                (r) => r.getAttribute("fill") === "#c9a84c"
+            )!;
+
+            await user.click(ownRect);
+
+            expect(onSeatClick).toHaveBeenCalledOnce();
+            expect(onSeatClick).toHaveBeenCalledWith({
+                name: "Alice Smith",
+                tableNumber: "1",
+                seatNumber: 1,
+            });
+        });
+
+        it("calls onSeatClick with correct info when clicking an allSeats seat", async () => {
+            const user = userEvent.setup();
+            const onSeatClick = vi.fn();
+
+            renderMap({
+                allSeats: [{ tableNumber: "2", seatNumber: 1, name: "Venue Guest" }],
+                onSeatClick,
+            });
+
+            const svg = document.querySelector("svg")!;
+            // allSeats seats get cursor:pointer but keep the default fill (#e4ddd0)
+            const pointerRects = Array.from(svg.querySelectorAll<SVGRectElement>("rect")).filter(
+                (r) => r.style.cursor === "pointer" && r.getAttribute("fill") === "#e4ddd0"
+            );
+
+            // Click the first one that corresponds to table 2, seat 1
+            // Since we only have one allSeats entry, only that rect should be pointer+default-fill
+            expect(pointerRects.length).toBeGreaterThanOrEqual(1);
+            await user.click(pointerRects[0]);
+
+            expect(onSeatClick).toHaveBeenCalledWith({
+                name: "Venue Guest",
+                tableNumber: "2",
+                seatNumber: 1,
+            });
+        });
+
+        it("does not call onSeatClick when clicking an unoccupied seat", async () => {
+            const user = userEvent.setup();
+            const onSeatClick = vi.fn();
+
+            renderMap({ onSeatClick });
+
+            const svg = document.querySelector("svg")!;
+            // Seats with no allSeats/highlighted entry have no onClick handler
+            const plainRects = Array.from(svg.querySelectorAll<SVGRectElement>("rect")).filter(
+                (r) =>
+                    r.getAttribute("fill") === "#e4ddd0" &&
+                    r.style.cursor !== "pointer"
+            );
+
+            if (plainRects.length > 0) {
+                await user.click(plainRects[0]);
+                expect(onSeatClick).not.toHaveBeenCalled();
+            }
+        });
+
+        it("calls onSeatClick with Bride info when clicking the bride couple seat", async () => {
+            const user = userEvent.setup();
+            const onSeatClick = vi.fn();
+
+            renderMap({ onSeatClick });
+
+            // Both couple seats are rendered with cursor:pointer (no allSeats data means
+            // only the couple seats have cursor:pointer in a bare render)
+            const svg = document.querySelector("svg")!;
+            const coupleRects = Array.from(svg.querySelectorAll<SVGRectElement>("rect")).filter(
+                (r) => r.style.cursor === "pointer"
+            );
+
+            // Bride is rendered first (lower x value — 378 vs 423)
+            expect(coupleRects.length).toBeGreaterThanOrEqual(2);
+            await user.click(coupleRects[0]);
+
+            expect(onSeatClick).toHaveBeenCalledWith({
+                name: "Bride",
+                tableNumber: "",
+                seatNumber: 0,
+            });
+        });
+
+        it("calls onSeatClick with Groom info when clicking the groom couple seat", async () => {
+            const user = userEvent.setup();
+            const onSeatClick = vi.fn();
+
+            renderMap({ onSeatClick });
+
+            const svg = document.querySelector("svg")!;
+            const coupleRects = Array.from(svg.querySelectorAll<SVGRectElement>("rect")).filter(
+                (r) => r.style.cursor === "pointer"
+            );
+
+            expect(coupleRects.length).toBeGreaterThanOrEqual(2);
+            await user.click(coupleRects[1]);
+
+            expect(onSeatClick).toHaveBeenCalledWith({
+                name: "Groom",
+                tableNumber: "",
+                seatNumber: 0,
+            });
+        });
+    });
+
+    describe("default props", () => {
+        it("renders without crashing when no props are supplied", () => {
+            expect(() => renderMap()).not.toThrow();
+        });
+
+        it("renders without crashing when onSeatClick is not provided", async () => {
+            const user = userEvent.setup();
+
+            renderMap({
+                highlightedSeats: [
+                    { tableNumber: "1", seatNumber: 1, isOwn: true, name: "Alice" },
+                ],
+            });
+
+            const svg = document.querySelector("svg")!;
+            const ownRect = Array.from(svg.querySelectorAll<SVGRectElement>("rect")).find(
+                (r) => r.getAttribute("fill") === "#c9a84c"
+            )!;
+
+            // Clicking should not throw even without onSeatClick
+            await expect(user.click(ownRect)).resolves.not.toThrow();
+        });
+    });
+});

--- a/src/app/seat-finder/page.tsx
+++ b/src/app/seat-finder/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { Container, Title, Text, Box, Autocomplete, Loader, Stack, Alert } from "@mantine/core";
 import { IconSearch, IconUsers, IconAlertCircle } from "@tabler/icons-react";
 import { Navigation } from "@/components/Navigation";
+import { SeatingMap } from "./SeatingMap";
 
 interface Suggestion {
     id: number;
@@ -15,12 +16,15 @@ interface PartyMember {
     first_name: string;
     last_name: string;
     is_primary: boolean;
+    table_number: string | null;
+    seat_number: number | null;
 }
 
 export default function SeatFinderPage() {
     const [query, setQuery] = useState("");
     const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
     const [party, setParty] = useState<PartyMember[] | null>(null);
+    const [selectedId, setSelectedId] = useState<number | null>(null);
     const [selectedName, setSelectedName] = useState<string | null>(null);
     const [searching, setSearching] = useState(false);
     const [loadingParty, setLoadingParty] = useState(false);
@@ -83,6 +87,7 @@ export default function SeatFinderPage() {
 
         setLoadingParty(true);
         setParty(null);
+        setSelectedId(id);
         setSelectedName(name);
 
         try {
@@ -97,6 +102,19 @@ export default function SeatFinderPage() {
             setLoadingParty(false);
         }
     }
+
+    const highlightedSeats = party
+        ? party
+              .filter((m) => m.table_number && m.seat_number)
+              .map((m) => ({
+                  tableNumber: m.table_number!,
+                  seatNumber: m.seat_number!,
+                  isOwn: m.id === selectedId,
+              }))
+        : [];
+
+    const seatedMembers = party?.filter((m) => m.table_number) ?? [];
+    const tableNumber = seatedMembers[0]?.table_number ?? null;
 
     return (
         <>
@@ -201,61 +219,118 @@ export default function SeatFinderPage() {
 
                         {/* Results */}
                         {party && !loadingParty && (
-                            <Box
-                                ref={resultsRef}
-                                style={{
-                                    marginTop: "1.25rem",
-                                    marginBottom: "2rem",
-                                    background: "white",
-                                    borderRadius: 12,
-                                    padding: "clamp(1.25rem, 5vw, 1.75rem)",
-                                    border: "1px solid rgba(139, 115, 85, 0.15)",
-                                    boxShadow: "0 4px 20px rgba(139, 115, 85, 0.1)",
-                                }}
-                            >
+                            <Box ref={resultsRef} style={{ marginTop: "1.25rem", marginBottom: "2rem" }}>
+                                {/* Party card */}
                                 <Box
                                     style={{
-                                        display: "flex",
-                                        alignItems: "center",
-                                        gap: "0.5rem",
+                                        background: "white",
+                                        borderRadius: 12,
+                                        padding: "clamp(1.25rem, 5vw, 1.75rem)",
+                                        border: "1px solid rgba(139, 115, 85, 0.15)",
+                                        boxShadow: "0 4px 20px rgba(139, 115, 85, 0.1)",
                                         marginBottom: "1rem",
                                     }}
                                 >
-                                    <IconUsers size={16} color="var(--gold-dark)" />
-                                    <Text
+                                    <Box
                                         style={{
-                                            fontSize: "0.75rem",
-                                            color: "var(--gold-dark)",
-                                            letterSpacing: "0.12em",
-                                            textTransform: "uppercase",
-                                            fontWeight: 600,
+                                            display: "flex",
+                                            alignItems: "center",
+                                            justifyContent: "space-between",
+                                            marginBottom: "1rem",
                                         }}
                                     >
-                                        {selectedName}&apos;s Party
-                                    </Text>
-                                </Box>
-                                <Stack gap={0}>
-                                    {party.map((member, i) => (
-                                        <Box
-                                            key={member.id}
-                                            style={{
-                                                padding: "0.75rem 0",
-                                                borderTop: i > 0 ? "1px solid rgba(139, 115, 85, 0.08)" : "none",
-                                            }}
-                                        >
+                                        <Box style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+                                            <IconUsers size={16} color="var(--gold-dark)" />
                                             <Text
                                                 style={{
-                                                    color: "var(--text-primary)",
-                                                    fontSize: "clamp(1rem, 4vw, 1.1rem)",
-                                                    fontWeight: member.is_primary ? 500 : 400,
-                                                    lineHeight: 1.3,
+                                                    fontSize: "0.75rem",
+                                                    color: "var(--gold-dark)",
+                                                    letterSpacing: "0.12em",
+                                                    textTransform: "uppercase",
+                                                    fontWeight: 600,
                                                 }}
                                             >
-                                                {member.first_name} {member.last_name}
+                                                {selectedName}&apos;s Party
                                             </Text>
                                         </Box>
-                                    ))}
-                                </Stack>
+                                        {tableNumber && (
+                                            <Text
+                                                style={{
+                                                    fontSize: "0.8rem",
+                                                    color: "var(--gold-dark)",
+                                                    fontWeight: 600,
+                                                    background: "rgba(201,168,76,0.12)",
+                                                    border: "1px solid rgba(201,168,76,0.3)",
+                                                    borderRadius: 6,
+                                                    padding: "0.2rem 0.6rem",
+                                                }}
+                                            >
+                                                Table {tableNumber}
+                                            </Text>
+                                        )}
+                                    </Box>
+                                    <Stack gap={0}>
+                                        {party.map((member, i) => (
+                                            <Box
+                                                key={member.id}
+                                                style={{
+                                                    padding: "0.75rem 0",
+                                                    borderTop: i > 0 ? "1px solid rgba(139, 115, 85, 0.08)" : "none",
+                                                    display: "flex",
+                                                    alignItems: "center",
+                                                    justifyContent: "space-between",
+                                                }}
+                                            >
+                                                <Text
+                                                    style={{
+                                                        color: member.id === selectedId ? "var(--text-primary)" : "var(--text-secondary)",
+                                                        fontSize: "clamp(1rem, 4vw, 1.1rem)",
+                                                        fontWeight: member.id === selectedId ? 600 : 400,
+                                                        lineHeight: 1.3,
+                                                    }}
+                                                >
+                                                    {member.first_name} {member.last_name}
+                                                    {member.id === selectedId && (
+                                                        <Text component="span" style={{ fontSize: "0.75rem", color: "var(--gold-dark)", marginLeft: "0.5rem", fontWeight: 400 }}>
+                                                            (you)
+                                                        </Text>
+                                                    )}
+                                                </Text>
+                                                {member.seat_number && (
+                                                    <Text style={{ fontSize: "0.8rem", color: "var(--text-secondary)", flexShrink: 0, marginLeft: "0.5rem" }}>
+                                                        Seat {member.seat_number}
+                                                    </Text>
+                                                )}
+                                            </Box>
+                                        ))}
+                                    </Stack>
+                                </Box>
+
+                                {/* Seating map */}
+                                {highlightedSeats.length > 0 && (
+                                    <Box
+                                        style={{
+                                            background: "white",
+                                            borderRadius: 12,
+                                            padding: "1rem",
+                                            border: "1px solid rgba(139, 115, 85, 0.15)",
+                                            boxShadow: "0 4px 20px rgba(139, 115, 85, 0.1)",
+                                        }}
+                                    >
+                                        <SeatingMap highlightedSeats={highlightedSeats} />
+                                        {/* Legend */}
+                                        <Box style={{ display: "flex", gap: "1.25rem", justifyContent: "center", marginTop: "0.75rem" }}>
+                                            <Box style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+                                                <svg width={16} height={16}><circle cx={8} cy={8} r={7} fill="#c9a84c" stroke="#6d5a44" strokeWidth={1.5} /></svg>
+                                                <Text style={{ fontSize: "0.75rem", color: "var(--text-secondary)" }}>Your seat</Text>
+                                            </Box>
+                                            <Box style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+                                                <svg width={16} height={16}><circle cx={8} cy={8} r={7} fill="rgba(201,168,76,0.4)" stroke="#c9a84c" strokeWidth={1.5} /></svg>
+                                                <Text style={{ fontSize: "0.75rem", color: "var(--text-secondary)" }}>Your party</Text>
+                                            </Box>
+                                        </Box>
+                                    </Box>
+                                )}
                             </Box>
                         )}
                     </Container>

--- a/src/app/seat-finder/page.tsx
+++ b/src/app/seat-finder/page.tsx
@@ -7,12 +7,12 @@ import { Navigation } from "@/components/Navigation";
 import { SeatingMap } from "./SeatingMap";
 
 interface Suggestion {
-    id: number;
+    id: string;
     name: string;
 }
 
 interface PartyMember {
-    id: number;
+    id: string;
     first_name: string;
     last_name: string;
     is_primary: boolean;
@@ -21,18 +21,28 @@ interface PartyMember {
 }
 
 export default function SeatFinderPage() {
+    const [allSeats, setAllSeats] = useState<{ tableNumber: string; seatNumber: number; name: string }[]>([]);
     const [query, setQuery] = useState("");
     const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
     const [party, setParty] = useState<PartyMember[] | null>(null);
-    const [selectedId, setSelectedId] = useState<number | null>(null);
+    const [selectedId, setSelectedId] = useState<string | null>(null);
+    type TappedSeat = { name: string; tableNumber: string; seatNumber: number };
+    const [tappedSeat, setTappedSeat] = useState<TappedSeat | null>(null);
     const [selectedName, setSelectedName] = useState<string | null>(null);
     const [searching, setSearching] = useState(false);
     const [loadingParty, setLoadingParty] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const nameToIdRef = useRef<Map<string, number>>(new Map());
+    const nameToIdRef = useRef<Map<string, string>>(new Map());
     const justSelectedRef = useRef(false);
     const resultsRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        fetch("/api/seat-finder/seats")
+            .then((r) => r.ok ? r.json() : [])
+            .then(setAllSeats)
+            .catch(() => {});
+    }, []);
 
     useEffect(() => {
         if (justSelectedRef.current) {
@@ -88,6 +98,7 @@ export default function SeatFinderPage() {
         setLoadingParty(true);
         setParty(null);
         setSelectedId(id);
+        setTappedSeat(null);
         setSelectedName(name);
 
         try {
@@ -110,11 +121,16 @@ export default function SeatFinderPage() {
                   tableNumber: m.table_number!,
                   seatNumber: m.seat_number!,
                   isOwn: m.id === selectedId,
+                  name: `${m.first_name} ${m.last_name}`,
               }))
         : [];
 
     const seatedMembers = party?.filter((m) => m.table_number) ?? [];
     const tableNumber = seatedMembers[0]?.table_number ?? null;
+    const primaryMember = party?.find((m) => m.is_primary);
+    const partyLabel = primaryMember
+        ? `${primaryMember.first_name} ${primaryMember.last_name}`
+        : selectedName;
 
     return (
         <>
@@ -220,92 +236,6 @@ export default function SeatFinderPage() {
                         {/* Results */}
                         {party && !loadingParty && (
                             <Box ref={resultsRef} style={{ marginTop: "1.25rem", marginBottom: "2rem" }}>
-                                {/* Party card */}
-                                <Box
-                                    style={{
-                                        background: "white",
-                                        borderRadius: 12,
-                                        padding: "clamp(1.25rem, 5vw, 1.75rem)",
-                                        border: "1px solid rgba(139, 115, 85, 0.15)",
-                                        boxShadow: "0 4px 20px rgba(139, 115, 85, 0.1)",
-                                        marginBottom: "1rem",
-                                    }}
-                                >
-                                    <Box
-                                        style={{
-                                            display: "flex",
-                                            alignItems: "center",
-                                            justifyContent: "space-between",
-                                            marginBottom: "1rem",
-                                        }}
-                                    >
-                                        <Box style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
-                                            <IconUsers size={16} color="var(--gold-dark)" />
-                                            <Text
-                                                style={{
-                                                    fontSize: "0.75rem",
-                                                    color: "var(--gold-dark)",
-                                                    letterSpacing: "0.12em",
-                                                    textTransform: "uppercase",
-                                                    fontWeight: 600,
-                                                }}
-                                            >
-                                                {selectedName}&apos;s Party
-                                            </Text>
-                                        </Box>
-                                        {tableNumber && (
-                                            <Text
-                                                style={{
-                                                    fontSize: "0.8rem",
-                                                    color: "var(--gold-dark)",
-                                                    fontWeight: 600,
-                                                    background: "rgba(201,168,76,0.12)",
-                                                    border: "1px solid rgba(201,168,76,0.3)",
-                                                    borderRadius: 6,
-                                                    padding: "0.2rem 0.6rem",
-                                                }}
-                                            >
-                                                Table {tableNumber}
-                                            </Text>
-                                        )}
-                                    </Box>
-                                    <Stack gap={0}>
-                                        {party.map((member, i) => (
-                                            <Box
-                                                key={member.id}
-                                                style={{
-                                                    padding: "0.75rem 0",
-                                                    borderTop: i > 0 ? "1px solid rgba(139, 115, 85, 0.08)" : "none",
-                                                    display: "flex",
-                                                    alignItems: "center",
-                                                    justifyContent: "space-between",
-                                                }}
-                                            >
-                                                <Text
-                                                    style={{
-                                                        color: member.id === selectedId ? "var(--text-primary)" : "var(--text-secondary)",
-                                                        fontSize: "clamp(1rem, 4vw, 1.1rem)",
-                                                        fontWeight: member.id === selectedId ? 600 : 400,
-                                                        lineHeight: 1.3,
-                                                    }}
-                                                >
-                                                    {member.first_name} {member.last_name}
-                                                    {member.id === selectedId && (
-                                                        <Text component="span" style={{ fontSize: "0.75rem", color: "var(--gold-dark)", marginLeft: "0.5rem", fontWeight: 400 }}>
-                                                            (you)
-                                                        </Text>
-                                                    )}
-                                                </Text>
-                                                {member.seat_number && (
-                                                    <Text style={{ fontSize: "0.8rem", color: "var(--text-secondary)", flexShrink: 0, marginLeft: "0.5rem" }}>
-                                                        Seat {member.seat_number}
-                                                    </Text>
-                                                )}
-                                            </Box>
-                                        ))}
-                                    </Stack>
-                                </Box>
-
                                 {/* Seating map */}
                                 {highlightedSeats.length > 0 && (
                                     <Box
@@ -317,20 +247,152 @@ export default function SeatFinderPage() {
                                             boxShadow: "0 4px 20px rgba(139, 115, 85, 0.1)",
                                         }}
                                     >
-                                        <SeatingMap highlightedSeats={highlightedSeats} />
+                                        <Box style={{ position: "relative" }}>
+                                            <SeatingMap
+                                                allSeats={allSeats}
+                                                highlightedSeats={highlightedSeats}
+                                                onSeatClick={setTappedSeat}
+                                            />
+                                            {tappedSeat && (
+                                                <Box
+                                                    onClick={() => setTappedSeat(null)}
+                                                    style={{
+                                                        position: "absolute",
+                                                        inset: 0,
+                                                        display: "flex",
+                                                        alignItems: "center",
+                                                        justifyContent: "center",
+                                                        background: "rgba(240,235,224,0.75)",
+                                                        borderRadius: 8,
+                                                        cursor: "pointer",
+                                                    }}
+                                                >
+                                                    <Box
+                                                        onClick={(e) => e.stopPropagation()}
+                                                        style={{
+                                                            background: "white",
+                                                            borderRadius: 10,
+                                                            padding: "1rem 1.5rem",
+                                                            boxShadow: "0 4px 24px rgba(139,115,85,0.2)",
+                                                            border: "1px solid rgba(139,115,85,0.15)",
+                                                            textAlign: "center",
+                                                            minWidth: 180,
+                                                        }}
+                                                    >
+                                                        <Text style={{ fontWeight: 600, fontSize: "1rem", color: "var(--text-primary)", marginBottom: "0.35rem" }}>
+                                                            {tappedSeat.name}
+                                                        </Text>
+                                                        {tappedSeat.tableNumber && (
+                                                            <Text style={{ fontSize: "0.8rem", color: "var(--text-secondary)" }}>
+                                                                Table {tappedSeat.tableNumber}
+                                                                {" · "}Seat {tappedSeat.seatNumber}
+                                                            </Text>
+                                                        )}
+                                                    </Box>
+                                                </Box>
+                                            )}
+                                        </Box>
                                         {/* Legend */}
                                         <Box style={{ display: "flex", gap: "1.25rem", justifyContent: "center", marginTop: "0.75rem" }}>
                                             <Box style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
                                                 <svg width={16} height={16}><circle cx={8} cy={8} r={7} fill="#c9a84c" stroke="#6d5a44" strokeWidth={1.5} /></svg>
                                                 <Text style={{ fontSize: "0.75rem", color: "var(--text-secondary)" }}>Your seat</Text>
                                             </Box>
-                                            <Box style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
-                                                <svg width={16} height={16}><circle cx={8} cy={8} r={7} fill="rgba(201,168,76,0.4)" stroke="#c9a84c" strokeWidth={1.5} /></svg>
-                                                <Text style={{ fontSize: "0.75rem", color: "var(--text-secondary)" }}>Your party</Text>
-                                            </Box>
+                                            {party.length > 1 && (
+                                                <Box style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+                                                    <svg width={16} height={16}><circle cx={8} cy={8} r={7} fill="rgba(201,168,76,0.4)" stroke="#c9a84c" strokeWidth={1.5} /></svg>
+                                                    <Text style={{ fontSize: "0.75rem", color: "var(--text-secondary)" }}>Your party</Text>
+                                                </Box>
+                                            )}
                                         </Box>
                                     </Box>
                                 )}
+
+                                {/* Party card */}
+                                <Box
+                                    style={{
+                                        background: "white",
+                                        borderRadius: 12,
+                                        padding: "0.75rem 1rem",
+                                        border: "1px solid rgba(139, 115, 85, 0.15)",
+                                        boxShadow: "0 4px 20px rgba(139, 115, 85, 0.1)",
+                                        marginTop: "1rem",
+                                    }}
+                                >
+                                    <Box
+                                        style={{
+                                            display: "flex",
+                                            alignItems: "center",
+                                            justifyContent: "space-between",
+                                            marginBottom: "0.5rem",
+                                        }}
+                                    >
+                                        <Box style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+                                            {party.length > 1 && <IconUsers size={14} color="var(--gold-dark)" />}
+                                            <Text
+                                                style={{
+                                                    fontSize: "0.7rem",
+                                                    color: "var(--gold-dark)",
+                                                    letterSpacing: "0.12em",
+                                                    textTransform: "uppercase",
+                                                    fontWeight: 600,
+                                                }}
+                                            >
+                                                {party.length > 1 ? <>{partyLabel}&apos;s Party</> : selectedName}
+                                            </Text>
+                                        </Box>
+                                        {tableNumber && (
+                                            <Text
+                                                style={{
+                                                    fontSize: "0.75rem",
+                                                    color: "var(--gold-dark)",
+                                                    fontWeight: 600,
+                                                    background: "rgba(201,168,76,0.12)",
+                                                    border: "1px solid rgba(201,168,76,0.3)",
+                                                    borderRadius: 6,
+                                                    padding: "0.15rem 0.5rem",
+                                                }}
+                                            >
+                                                Table {tableNumber}
+                                            </Text>
+                                        )}
+                                    </Box>
+                                    <Stack gap={0}>
+                                        {party.map((member, i) => (
+                                            <Box
+                                                key={member.id}
+                                                style={{
+                                                    padding: "0.4rem 0",
+                                                    borderTop: i > 0 ? "1px solid rgba(139, 115, 85, 0.08)" : "none",
+                                                    display: "flex",
+                                                    alignItems: "center",
+                                                    justifyContent: "space-between",
+                                                }}
+                                            >
+                                                <Text
+                                                    style={{
+                                                        color: member.id === selectedId ? "var(--text-primary)" : "var(--text-secondary)",
+                                                        fontSize: "0.95rem",
+                                                        fontWeight: member.id === selectedId ? 600 : 400,
+                                                        lineHeight: 1.3,
+                                                    }}
+                                                >
+                                                    {member.first_name} {member.last_name}
+                                                    {party.length > 1 && member.id === selectedId && (
+                                                        <Text component="span" style={{ fontSize: "0.7rem", color: "var(--gold-dark)", marginLeft: "0.4rem", fontWeight: 400 }}>
+                                                            (you)
+                                                        </Text>
+                                                    )}
+                                                </Text>
+                                                {member.seat_number && (
+                                                    <Text style={{ fontSize: "0.75rem", color: "var(--text-secondary)", flexShrink: 0, marginLeft: "0.5rem" }}>
+                                                        Seat {member.seat_number}
+                                                    </Text>
+                                                )}
+                                            </Box>
+                                        ))}
+                                    </Stack>
+                                </Box>
                             </Box>
                         )}
                     </Container>

--- a/src/app/seat-finder/page.tsx
+++ b/src/app/seat-finder/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { Container, Title, Text, Box, Autocomplete, Loader, Stack } from "@mantine/core";
-import { IconSearch, IconUsers } from "@tabler/icons-react";
+import { Container, Title, Text, Box, Autocomplete, Loader, Stack, Alert } from "@mantine/core";
+import { IconSearch, IconUsers, IconAlertCircle } from "@tabler/icons-react";
 import { Navigation } from "@/components/Navigation";
 
 interface Suggestion {
@@ -24,22 +24,31 @@ export default function SeatFinderPage() {
     const [selectedName, setSelectedName] = useState<string | null>(null);
     const [searching, setSearching] = useState(false);
     const [loadingParty, setLoadingParty] = useState(false);
+    const [error, setError] = useState<string | null>(null);
     const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const nameToIdRef = useRef<Map<string, number>>(new Map());
+    const justSelectedRef = useRef(false);
+    const resultsRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
+        if (justSelectedRef.current) {
+            justSelectedRef.current = false;
+            return;
+        }
+
         if (debounceRef.current) clearTimeout(debounceRef.current);
 
         if (query.trim().length < 2) {
             setSuggestions([]);
             setSearching(false);
-            return;
+            return () => {};
         }
 
         setSearching(true);
         debounceRef.current = setTimeout(async () => {
             try {
                 const res = await fetch(`/api/seat-finder/search?q=${encodeURIComponent(query)}`);
+                if (!res.ok) throw new Error("Search failed");
                 const data: Suggestion[] = await res.json();
                 setSuggestions(data);
                 nameToIdRef.current = new Map(data.map((s) => [s.name, s.id]));
@@ -49,11 +58,25 @@ export default function SeatFinderPage() {
                 setSearching(false);
             }
         }, 300);
+
+        return () => {
+            if (debounceRef.current) clearTimeout(debounceRef.current);
+        };
     }, [query]);
 
+    useEffect(() => {
+        if (party && resultsRef.current) {
+            setTimeout(() => {
+                resultsRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+            }, 100);
+        }
+    }, [party]);
+
     async function handleSelect(name: string) {
+        justSelectedRef.current = true;
         setQuery(name);
         setSuggestions([]);
+        setError(null);
 
         const id = nameToIdRef.current.get(name);
         if (!id) return;
@@ -64,10 +87,12 @@ export default function SeatFinderPage() {
 
         try {
             const res = await fetch(`/api/seat-finder/party?id=${id}`);
+            if (!res.ok) throw new Error("Failed to load party");
             const data = await res.json();
             setParty(data.party ?? null);
         } catch {
             setParty(null);
+            setError("Something went wrong. Please try again.");
         } finally {
             setLoadingParty(false);
         }
@@ -84,70 +109,108 @@ export default function SeatFinderPage() {
                         background: "linear-gradient(135deg, #f9f7f2 0%, #f0ebe0 100%)",
                     }}
                 >
-                    <Container size="sm" py="xl">
-                        <Box style={{ paddingTop: "3rem", paddingBottom: "2rem" }}>
-                            <Text
-                                style={{
-                                    fontSize: "0.85rem",
-                                    color: "var(--gold)",
-                                    letterSpacing: "0.15em",
-                                    textTransform: "uppercase",
-                                    fontWeight: 600,
-                                    marginBottom: "0.75rem",
-                                }}
-                            >
-                                Find Your Seat
-                            </Text>
+                    <Container size="sm" px="md">
+                        {/* Header */}
+                        <Box style={{ paddingTop: "clamp(1.5rem, 5vw, 3rem)", paddingBottom: "1.75rem" }}>
                             <Title
                                 order={1}
                                 style={{
                                     fontFamily: "var(--font-playfair), serif",
-                                    fontSize: "clamp(2rem, 6vw, 3rem)",
+                                    fontSize: "clamp(1.75rem, 7vw, 3rem)",
                                     fontWeight: 400,
                                     color: "var(--text-primary)",
-                                    marginBottom: "0.75rem",
+                                    marginBottom: "0.5rem",
+                                    lineHeight: 1.2,
                                 }}
                             >
                                 Seat Finder
                             </Title>
-                            <Text style={{ color: "var(--text-secondary)", marginBottom: "2.5rem" }}>
-                                Search for your name to see your party&apos;s seating.
-                            </Text>
-
-                            <Autocomplete
-                                value={query}
-                                onChange={setQuery}
-                                onOptionSubmit={handleSelect}
-                                data={suggestions.map((s) => s.name)}
-                                filter={({ options }) => options}
-                                placeholder="Search your name…"
-                                leftSection={
-                                    searching ? <Loader size={16} color="var(--gold)" /> : <IconSearch size={16} />
-                                }
-                                size="md"
-                                styles={{
-                                    input: {
-                                        borderColor: "rgba(139, 115, 85, 0.3)",
-                                        "&:focus": { borderColor: "var(--gold)" },
-                                    },
+                            <Text
+                                style={{
+                                    color: "var(--text-secondary)",
+                                    fontSize: "clamp(0.875rem, 3.5vw, 1rem)",
+                                    lineHeight: 1.5,
                                 }}
-                            />
+                            >
+                                Search for your name to find your party&apos;s seating.
+                            </Text>
                         </Box>
 
+                        {/* Search */}
+                        <Autocomplete
+                            value={query}
+                            onChange={setQuery}
+                            onOptionSubmit={handleSelect}
+                            data={suggestions.map((s) => s.name)}
+                            filter={({ options }) => options}
+                            placeholder="Search your name…"
+                            inputMode="search"
+                            autoComplete="off"
+                            autoCorrect="off"
+                            autoCapitalize="words"
+                            leftSection={
+                                searching ? (
+                                    <Loader size={18} color="var(--gold)" />
+                                ) : (
+                                    <IconSearch size={18} color="var(--text-secondary)" />
+                                )
+                            }
+                            size="lg"
+                            styles={{
+                                input: {
+                                    fontSize: 16,
+                                    height: 52,
+                                    borderColor: "rgba(139, 115, 85, 0.3)",
+                                    borderRadius: 8,
+                                    paddingLeft: 48,
+                                    backgroundColor: "white",
+                                },
+                                option: {
+                                    minHeight: 48,
+                                    fontSize: 16,
+                                    display: "flex",
+                                    alignItems: "center",
+                                    padding: "0 1rem",
+                                },
+                                dropdown: {
+                                    borderRadius: 8,
+                                    border: "1px solid rgba(139, 115, 85, 0.2)",
+                                    boxShadow: "0 4px 20px rgba(139, 115, 85, 0.12)",
+                                },
+                            }}
+                        />
+
+                        {/* Loading */}
                         {loadingParty && (
-                            <Box style={{ display: "flex", justifyContent: "center", paddingTop: "2rem" }}>
-                                <Loader color="var(--gold)" />
+                            <Box style={{ display: "flex", justifyContent: "center", paddingTop: "2.5rem" }}>
+                                <Loader color="var(--gold)" size="md" />
                             </Box>
                         )}
 
+                        {/* Error */}
+                        {error && !loadingParty && (
+                            <Alert
+                                icon={<IconAlertCircle size={16} />}
+                                color="red"
+                                variant="light"
+                                mt="md"
+                            >
+                                {error}
+                            </Alert>
+                        )}
+
+                        {/* Results */}
                         {party && !loadingParty && (
                             <Box
+                                ref={resultsRef}
                                 style={{
+                                    marginTop: "1.25rem",
+                                    marginBottom: "2rem",
                                     background: "white",
-                                    borderRadius: 8,
-                                    padding: "1.75rem",
+                                    borderRadius: 12,
+                                    padding: "clamp(1.25rem, 5vw, 1.75rem)",
                                     border: "1px solid rgba(139, 115, 85, 0.15)",
-                                    boxShadow: "0 2px 12px rgba(139, 115, 85, 0.08)",
+                                    boxShadow: "0 4px 20px rgba(139, 115, 85, 0.1)",
                                 }}
                             >
                                 <Box
@@ -155,13 +218,13 @@ export default function SeatFinderPage() {
                                         display: "flex",
                                         alignItems: "center",
                                         gap: "0.5rem",
-                                        marginBottom: "1.25rem",
+                                        marginBottom: "1rem",
                                     }}
                                 >
-                                    <IconUsers size={18} color="var(--gold-dark)" />
+                                    <IconUsers size={16} color="var(--gold-dark)" />
                                     <Text
                                         style={{
-                                            fontSize: "0.8rem",
+                                            fontSize: "0.75rem",
                                             color: "var(--gold-dark)",
                                             letterSpacing: "0.12em",
                                             textTransform: "uppercase",
@@ -171,18 +234,26 @@ export default function SeatFinderPage() {
                                         {selectedName}&apos;s Party
                                     </Text>
                                 </Box>
-                                <Stack gap="xs">
-                                    {party.map((member) => (
-                                        <Text
+                                <Stack gap={0}>
+                                    {party.map((member, i) => (
+                                        <Box
                                             key={member.id}
                                             style={{
-                                                color: "var(--text-primary)",
-                                                fontSize: "1.05rem",
-                                                fontWeight: member.is_primary ? 500 : 400,
+                                                padding: "0.75rem 0",
+                                                borderTop: i > 0 ? "1px solid rgba(139, 115, 85, 0.08)" : "none",
                                             }}
                                         >
-                                            {member.first_name} {member.last_name}
-                                        </Text>
+                                            <Text
+                                                style={{
+                                                    color: "var(--text-primary)",
+                                                    fontSize: "clamp(1rem, 4vw, 1.1rem)",
+                                                    fontWeight: member.is_primary ? 500 : 400,
+                                                    lineHeight: 1.3,
+                                                }}
+                                            >
+                                                {member.first_name} {member.last_name}
+                                            </Text>
+                                        </Box>
                                     ))}
                                 </Stack>
                             </Box>

--- a/src/app/seat-finder/page.tsx
+++ b/src/app/seat-finder/page.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { Container, Title, Text, Box, Autocomplete, Loader, Stack } from "@mantine/core";
+import { IconSearch, IconUsers } from "@tabler/icons-react";
+import { Navigation } from "@/components/Navigation";
+
+interface Suggestion {
+    id: number;
+    name: string;
+}
+
+interface PartyMember {
+    id: number;
+    first_name: string;
+    last_name: string;
+    is_primary: boolean;
+}
+
+export default function SeatFinderPage() {
+    const [query, setQuery] = useState("");
+    const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+    const [party, setParty] = useState<PartyMember[] | null>(null);
+    const [selectedName, setSelectedName] = useState<string | null>(null);
+    const [searching, setSearching] = useState(false);
+    const [loadingParty, setLoadingParty] = useState(false);
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const nameToIdRef = useRef<Map<string, number>>(new Map());
+
+    useEffect(() => {
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+
+        if (query.trim().length < 2) {
+            setSuggestions([]);
+            setSearching(false);
+            return;
+        }
+
+        setSearching(true);
+        debounceRef.current = setTimeout(async () => {
+            try {
+                const res = await fetch(`/api/seat-finder/search?q=${encodeURIComponent(query)}`);
+                const data: Suggestion[] = await res.json();
+                setSuggestions(data);
+                nameToIdRef.current = new Map(data.map((s) => [s.name, s.id]));
+            } catch {
+                setSuggestions([]);
+            } finally {
+                setSearching(false);
+            }
+        }, 300);
+    }, [query]);
+
+    async function handleSelect(name: string) {
+        setQuery(name);
+        setSuggestions([]);
+
+        const id = nameToIdRef.current.get(name);
+        if (!id) return;
+
+        setLoadingParty(true);
+        setParty(null);
+        setSelectedName(name);
+
+        try {
+            const res = await fetch(`/api/seat-finder/party?id=${id}`);
+            const data = await res.json();
+            setParty(data.party ?? null);
+        } catch {
+            setParty(null);
+        } finally {
+            setLoadingParty(false);
+        }
+    }
+
+    return (
+        <>
+            <Navigation />
+            <main id="main-content">
+                <Box
+                    style={{
+                        paddingTop: 56,
+                        minHeight: "100vh",
+                        background: "linear-gradient(135deg, #f9f7f2 0%, #f0ebe0 100%)",
+                    }}
+                >
+                    <Container size="sm" py="xl">
+                        <Box style={{ paddingTop: "3rem", paddingBottom: "2rem" }}>
+                            <Text
+                                style={{
+                                    fontSize: "0.85rem",
+                                    color: "var(--gold)",
+                                    letterSpacing: "0.15em",
+                                    textTransform: "uppercase",
+                                    fontWeight: 600,
+                                    marginBottom: "0.75rem",
+                                }}
+                            >
+                                Find Your Seat
+                            </Text>
+                            <Title
+                                order={1}
+                                style={{
+                                    fontFamily: "var(--font-playfair), serif",
+                                    fontSize: "clamp(2rem, 6vw, 3rem)",
+                                    fontWeight: 400,
+                                    color: "var(--text-primary)",
+                                    marginBottom: "0.75rem",
+                                }}
+                            >
+                                Seat Finder
+                            </Title>
+                            <Text style={{ color: "var(--text-secondary)", marginBottom: "2.5rem" }}>
+                                Search for your name to see your party&apos;s seating.
+                            </Text>
+
+                            <Autocomplete
+                                value={query}
+                                onChange={setQuery}
+                                onOptionSubmit={handleSelect}
+                                data={suggestions.map((s) => s.name)}
+                                filter={({ options }) => options}
+                                placeholder="Search your name…"
+                                leftSection={
+                                    searching ? <Loader size={16} color="var(--gold)" /> : <IconSearch size={16} />
+                                }
+                                size="md"
+                                styles={{
+                                    input: {
+                                        borderColor: "rgba(139, 115, 85, 0.3)",
+                                        "&:focus": { borderColor: "var(--gold)" },
+                                    },
+                                }}
+                            />
+                        </Box>
+
+                        {loadingParty && (
+                            <Box style={{ display: "flex", justifyContent: "center", paddingTop: "2rem" }}>
+                                <Loader color="var(--gold)" />
+                            </Box>
+                        )}
+
+                        {party && !loadingParty && (
+                            <Box
+                                style={{
+                                    background: "white",
+                                    borderRadius: 8,
+                                    padding: "1.75rem",
+                                    border: "1px solid rgba(139, 115, 85, 0.15)",
+                                    boxShadow: "0 2px 12px rgba(139, 115, 85, 0.08)",
+                                }}
+                            >
+                                <Box
+                                    style={{
+                                        display: "flex",
+                                        alignItems: "center",
+                                        gap: "0.5rem",
+                                        marginBottom: "1.25rem",
+                                    }}
+                                >
+                                    <IconUsers size={18} color="var(--gold-dark)" />
+                                    <Text
+                                        style={{
+                                            fontSize: "0.8rem",
+                                            color: "var(--gold-dark)",
+                                            letterSpacing: "0.12em",
+                                            textTransform: "uppercase",
+                                            fontWeight: 600,
+                                        }}
+                                    >
+                                        {selectedName}&apos;s Party
+                                    </Text>
+                                </Box>
+                                <Stack gap="xs">
+                                    {party.map((member) => (
+                                        <Text
+                                            key={member.id}
+                                            style={{
+                                                color: "var(--text-primary)",
+                                                fontSize: "1.05rem",
+                                                fontWeight: member.is_primary ? 500 : 400,
+                                            }}
+                                        >
+                                            {member.first_name} {member.last_name}
+                                        </Text>
+                                    ))}
+                                </Stack>
+                            </Box>
+                        )}
+                    </Container>
+                </Box>
+            </main>
+        </>
+    );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -34,6 +34,18 @@ export async function middleware(request: NextRequest) {
         }
     }
 
+    // Seat finder is auth-gated until May 22nd 2026 (day before the wedding)
+    const SEAT_FINDER_PUBLIC_DATE = new Date("2026-05-22T00:00:00Z");
+    if (
+        request.nextUrl.pathname.startsWith("/seat-finder") &&
+        new Date() < SEAT_FINDER_PUBLIC_DATE &&
+        !session
+    ) {
+        const redirectUrl = new URL("/login", request.url);
+        redirectUrl.searchParams.set("redirectedFrom", request.nextUrl.pathname);
+        return NextResponse.redirect(redirectUrl);
+    }
+
     // If logged in and trying to access login page, redirect to dashboard
     if (request.nextUrl.pathname === "/login" && session) {
         if (process.env.NODE_ENV === "development") {
@@ -46,5 +58,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-    matcher: ["/dashboard/:path*", "/login"],
+    matcher: ["/dashboard/:path*", "/login", "/seat-finder/:path*", "/seat-finder"],
 };

--- a/supabase/migrations/20260501203922_add_seat_assignment.sql
+++ b/supabase/migrations/20260501203922_add_seat_assignment.sql
@@ -1,0 +1,3 @@
+ALTER TABLE invitees
+  ADD COLUMN table_number TEXT,
+  ADD COLUMN seat_number INTEGER;


### PR DESCRIPTION
Closes #126

## Summary
- New page at `/seat-finder` with name search autocomplete
- `GET /api/seat-finder/search?q=` — searches invitees by first/last name (case-insensitive, debounced 300ms)
- `GET /api/seat-finder/party?id=` — returns all members of the selected guest's invitation
- Party members displayed in a card once a name is selected
- Both endpoints use the existing GENERAL rate limit

Map integration will follow in a subsequent PR once the venue map is available.