### PR TITLE
chore(ci): remove Cypress cloud recording integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,13 +66,6 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
 
-    # Runs tests in parallel with matrix strategy
-    # https://docs.cypress.io/guides/guides/parallelization
-    strategy:
-      fail-fast: false
-      matrix:
-        containers: [1, 2]
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -117,17 +110,14 @@ jobs:
         start: npm run dev:test
         wait-on: 'http://localhost:3907'
         wait-on-timeout: 120
-        record: true
-        parallel: true
       env:
-        CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Upload Cypress screenshots
       uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: cypress-screenshots-${{ matrix.containers }}
+        name: cypress-screenshots
         path: cypress/screenshots
         retention-days: 7
 
@@ -135,7 +125,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: cypress-videos-${{ matrix.containers }}
+        name: cypress-videos
         path: cypress/videos
         retention-days: 7
 


### PR DESCRIPTION
Free trial expired. Removes `record: true`, `parallel: true`, `CYPRESS_RECORD_KEY`, and the matrix strategy from the e2e CI job. Tests still run in full on every push/PR via the cypress-io GitHub Action — just without cloud recording.