### PR TITLE
Fix: bake Lambda AWS credentials into build

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -21,6 +21,8 @@ const nextConfig = {
         COGNITO_CLIENT_SECRET: process.env.COGNITO_CLIENT_SECRET ?? "",
         AURORA_CLUSTER_ARN: process.env.AURORA_CLUSTER_ARN ?? "",
         AURORA_SECRET_ARN: process.env.AURORA_SECRET_ARN ?? "",
+        LAMBDA_AWS_KEY_ID: process.env.LAMBDA_AWS_KEY_ID ?? "",
+        LAMBDA_AWS_SECRET: process.env.LAMBDA_AWS_SECRET ?? "",
     },
     images: {
         remotePatterns: cloudfrontDomain


### PR DESCRIPTION
The Amplify Lambda runtime only receives env vars that are explicitly baked at build time via next.config `env` section. LAMBDA_AWS_KEY_ID and LAMBDA_AWS_SECRET were not in that section, so the Lambda had no AWS credentials and the DB call failed with CredentialsProviderError. Confirmed via the /api/debug diagnostic endpoint.