### PR TITLE
Fix Lambda env vars and expose real error messages

### DIFF
--- a/src/app/api/dashboard/summary/route.ts
+++ b/src/app/api/dashboard/summary/route.ts
@@ -69,7 +69,8 @@ export async function GET(request: NextRequest) {
             },
         });
     } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
         console.error("Error in GET /api/dashboard/summary:", error);
-        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+        return NextResponse.json({ error: msg }, { status: 500 });
     }
 }

--- a/src/utils/db/client.ts
+++ b/src/utils/db/client.ts
@@ -1,11 +1,14 @@
 import { RDSDataClient, ExecuteStatementCommand, type Field } from "@aws-sdk/client-rds-data";
 
+const lambdaKeyId = process.env["LAMBDA_AWS_KEY_ID"];
+const lambdaSecret = process.env["LAMBDA_AWS_SECRET"];
+
 const client = new RDSDataClient({
-    region: process.env.AWS_REGION ?? "eu-west-1",
-    ...(process.env.LAMBDA_AWS_KEY_ID && {
+    region: process.env["AWS_REGION"] ?? "eu-west-1",
+    ...(lambdaKeyId && lambdaSecret && {
         credentials: {
-            accessKeyId: process.env.LAMBDA_AWS_KEY_ID,
-            secretAccessKey: process.env.LAMBDA_AWS_SECRET!,
+            accessKeyId: lambdaKeyId,
+            secretAccessKey: lambdaSecret,
         },
     }),
 });
@@ -44,9 +47,9 @@ const db = {
         const { sql: transformedSql, parameters } = toRdsParams(sql, params);
         const result = await client.send(
             new ExecuteStatementCommand({
-                resourceArn: process.env.AURORA_CLUSTER_ARN!,
-                secretArn: process.env.AURORA_SECRET_ARN!,
-                database: process.env.DB_NAME ?? "wedding",
+                resourceArn: process.env["AURORA_CLUSTER_ARN"]!,
+                secretArn: process.env["AURORA_SECRET_ARN"]!,
+                database: process.env["DB_NAME"] ?? "wedding",
                 sql: transformedSql,
                 parameters,
                 formatRecordsAs: "JSON",


### PR DESCRIPTION
Use bracket notation for LAMBDA_AWS_KEY_ID/SECRET to prevent webpack static analysis. Return actual exception message from the summary API instead of the generic 'Internal server error' so failures are diagnosable.