### PR TITLE
feat(seat-finder): add hint to tap other guests to see nearby seating

### DIFF
--- a/src/app/seat-finder/page.tsx
+++ b/src/app/seat-finder/page.tsx
@@ -168,7 +168,8 @@ export default function SeatFinderPage() {
                                     lineHeight: 1.5,
                                 }}
                             >
-                                Search for your name to find your party&apos;s seating.
+                                Search for your name to find your party&apos;s seating.{" "}
+                                Tap other guests to see who&apos;s sitting near you!
                             </Text>
                         </Box>
 


### PR DESCRIPTION
## Summary
- Adds a sentence to the seat finder intro text: "Tap other guests to see who's sitting near you!"

## Test plan
- [ ] Visit the seat finder page and verify the updated hint text appears below the search prompt