### PR TITLE
fix: make JWKS and env var checks lazy to prevent module-init crashes

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,32 +2,32 @@ import { type NextRequest, NextResponse } from "next/server";
 import { jwtVerify, createRemoteJWKSet } from "jose";
 
 const region = process.env.AWS_REGION ?? "eu-west-1";
-const userPoolId = process.env.COGNITO_USER_POOL_ID;
 
-if (!userPoolId) {
-    throw new Error("COGNITO_USER_POOL_ID environment variable is required");
+let _jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
+
+function getJWKS() {
+    const userPoolId = process.env.COGNITO_USER_POOL_ID;
+    if (!userPoolId) throw new Error("COGNITO_USER_POOL_ID environment variable is required");
+    if (!_jwks) {
+        _jwks = createRemoteJWKSet(
+            new URL(`https://cognito-idp.${region}.amazonaws.com/${userPoolId}/.well-known/jwks.json`)
+        );
+    }
+    return _jwks;
 }
-
-const JWKS = createRemoteJWKSet(
-    new URL(`https://cognito-idp.${region}.amazonaws.com/${userPoolId}/.well-known/jwks.json`)
-);
-
-const JWT_ISSUER = `https://cognito-idp.${region}.amazonaws.com/${userPoolId}`;
 
 async function isAuthenticated(request: NextRequest): Promise<boolean> {
     const token = request.cookies.get("wedding_session")?.value;
     if (!token) return false;
 
     const audience = process.env.COGNITO_CLIENT_ID;
-    if (!audience) {
-        throw new Error("COGNITO_CLIENT_ID environment variable is required");
-    }
+    if (!audience) throw new Error("COGNITO_CLIENT_ID environment variable is required");
+
+    const userPoolId = process.env.COGNITO_USER_POOL_ID!;
+    const issuer = `https://cognito-idp.${region}.amazonaws.com/${userPoolId}`;
 
     try {
-        await jwtVerify(token, JWKS, {
-            issuer: JWT_ISSUER,
-            audience,
-        });
+        await jwtVerify(token, getJWKS(), { issuer, audience });
         return true;
     } catch {
         return false;

--- a/src/utils/auth/jwks.ts
+++ b/src/utils/auth/jwks.ts
@@ -1,14 +1,24 @@
 import { createRemoteJWKSet } from "jose";
 
 const region = process.env.AWS_REGION ?? "eu-west-1";
-const userPoolId = process.env.COGNITO_USER_POOL_ID;
 
-if (!userPoolId) {
-    throw new Error("COGNITO_USER_POOL_ID environment variable is required");
+let _jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
+
+function getUserPoolId(): string {
+    const id = process.env.COGNITO_USER_POOL_ID;
+    if (!id) throw new Error("COGNITO_USER_POOL_ID environment variable is required");
+    return id;
 }
 
-export const JWKS = createRemoteJWKSet(
-    new URL(`https://cognito-idp.${region}.amazonaws.com/${userPoolId}/.well-known/jwks.json`)
-);
+export function getJWKS(): ReturnType<typeof createRemoteJWKSet> {
+    if (!_jwks) {
+        _jwks = createRemoteJWKSet(
+            new URL(`https://cognito-idp.${region}.amazonaws.com/${getUserPoolId()}/.well-known/jwks.json`)
+        );
+    }
+    return _jwks;
+}
 
-export const JWT_ISSUER = `https://cognito-idp.${region}.amazonaws.com/${userPoolId}`;
+export function getJWTIssuer(): string {
+    return `https://cognito-idp.${region}.amazonaws.com/${getUserPoolId()}`;
+}

--- a/src/utils/auth/requireAuth.ts
+++ b/src/utils/auth/requireAuth.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { jwtVerify, type JWTPayload } from "jose";
-import { JWKS, JWT_ISSUER } from "./jwks";
+import { getJWKS, getJWTIssuer } from "./jwks";
 
 export type AuthResult =
     | { success: true; payload: JWTPayload }
@@ -22,8 +22,8 @@ export async function requireAuth(request: NextRequest): Promise<AuthResult> {
     }
 
     try {
-        const { payload } = await jwtVerify(token, JWKS, {
-            issuer: JWT_ISSUER,
+        const { payload } = await jwtVerify(token, getJWKS(), {
+            issuer: getJWTIssuer(),
             audience,
         });
         return { success: true, payload };

--- a/src/utils/auth/session.ts
+++ b/src/utils/auth/session.ts
@@ -1,6 +1,6 @@
 import { cookies } from "next/headers";
 import { jwtVerify, type JWTPayload } from "jose";
-import { JWKS, JWT_ISSUER } from "./jwks";
+import { getJWKS, getJWTIssuer } from "./jwks";
 
 const SESSION_COOKIE = "wedding_session";
 
@@ -19,8 +19,8 @@ export async function getSession(): Promise<SessionPayload | null> {
     }
 
     try {
-        const { payload } = await jwtVerify<SessionPayload>(token, JWKS, {
-            issuer: JWT_ISSUER,
+        const { payload } = await jwtVerify<SessionPayload>(token, getJWKS(), {
+            issuer: getJWTIssuer(),
             audience,
         });
         return payload;


### PR DESCRIPTION
## Problem
`jwks.ts` and `middleware.ts` threw at module initialization level if `COGNITO_USER_POOL_ID` was missing or not yet available in the Lambda/Edge runtime. This caused every route that imported them to return 500 before handling any request.

## Fix
Move all env var checks and JWKS initialization inside functions so they run lazily on first call, not at import time. The JWKS instance is still cached after first initialization.

## Affected files
- `src/utils/auth/jwks.ts` — replaced exported constants with `getJWKS()` / `getJWTIssuer()` functions
- `src/utils/auth/requireAuth.ts` — updated to call functions
- `src/utils/auth/session.ts` — updated to call functions  
- `src/middleware.ts` — moved JWKS init and env checks inside `isAuthenticated()`