### PR TITLE
Add CloudWatch logging to API routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "wedding",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-cloudwatch-logs": "^3.1065.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.1058.0",
         "@aws-sdk/client-rds-data": "^3.1064.0",
         "@aws-sdk/client-rekognition": "^3.1058.0",
@@ -172,6 +173,27 @@
         "tslib": "^2.6.2"
       }
     },
+    "node_modules/@aws-sdk/client-cloudwatch-logs": {
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.1065.0.tgz",
+      "integrity": "sha512-wQZtnsU5ogs6H4nViafC8nESKZgvP9TsnRCQw+hAnzbLTx+djrZ+GBNs4XizcGBrHjdokJDPVMowLvM7MUSq9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-node": "^3.972.54",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-cognito-identity-provider": {
       "version": "3.1058.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.1058.0.tgz",
@@ -265,9 +287,9 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.19.tgz",
-      "integrity": "sha512-SMNfLCU/41xxfFaC5Slwy8V/f1FRhakvyeeMeDeIxqNF0DzhDlXsXnJDELJYke1EtnJbfzfilW7tvulGfxMY6A==",
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+      "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.12",
@@ -297,12 +319,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.45.tgz",
-      "integrity": "sha512-ZPsnLyrpDRmojKrBbJykASyLLVFkjyD+fWATeSuYgaqablijGOzxPxEKyrwUvNg+bgSQ7PkW2FTu65Xco19Gag==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
+      "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/core": "^3.974.20",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
@@ -313,12 +335,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.47",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.47.tgz",
-      "integrity": "sha512-1XdgHDIPbARHuzZXM7ouzIbSUZFU9dTi9k+ryMhiZU4QCam4dvwOyUEFjEHNxAZehCYUIOmsSUZ2un6BIgUkWg==",
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
+      "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/core": "^3.974.20",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/fetch-http-handler": "^5.4.6",
@@ -331,19 +353,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.51",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.51.tgz",
-      "integrity": "sha512-f8sRTVyM+9BbzQKPlUP9dVVpgNEu65jFckNAAGzRfCrlaSi5AWUbCKEHIMcIYokv8pWblSKEqHkqKYZtwINnhw==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.52.tgz",
+      "integrity": "sha512-szg1nnebqC+Svv6Vfsdf6P/QK8x5g/ghG2CKa/1WkHifRnq0BBmDELj2Qnqk9nPsUvEu/OEcYic97CPLpKqF9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/credential-provider-env": "^3.972.45",
-        "@aws-sdk/credential-provider-http": "^3.972.47",
-        "@aws-sdk/credential-provider-login": "^3.972.50",
-        "@aws-sdk/credential-provider-process": "^3.972.45",
-        "@aws-sdk/credential-provider-sso": "^3.972.50",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.50",
-        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-login": "^3.972.51",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.51",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+        "@aws-sdk/nested-clients": "^3.997.19",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/credential-provider-imds": "^4.3.7",
@@ -355,13 +377,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.50.tgz",
-      "integrity": "sha512-NHHsKoMhw6UylSU0XDnDc87+IQW8tRBTIe6vnOX12GSIlBDtoce6bSzONleIglCyu8d3H9bmTSfk+sIN5yh3WA==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.51.tgz",
+      "integrity": "sha512-csHFsH+/VjnI40oqm1l1OqMY4B4kza36DbfcbHcgcbobgjebasqUbTU34xvwUkvtoNGGizbfyMSlMzJWUPv3dQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
@@ -372,17 +394,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.53",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.53.tgz",
-      "integrity": "sha512-z/JJ8Qvf2GiTn4bw+x8k7wQjxmPpNsiwZ7ls/h1cZHikrSpS0+65lB+lafnXZlxv1lqH4k6rQwh+2UsycC662g==",
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.54.tgz",
+      "integrity": "sha512-vinTSQtziNHxi2nqXF+76jr2sO44q88Ind1qFFVaotNgBaC1rcWDjBug8yoE8n0ov33s21xks9WY5XDHH9SENw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.45",
-        "@aws-sdk/credential-provider-http": "^3.972.47",
-        "@aws-sdk/credential-provider-ini": "^3.972.51",
-        "@aws-sdk/credential-provider-process": "^3.972.45",
-        "@aws-sdk/credential-provider-sso": "^3.972.50",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.50",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-ini": "^3.972.52",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.51",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.51",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/credential-provider-imds": "^4.3.7",
@@ -394,12 +416,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.45.tgz",
-      "integrity": "sha512-QMJXjTGLmHE4Ie03T5H4hHOLfcvMc9DaODO6b5dgte3S8ECf5bBuHUJW4cQREcYZyRkOU8iymqtiBxqF4icxZg==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
+      "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/core": "^3.974.20",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
@@ -410,14 +432,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.50.tgz",
-      "integrity": "sha512-pQ9ww4G53gwHlon1NMz25JhaBo13E9Jv+VVgjh39C/yzvby+xhSnEOb+VDYShKNCh1TbttMF/5CFCHkZrIqOcA==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.51.tgz",
+      "integrity": "sha512-60qhpQcSDIKIr0AuBlmJezKX0b5nbJPCINiR49N9yJXrEI5tTRwsXVBr0IdSvvsNJyqgiINyoBd++Ed0yvggbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/nested-clients": "^3.997.18",
-        "@aws-sdk/token-providers": "3.1064.0",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/token-providers": "3.1065.0",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
@@ -428,13 +450,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.50.tgz",
-      "integrity": "sha512-9DbaPaT2aMbz18wtSpq9HVBErjBQwxykqTFgG6n8Bn05GN68mITz+G1869ekYx0mVT/BDjETj5czz/3cPgLwxA==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.51.tgz",
+      "integrity": "sha512-0X5eWsUIp8ItRJeJBBrhQAPzc9AQelDetRTVTsycCAISCCzM17R4hs/vFAPeQ0o0B35sciLiqe/Pwmml909cZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
@@ -541,14 +563,14 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.18.tgz",
-      "integrity": "sha512-xBWrodBvW5SHCZV11UZUJG0pSHkLCEREIBoNbff1C1sacOUCmxJnTCPE80sCGLCtqgXg98I2MQJe2z28tcZSsw==",
+      "version": "3.997.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.19.tgz",
+      "integrity": "sha512-P2Otgf15GBJMKzG6j5Ddf7w+Kz6z2jvesMy874TD3jlMfDWNK7clJeUd7hgigdeVOotjoUP4emcTWVdS9sfZDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/core": "^3.974.20",
         "@aws-sdk/signature-v4-multi-region": "^3.996.33",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
@@ -594,13 +616,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1064.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1064.0.tgz",
-      "integrity": "sha512-sjI+iA4JtgeckBgKwPQF7KzWillRoNDmtpiM0TRa0syiAKFHKUSf84kPXSO3+gA7aMMSxrcxzOM2oPSecaJvEA==",
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1065.0.tgz",
+      "integrity": "sha512-qdHQntq82gMqG6Tf8xrgmhJxacaYkxW4PEeDg/ISMVJ84EWe7iD6JyCTgbyox3uNDH6vqEJ8GUiTaXCq307zVw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@aws-sdk/client-cloudwatch-logs": "^3.1065.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.1058.0",
     "@aws-sdk/client-rds-data": "^3.1064.0",
     "@aws-sdk/client-rekognition": "^3.1058.0",

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,11 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { signIn, completeNewPassword, isNewPasswordChallenge } from "@/utils/auth/cognito";
 import { setSessionCookie, setAccessTokenCookie } from "@/utils/auth/session";
+import * as logger from "@/utils/logger";
 
 export async function POST(request: NextRequest) {
+    let email: string | undefined;
     try {
         const body = await request.json();
-        const { email, password, newPassword, session } = body;
+        ({ email } = body);
+        const { password, newPassword, session } = body;
 
         if (!email || !password) {
             return NextResponse.json({ error: "Email and password are required" }, { status: 400 });
@@ -23,6 +26,7 @@ export async function POST(request: NextRequest) {
         const result = await signIn(email as string, password as string);
 
         if (isNewPasswordChallenge(result)) {
+            logger.info("POST /api/auth/login", "NEW_PASSWORD_REQUIRED challenge", { email });
             return NextResponse.json({
                 challenge: "NEW_PASSWORD_REQUIRED",
                 session: result.session,
@@ -30,6 +34,7 @@ export async function POST(request: NextRequest) {
             });
         }
 
+        logger.info("POST /api/auth/login", "Login successful", { email });
         const response = NextResponse.json({ ok: true });
         response.cookies.set(setSessionCookie(result.idToken, result.expiresIn));
         response.cookies.set(setAccessTokenCookie(result.accessToken, result.expiresIn));
@@ -37,6 +42,7 @@ export async function POST(request: NextRequest) {
         return response;
     } catch (err) {
         const message = err instanceof Error ? err.message : "Authentication failed";
+        await logger.error("POST /api/auth/login", "Login failed", { email, message });
         return NextResponse.json({ error: message }, { status: 401 });
     }
 }

--- a/src/app/api/dashboard/summary/route.ts
+++ b/src/app/api/dashboard/summary/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb } from "@/utils/db/client";
 import { requireAuth } from "@/utils/auth/requireAuth";
+import * as logger from "@/utils/logger";
 
 export async function GET(request: NextRequest) {
     const auth = await requireAuth(request);
@@ -70,7 +71,7 @@ export async function GET(request: NextRequest) {
         });
     } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        console.error("Error in GET /api/dashboard/summary:", error);
+        await logger.error("GET /api/dashboard/summary", "DB query failed", error);
         return NextResponse.json({ error: msg }, { status: 500 });
     }
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,80 @@
+import {
+    CloudWatchLogsClient,
+    PutLogEventsCommand,
+    CreateLogStreamCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+const LOG_GROUP = "/wedding/app";
+
+const cwClient = new CloudWatchLogsClient({
+    region: process.env["AWS_REGION"] ?? "eu-west-1",
+    ...(process.env["LAMBDA_AWS_KEY_ID"] && process.env["LAMBDA_AWS_SECRET"] && {
+        credentials: {
+            accessKeyId: process.env["LAMBDA_AWS_KEY_ID"],
+            secretAccessKey: process.env["LAMBDA_AWS_SECRET"],
+        },
+    }),
+});
+
+// Cache which streams we've already created this process lifetime
+const knownStreams = new Set<string>();
+
+function streamName(): string {
+    return new Date().toISOString().slice(0, 10); // "2026-06-10"
+}
+
+async function ensureStream(stream: string): Promise<void> {
+    if (knownStreams.has(stream)) return;
+    try {
+        await cwClient.send(new CreateLogStreamCommand({
+            logGroupName: LOG_GROUP,
+            logStreamName: stream,
+        }));
+    } catch (e: unknown) {
+        if ((e as { name?: string }).name !== "ResourceAlreadyExistsException") throw e;
+    }
+    knownStreams.add(stream);
+}
+
+type Level = "INFO" | "WARN" | "ERROR";
+
+interface LogEntry {
+    level: Level;
+    route: string;
+    message: string;
+    data?: unknown;
+}
+
+async function write(entry: LogEntry): Promise<void> {
+    const stream = streamName();
+    try {
+        await ensureStream(stream);
+        await cwClient.send(new PutLogEventsCommand({
+            logGroupName: LOG_GROUP,
+            logStreamName: stream,
+            logEvents: [{
+                timestamp: Date.now(),
+                message: JSON.stringify(entry),
+            }],
+        }));
+    } catch {
+        // Never let logging failures break the app — fall back to console
+        console.error("[logger]", JSON.stringify(entry));
+    }
+}
+
+export function info(route: string, message: string, data?: unknown): void {
+    void write({ level: "INFO", route, message, data });
+}
+
+export function warn(route: string, message: string, data?: unknown): void {
+    void write({ level: "WARN", route, message, data });
+}
+
+// Awaited so the error is guaranteed to land before the response returns
+export async function error(route: string, message: string, err?: unknown): Promise<void> {
+    const data = err instanceof Error
+        ? { name: err.name, message: err.message, stack: err.stack }
+        : err;
+    await write({ level: "ERROR", route, message, data });
+}


### PR DESCRIPTION
Adds a logger utility (src/utils/logger.ts) that writes structured JSON log entries to CloudWatch Logs /wedding/app. Errors are awaited before the response returns to guarantee they land. Info logs are fire-and-forget. Wired into the dashboard summary and login routes.