### PR TITLE
fix: disable standalone output on Amplify builds

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -23,7 +23,8 @@ const nextConfig = {
     experimental: {
         optimizePackageImports: ["@mantine/core", "@mantine/hooks"],
     },
-    ...(process.env.CI && {
+    // standalone only for GitHub CI — Amplify handles SSR natively (sets AWS_APP_ID)
+    ...(process.env.CI && !process.env.AWS_APP_ID && {
         output: "standalone",
         trailingSlash: true,
     }),


### PR DESCRIPTION
## Summary
- `CI=true` is set by Amplify during builds, which was triggering `output: "standalone"` in next.config.js
- Standalone output puts artifacts in `.next/standalone/` but `amplify.yml` expects them in `.next/`
- This caused a 500 on all SSR pages in production
- Fix: gate standalone on `!AWS_APP_ID` — Amplify always sets this env var, GitHub CI does not