### PR TITLE
Fix Lambda DB credentials for Amplify runtime

### DIFF
--- a/src/utils/db/client.ts
+++ b/src/utils/db/client.ts
@@ -1,6 +1,14 @@
 import { RDSDataClient, ExecuteStatementCommand, type Field } from "@aws-sdk/client-rds-data";
 
-const client = new RDSDataClient({ region: process.env.AWS_REGION ?? "eu-west-1" });
+const client = new RDSDataClient({
+    region: process.env.AWS_REGION ?? "eu-west-1",
+    ...(process.env.LAMBDA_AWS_KEY_ID && {
+        credentials: {
+            accessKeyId: process.env.LAMBDA_AWS_KEY_ID,
+            secretAccessKey: process.env.LAMBDA_AWS_SECRET!,
+        },
+    }),
+});
 
 type ParamValue = string | number | boolean | null | undefined;
 


### PR DESCRIPTION
Pass explicit AWS credentials (LAMBDA_AWS_KEY_ID / LAMBDA_AWS_SECRET) to the RDS Data client. Amplify's SSR Lambda runs in Amplify's own managed infrastructure and has no ambient IAM role, so the credential chain falls through. The wedding-api-lambda IAM user has been created with minimal rds-data + secretsmanager permissions and the keys are set in the Amplify env vars.