### PR TITLE
Fix dashboard data load and add password-change flow

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,20 +1,38 @@
 import { NextRequest, NextResponse } from "next/server";
-import { signIn } from "@/utils/auth/cognito";
+import { signIn, completeNewPassword, isNewPasswordChallenge } from "@/utils/auth/cognito";
 import { setSessionCookie, setAccessTokenCookie } from "@/utils/auth/session";
 
 export async function POST(request: NextRequest) {
     try {
-        const { email, password } = await request.json();
+        const body = await request.json();
+        const { email, password, newPassword, session } = body;
 
         if (!email || !password) {
             return NextResponse.json({ error: "Email and password are required" }, { status: 400 });
         }
 
-        const tokens = await signIn(email as string, password as string);
+        // Complete a NEW_PASSWORD_REQUIRED challenge
+        if (newPassword && session) {
+            const tokens = await completeNewPassword(email as string, newPassword as string, session as string);
+            const response = NextResponse.json({ ok: true });
+            response.cookies.set(setSessionCookie(tokens.idToken, tokens.expiresIn));
+            response.cookies.set(setAccessTokenCookie(tokens.accessToken, tokens.expiresIn));
+            return response;
+        }
+
+        const result = await signIn(email as string, password as string);
+
+        if (isNewPasswordChallenge(result)) {
+            return NextResponse.json({
+                challenge: "NEW_PASSWORD_REQUIRED",
+                session: result.session,
+                username: result.username,
+            });
+        }
 
         const response = NextResponse.json({ ok: true });
-        response.cookies.set(setSessionCookie(tokens.idToken, tokens.expiresIn));
-        response.cookies.set(setAccessTokenCookie(tokens.accessToken, tokens.expiresIn));
+        response.cookies.set(setSessionCookie(result.idToken, result.expiresIn));
+        response.cookies.set(setAccessTokenCookie(result.accessToken, result.expiresIn));
 
         return response;
     } catch (err) {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Title, Text, Group, Stack, Paper, Box, SimpleGrid, Progress, Button } from "@mantine/core";
-import { IconExternalLink } from "@tabler/icons-react";
+import { Title, Text, Group, Stack, Paper, Box, SimpleGrid, Progress, Button, Alert } from "@mantine/core";
+import { IconExternalLink, IconAlertCircle } from "@tabler/icons-react";
 import { useState, useEffect } from "react";
 
 interface SummaryData {
@@ -18,12 +18,17 @@ export default function DashboardPage() {
         guests: { total: 0, coming: 0, notComing: 0, undecided: 0 },
         villa: { stayingYes: 0, stayingNo: 0, undecided: 0 },
     });
+    const [fetchError, setFetchError] = useState<string | null>(null);
 
     useEffect(() => {
         fetch("/api/dashboard/summary")
-            .then(r => r.json())
+            .then(async r => {
+                const data = await r.json();
+                if (!r.ok) throw new Error(data.error ?? `Request failed (${r.status})`);
+                return data;
+            })
             .then(data => { if (data.summary) setSummary(data.summary); })
-            .catch(err => console.error("Failed to fetch summary:", err));
+            .catch(err => setFetchError(err instanceof Error ? err.message : "Failed to load data"));
     }, []);
 
     return (
@@ -56,6 +61,12 @@ export default function DashboardPage() {
                         Planning Sheet
                     </Button>
                 </Group>
+
+                {fetchError && (
+                    <Alert icon={<IconAlertCircle size={16} />} color="red" variant="light" mb="lg">
+                        Failed to load summary: {fetchError}
+                    </Alert>
+                )}
 
                 <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="lg">
                     <Paper shadow="md" radius="lg" p="lg" style={{ backgroundColor: "#ffffff" }}>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -10,6 +10,9 @@ export default function LoginPage() {
     const [password, setPassword] = useState("");
     const [error, setError] = useState("");
     const [loading, setLoading] = useState(false);
+    const [challengeSession, setChallengeSession] = useState<string | null>(null);
+    const [newPassword, setNewPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
 
     const router = useRouter();
 
@@ -19,15 +22,32 @@ export default function LoginPage() {
         setLoading(true);
 
         try {
+            const body = challengeSession
+                ? { email, password, newPassword, session: challengeSession }
+                : { email, password };
+
+            if (challengeSession && newPassword !== confirmPassword) {
+                setError("Passwords do not match");
+                setLoading(false);
+                return;
+            }
+
             const res = await fetch("/api/auth/login", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ email, password }),
+                body: JSON.stringify(body),
             });
 
+            const data = await res.json();
+
             if (!res.ok) {
-                const { error: msg } = await res.json();
-                setError(msg ?? "Sign in failed");
+                setError(data.error ?? "Sign in failed");
+                setLoading(false);
+                return;
+            }
+
+            if (data.challenge === "NEW_PASSWORD_REQUIRED") {
+                setChallengeSession(data.session);
                 setLoading(false);
                 return;
             }
@@ -77,6 +97,12 @@ export default function LoginPage() {
                             </Alert>
                         )}
 
+                        {challengeSession && (
+                            <Alert color="blue" variant="light">
+                                Your temporary password has expired. Please set a new password to continue.
+                            </Alert>
+                        )}
+
                         <form onSubmit={handleSubmit}>
                             <Stack gap="md">
                                 <TextInput
@@ -86,23 +112,53 @@ export default function LoginPage() {
                                     required
                                     value={email}
                                     onChange={e => setEmail(e.target.value)}
+                                    disabled={!!challengeSession}
                                     styles={{
                                         label: { color: "#495057", fontWeight: 500 },
                                         input: { borderColor: "#dee2e6" },
                                     }}
                                 />
 
-                                <PasswordInput
-                                    label="Password"
-                                    placeholder="Enter your password"
-                                    required
-                                    value={password}
-                                    onChange={e => setPassword(e.target.value)}
-                                    styles={{
-                                        label: { color: "#495057", fontWeight: 500 },
-                                        input: { borderColor: "#dee2e6" },
-                                    }}
-                                />
+                                {!challengeSession && (
+                                    <PasswordInput
+                                        label="Password"
+                                        placeholder="Enter your password"
+                                        required
+                                        value={password}
+                                        onChange={e => setPassword(e.target.value)}
+                                        styles={{
+                                            label: { color: "#495057", fontWeight: 500 },
+                                            input: { borderColor: "#dee2e6" },
+                                        }}
+                                    />
+                                )}
+
+                                {challengeSession && (
+                                    <>
+                                        <PasswordInput
+                                            label="New Password"
+                                            placeholder="Choose a new password"
+                                            required
+                                            value={newPassword}
+                                            onChange={e => setNewPassword(e.target.value)}
+                                            styles={{
+                                                label: { color: "#495057", fontWeight: 500 },
+                                                input: { borderColor: "#dee2e6" },
+                                            }}
+                                        />
+                                        <PasswordInput
+                                            label="Confirm New Password"
+                                            placeholder="Confirm your new password"
+                                            required
+                                            value={confirmPassword}
+                                            onChange={e => setConfirmPassword(e.target.value)}
+                                            styles={{
+                                                label: { color: "#495057", fontWeight: 500 },
+                                                input: { borderColor: "#dee2e6" },
+                                            }}
+                                        />
+                                    </>
+                                )}
 
                                 <Button
                                     type="submit"
@@ -115,7 +171,7 @@ export default function LoginPage() {
                                         marginTop: "1rem",
                                     }}
                                 >
-                                    Sign In
+                                    {challengeSession ? "Set New Password" : "Sign In"}
                                 </Button>
                             </Stack>
                         </form>

--- a/src/utils/auth/cognito.ts
+++ b/src/utils/auth/cognito.ts
@@ -2,6 +2,7 @@ import {
     CognitoIdentityProviderClient,
     InitiateAuthCommand,
     GlobalSignOutCommand,
+    RespondToAuthChallengeCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 
 const client = new CognitoIdentityProviderClient({
@@ -15,7 +16,19 @@ export interface CognitoTokens {
     expiresIn: number;
 }
 
-export async function signIn(email: string, password: string): Promise<CognitoTokens> {
+export interface NewPasswordChallenge {
+    challenge: "NEW_PASSWORD_REQUIRED";
+    session: string;
+    username: string;
+}
+
+export type SignInResult = CognitoTokens | NewPasswordChallenge;
+
+export function isNewPasswordChallenge(r: SignInResult): r is NewPasswordChallenge {
+    return "challenge" in r;
+}
+
+export async function signIn(email: string, password: string): Promise<SignInResult> {
     const clientId = process.env.COGNITO_CLIENT_ID;
     if (!clientId) throw new Error("COGNITO_CLIENT_ID environment variable is required");
 
@@ -30,10 +43,49 @@ export async function signIn(email: string, password: string): Promise<CognitoTo
     });
 
     const result = await client.send(command);
+
+    if (result.ChallengeName === "NEW_PASSWORD_REQUIRED") {
+        if (!result.Session) throw new Error("Missing session in NEW_PASSWORD_REQUIRED challenge");
+        return { challenge: "NEW_PASSWORD_REQUIRED", session: result.Session, username: email };
+    }
+
+    const auth = result.AuthenticationResult;
+    if (!auth?.AccessToken || !auth.IdToken || !auth.RefreshToken) {
+        throw new Error("Authentication failed");
+    }
+
+    return {
+        accessToken: auth.AccessToken,
+        idToken: auth.IdToken,
+        refreshToken: auth.RefreshToken,
+        expiresIn: auth.ExpiresIn ?? 3600,
+    };
+}
+
+export async function completeNewPassword(
+    username: string,
+    newPassword: string,
+    session: string
+): Promise<CognitoTokens> {
+    const clientId = process.env.COGNITO_CLIENT_ID;
+    if (!clientId) throw new Error("COGNITO_CLIENT_ID environment variable is required");
+
+    const command = new RespondToAuthChallengeCommand({
+        ClientId: clientId,
+        ChallengeName: "NEW_PASSWORD_REQUIRED",
+        Session: session,
+        ChallengeResponses: {
+            USERNAME: username,
+            NEW_PASSWORD: newPassword,
+            SECRET_HASH: await computeSecretHash(username, clientId),
+        },
+    });
+
+    const result = await client.send(command);
     const auth = result.AuthenticationResult;
 
     if (!auth?.AccessToken || !auth.IdToken || !auth.RefreshToken) {
-        throw new Error("Authentication failed");
+        throw new Error("Password change failed");
     }
 
     return {


### PR DESCRIPTION
## Summary
- Fixed silent zero-data on the dashboard by surfacing API errors with an Alert component
- Added `NEW_PASSWORD_REQUIRED` Cognito challenge handling so users are prompted to set a new password when their temporary password expires
- Completed the login flow to handle the challenge response in the same POST endpoint

## Infrastructure changes (already applied via CLI)
- Updated `AURORA_CLUSTER_ARN` and `AURORA_SECRET_ARN` Amplify env vars to use the correct same-account ARNs (`084032333902` instead of `297374559677`)
- Created IAM role `amplify-wedding-ssr-role` with `rds-data:ExecuteStatement` and `secretsmanager:GetSecretValue` permissions
- Set this role as the Amplify service role (used for SSR Lambda execution at runtime)
- A manual redeploy of `main` was triggered to pick up these changes