### PR TITLE
docs: replace Supabase/Vercel references with current AWS stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,17 +4,27 @@
 # Next.js port (optional, defaults to 3000)
 PORT=3022
 
-# Supabase Configuration
-# For local development, use local Supabase instance:
-#   NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
-#   NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
-#
-# For production, use your Supabase project credentials:
-NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+# AWS Region
+AWS_REGION=eu-west-1
+
+# Cognito Authentication
+COGNITO_USER_POOL_ID=eu-west-1_XXXXXXXXX
+COGNITO_CLIENT_ID=your-client-id
+COGNITO_CLIENT_SECRET=your-client-secret
+
+# Aurora Serverless (RDS Data API)
+AURORA_CLUSTER_ARN=arn:aws:rds:eu-west-1:084032333902:cluster:your-cluster
+AURORA_SECRET_ARN=arn:aws:secretsmanager:eu-west-1:084032333902:secret:your-secret
+
+# IAM credentials for Lambda to call RDS Data API and CloudWatch
+# Use the wedding-api-lambda IAM user keys
+LAMBDA_AWS_KEY_ID=your-access-key-id
+LAMBDA_AWS_SECRET=your-secret-access-key
+
+# CloudFront URL for wedding photos (optional)
+NEXT_PUBLIC_CLOUDFRONT_URL=https://your-distribution.cloudfront.net
 
 # PostHog Analytics (Optional)
-# Sign up at https://posthog.com and create a project to get your key
 # Leave blank to disable analytics
 NEXT_PUBLIC_POSTHOG_KEY=
 NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,11 @@
 ---
 name: Wedding Website Development Agent
-description: AI assistant for building and maintaining Rebecca & Matthew's wedding website with Next.js, TypeScript, Mantine UI, and Supabase
+description: AI assistant for building and maintaining Rebecca & Matthew's wedding website with Next.js, TypeScript, Mantine UI, and AWS
 ---
 
 # Wedding Website Development Agent
 
-You are a full-stack TypeScript developer specializing in modern React applications. Your role is to help build and maintain a wedding website with a focus on clean code, accessibility, and thorough testing.
+You are a full-stack TypeScript developer specialising in modern React applications. Your role is to help build and maintain a wedding website with a focus on clean code, accessibility, and thorough testing.
 
 ## Project Overview
 
@@ -29,9 +29,11 @@ You are a full-stack TypeScript developer specializing in modern React applicati
 - **Color Scheme**: Brown/gold (`#8b7355`)
 
 ### Backend & Data
-- **Supabase**: PostgreSQL database with authentication
-- **@supabase/ssr**: 0.6.1
-- **@supabase/supabase-js**: 2.49.1
+- **Aurora Serverless v2**: PostgreSQL via RDS Data API (no connection pooling needed)
+- **AWS Cognito**: Admin authentication
+- **AWS Amplify**: Hosting (WEB_COMPUTE — Lambda-based SSR)
+- **CloudFront + S3**: Wedding photo CDN
+- **CloudWatch**: Structured app logs at `/wedding/app`
 
 ### Testing
 - **Vitest**: 3.2.4 (unit tests)
@@ -50,6 +52,8 @@ Wedding/
 ├── src/
 │   ├── app/                    # Next.js App Router pages
 │   │   ├── api/               # API routes
+│   │   │   ├── auth/         # Login/logout
+│   │   │   ├── dashboard/    # Dashboard summary
 │   │   │   ├── faqs/         # FAQ management
 │   │   │   └── rsvp/         # RSVP endpoints
 │   │   ├── dashboard/        # Admin dashboard (protected)
@@ -64,14 +68,14 @@ Wedding/
 │   ├── hooks/                # Custom hooks (useRSVPForm)
 │   ├── types/                # TypeScript definitions
 │   ├── utils/                # Utility functions
-│   │   └── supabase/        # Supabase clients
+│   │   ├── auth/            # Cognito sign-in helpers
+│   │   ├── db/              # Aurora Data API client
+│   │   └── logger.ts        # CloudWatch structured logger
 │   └── test/                 # Test utilities
 ├── cypress/                  # E2E tests
 │   ├── e2e/                 # Test specs
-│   ├── fixtures/            # Test data
+│   ├── fixtures/            # Test data (auth-data.json written by CI)
 │   └── support/             # Custom commands
-├── supabase/                 # Dev Supabase config
-├── supabase-test/           # Test Supabase config (isolated)
 ├── docs/                    # Documentation
 └── public/                  # Static assets
 ```
@@ -80,8 +84,7 @@ Wedding/
 
 ### Development
 ```bash
-npm run dev                  # Start dev server (starts Supabase automatically)
-npm run dev:next-only       # Start Next.js only (Supabase already running)
+npm run dev                  # Start dev server
 npm run build               # Production build
 npm run lint                # Run ESLint
 ```
@@ -95,13 +98,11 @@ npm run cypress:open       # Open Cypress UI
 npm run test:e2e          # Run E2E tests (automated)
 ```
 
-### Database
-```bash
-npm run supabase:start     # Start local Supabase (dev instance)
-npm run supabase:reset     # Reset dev database
-npm run supabase:test:start    # Start test Supabase (port 54421)
-npm run supabase:test:reset    # Reset test database
-```
+## How Env Vars Reach the Lambda
+
+Amplify builds the Next.js app and deploys it as a Lambda. Environment variables are only available at Lambda runtime if they are **explicitly baked** into the bundle via the `env` section in `next.config.js`. Variables set in the Amplify console but NOT listed in `next.config.js` `env` are NOT available at runtime.
+
+Current baked vars: `COGNITO_USER_POOL_ID`, `COGNITO_CLIENT_ID`, `COGNITO_CLIENT_SECRET`, `AURORA_CLUSTER_ARN`, `AURORA_SECRET_ARN`, `LAMBDA_AWS_KEY_ID`, `LAMBDA_AWS_SECRET`.
 
 ## Code Style Guide
 
@@ -192,42 +193,26 @@ export const useRSVPForm = () => {
 ✅ **Good Example:**
 ```tsx
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/utils/supabase/server";
+import { query } from "@/utils/db/client";
+import * as logger from "@/utils/logger";
 
-export async function GET(
-    request: NextRequest,
-    { params }: { params: { code: string } }
-) {
-    const supabase = await createClient();
-    const { code } = await params;
-
-    const { data, error } = await supabase
-        .from("RSVPs")
-        .select("*")
-        .eq("short_url", code)
-        .single();
-
-    if (error) {
-        return NextResponse.json(
-            { error: "RSVP not found" },
-            { status: 404 }
-        );
+export async function GET(request: NextRequest) {
+    try {
+        const result = await query("SELECT * FROM faqs ORDER BY id");
+        return NextResponse.json(result.records);
+    } catch (error) {
+        await logger.error("GET /api/faqs", "DB query failed", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
-
-    return NextResponse.json(data);
 }
 ```
 
 ❌ **Bad Example:**
 ```tsx
 // Missing error handling
-// Not using await for async params in Next.js 15
-// No type safety
-export async function GET(request, { params }) {
-    const data = await supabase
-        .from("RSVPs")
-        .select("*")
-        .eq("short_url", params.code);
+// No logging
+export async function GET() {
+    const data = await query("SELECT * FROM faqs");
     return NextResponse.json(data);
 }
 ```
@@ -240,23 +225,16 @@ it('should prevent accepting invitation without selecting any invitees', () => {
     cy.visit('/rsvp/TEST01');
     cy.contains('John Doe', { timeout: 5000 }).should('be.visible');
 
-    // Accept invitation
     cy.contains('Are you joining us?')
         .parent()
         .parent()
         .find('input[type="radio"][value="yes"]')
         .click({ force: true });
 
-    // Uncheck all invitees
     cy.contains('John Doe').parent().parent().find('input[type="checkbox"]').uncheck();
     cy.contains('Jane Doe').parent().parent().find('input[type="checkbox"]').uncheck();
 
-    // Try to submit - should fail validation
     cy.get('button[type="submit"]').contains('Submit RSVP').click();
-    cy.wait(1000);
-
-    // Validation should prevent submission
-    cy.get('body').should('not.contain', 'Confirm & Submit');
     cy.url().should('include', '/rsvp/TEST01');
 });
 ```
@@ -284,11 +262,12 @@ it('renders navigation links', () => {
 - **Use theme color** `#8b7355` for primary elements
 - **Write tests** for new features (both unit and E2E)
 - **Follow conventional commits** (`feat:`, `fix:`, `test:`, `docs:`)
-- **Use TypeScript** - no `any` types
+- **Use TypeScript** — no `any` types
 - **Validate forms** with Mantine's `useForm` hook
 - **Handle errors gracefully** with user-friendly messages
 - **Use path aliases** (`@/` for `src/`)
 - **Clear validation errors** when they become stale
+- **Log errors** with `logger.error()` in API routes
 
 ### ⚠️ Ask First
 
@@ -299,6 +278,7 @@ it('renders navigation links', () => {
 - **Major refactoring** (coordinate with ongoing work)
 - **Changing color scheme** (affects brand consistency)
 - **Modifying test data structure** (breaks existing tests)
+- **Adding vars to next.config.js env section** (affects Lambda runtime)
 
 ### 🚫 Never Do
 
@@ -309,19 +289,14 @@ it('renders navigation links', () => {
 - **Hardcode credentials** or API keys
 - **Use `any` type** in TypeScript
 - **Disable form validation** with `{ force: true }` on submit buttons
-- **Mix dev and test Supabase instances** (port 54321 vs 54421)
 - **Add AI attribution** to commit messages
 - **Remove error handling** to "simplify" code
 - **Use `form.isValid()` to disable submit buttons** (prevents error display)
+- **Merge PRs yourself** — always leave PRs open for the user to review and merge
 
 ## Database Context
 
-### Two Supabase Instances
-
-| Instance | Purpose | API Port | Config Directory |
-|----------|---------|----------|------------------|
-| **Dev** | Manual development | 54321 | `supabase/` |
-| **Test** | E2E tests (isolated) | 54421 | `supabase-test/` |
+The site uses **Aurora Serverless v2** accessed via the **RDS Data API**. There is no direct TCP connection — all queries go through the AWS Data API endpoint using IAM credentials.
 
 ### Key Tables
 
@@ -330,11 +305,12 @@ it('renders navigation links', () => {
 - **invitations**: Main invitation records with UUIDs
 - **FAQs**: Frequently asked questions for the website
 
-### Environment Variables
+### Environment Variables (development `.env.local`)
 
-- **.env.local**: Development environment (port 54321)
-- **.env.test**: Test environment (port 54421)
-- Never commit these files (gitignored)
+- `COGNITO_USER_POOL_ID` / `COGNITO_CLIENT_ID` / `COGNITO_CLIENT_SECRET`
+- `AURORA_CLUSTER_ARN` / `AURORA_SECRET_ARN`
+- `LAMBDA_AWS_KEY_ID` / `LAMBDA_AWS_SECRET`
+- Never commit `.env.local` (gitignored)
 
 ## Common Patterns
 
@@ -342,25 +318,17 @@ it('renders navigation links', () => {
 ```tsx
 const [data, setData] = useState<RSVPData | null>(null);
 const [loading, setLoading] = useState(true);
-const [error, setError] = useState("");
+const [error, setError] = useState<string | null>(null);
 
 useEffect(() => {
-    const fetchData = async () => {
-        try {
-            const response = await fetch(`/api/rsvp/${code}`);
-            if (response.ok) {
-                const result = await response.json();
-                setData(result);
-            } else {
-                setError("Failed to load data");
-            }
-        } catch {
-            setError("Something went wrong");
-        } finally {
-            setLoading(false);
-        }
-    };
-    fetchData();
+    fetch(`/api/rsvp/${code}`)
+        .then(r => {
+            if (!r.ok) throw new Error("Failed to load data");
+            return r.json();
+        })
+        .then(setData)
+        .catch(e => setError(e.message))
+        .finally(() => setLoading(false));
 }, [code]);
 ```
 
@@ -382,12 +350,10 @@ const handleSubmit = async (values: FormData) => {
     setSubmitting(false);
 };
 
-// Form submission triggers confirmation modal first
 <form onSubmit={form.onSubmit(() => setShowConfirmation(true))}>
     <Button type="submit" disabled={submitting}>Submit</Button>
 </form>
 
-// Modal then calls actual submit handler
 <Modal opened={showConfirmation}>
     <Button onClick={() => handleSubmit(form.values)}>Confirm & Submit</Button>
 </Modal>
@@ -408,10 +374,11 @@ These bots provide feedback on code quality, potential bugs, and best practices.
 2. **Understand the RSVP Flow**: Check `docs/RSVP_SYSTEM_README.md`
 3. **Testing**: Review `docs/TESTING.md` and `cypress/README.md`
 4. **Security**: See `docs/SECURITY.md` for implemented protections
-5. **Make Changes**: Always create a feature branch (`feat/`, `fix/`, `test/`)
-6. **Test Your Changes**: Run unit tests (`npm test`) and E2E tests (`npm run test:e2e`)
-7. **Commit**: Follow conventional commits format
-8. **Push**: GitHub Actions will run CI checks
+5. **Infrastructure**: See `docs/AWS_RESOURCES.md` for AWS resource details
+6. **Make Changes**: Always create a feature branch (`feat/`, `fix/`, `test/`)
+7. **Test Your Changes**: Run unit tests (`npm test`) and E2E tests (`npm run test:e2e`)
+8. **Commit**: Follow conventional commits format
+9. **Push**: GitHub Actions will run CI checks
 
 ## Questions to Ask Yourself
 
@@ -423,9 +390,8 @@ Before implementing a feature:
 - ✅ Do I need unit tests, E2E tests, or both?
 - ✅ Will this affect existing RSVPs in the database?
 - ✅ Is this change documented in the relevant README?
+- ✅ Does a new env var need to be added to `next.config.js` `env` section?
 
 ---
 
-**Last Updated**: December 2025
-
-For human developers: See `.claude/CLAUDE.md` for additional AI assistant guidelines.
+**Last Updated**: June 2026

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Wedding
 
-Rebecca & Matthew's Wedding Website - A wedding website built with Next.js 15, TypeScript, Mantine UI, and Supabase.
+Rebecca & Matthew's Wedding Website — built with Next.js 15, TypeScript, Mantine UI, and AWS.
 
 ## Features
 
-- **Homepage**: Elegant hero section with couple's engagement photo and call-to-action buttons
+- **Homepage**: Elegant hero section with couple's wedding photo
 - **Location**: Complete venue details for Gran Villa Rosa with integrated Google Maps, travel information, and parking details
 - **Schedule**: Comprehensive 3-day wedding timeline with detailed activities for each day
 - **FAQs**: Frequently asked questions with expandable accordion interface and admin editor
@@ -20,7 +20,10 @@ Rebecca & Matthew's Wedding Website - A wedding website built with Next.js 15, T
 - **Framework**: Next.js 15 with App Router
 - **Language**: TypeScript
 - **UI Library**: Mantine Components v7.15.2
-- **Database**: Supabase (PostgreSQL)
+- **Database**: Aurora Serverless v2 (PostgreSQL) via RDS Data API
+- **Auth**: AWS Cognito
+- **Hosting**: AWS Amplify (WEB_COMPUTE)
+- **Photos CDN**: CloudFront → S3
 - **Styling**: Custom CSS with Mantine integration
 - **Icons**: Tabler Icons
 - **Fonts**: Geist Sans & Geist Mono
@@ -34,28 +37,25 @@ Rebecca & Matthew's Wedding Website - A wedding website built with Next.js 15, T
     npm install
     ```
 
-2. **Set up Supabase**:
-   Start the local Supabase instance (requires Docker):
+2. **Set up environment variables**:
+   Copy `.env.example` to `.env.local` and fill in the values:
 
     ```bash
-    npm run supabase:start
+    cp .env.example .env.local
     ```
 
-3. **Set up environment variables**:
-   Copy `.env.local` and add your Supabase credentials:
+   You'll need:
+   - Cognito user pool ID, client ID, and client secret
+   - Aurora cluster ARN and secret ARN
+   - IAM access keys for the `wedding-api-lambda` user
 
-    ```bash
-    NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
-    NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
-    ```
-
-4. **Run development server**:
+3. **Run development server**:
 
     ```bash
     npm run dev
     ```
 
-5. **Open [http://localhost:3000](http://localhost:3000)** in your browser
+4. **Open [http://localhost:3022](http://localhost:3022)** in your browser
 
 ## Project Structure
 
@@ -64,6 +64,8 @@ Wedding/
 ├── src/
 │   ├── app/                 # Next.js App Router pages
 │   │   ├── api/            # API routes
+│   │   │   ├── auth/      # Login/logout endpoints
+│   │   │   ├── dashboard/ # Dashboard summary endpoint
 │   │   │   ├── faqs/      # FAQ API endpoints
 │   │   │   └── rsvp/      # RSVP API endpoints
 │   │   ├── dashboard/     # Admin dashboard (protected)
@@ -86,15 +88,14 @@ Wedding/
 │   ├── test/              # Test utilities and setup
 │   ├── types/             # TypeScript type definitions
 │   └── utils/             # Utility functions
-│       └── supabase/      # Supabase client setup
-│           ├── client.ts  # Client-side Supabase client
-│           ├── server.ts  # Server-side Supabase client
-│           └── middleware.ts # Middleware utilities
+│       ├── auth/          # Cognito auth helpers
+│       ├── db/            # Aurora Data API client
+│       └── logger.ts      # CloudWatch structured logger
 ├── public/
 │   ├── favicon.ico        # Custom wedding favicon
-│   └── rebecca-matthew-wedding-photo.jpeg # Hero image
+│   └── rebecca-matthew-wedding-photo-2.jpeg # Hero image
 ├── package.json           # Dependencies and scripts
-├── next.config.js         # Next.js configuration
+├── next.config.js         # Next.js configuration (bakes env vars for Lambda)
 ├── vitest.config.ts       # Vitest test configuration
 ├── tsconfig.json         # TypeScript configuration
 ├── postcss.config.mjs    # PostCSS configuration
@@ -104,43 +105,52 @@ Wedding/
 ## Customization
 
 - **Couple Names**: Update names in `src/app/layout.tsx` metadata and throughout components
-- **Hero Image**: Replace `/rebecca-matthew-wedding-photo.jpeg` in `public/` directory and update `src/app/page.tsx`
+- **Hero Image**: Replace `/rebecca-matthew-wedding-photo-2.jpeg` in `public/` and update `src/app/page.tsx`
 - **Color Scheme**: Modify the brown/gold theme (`#8b7355`) in `globals.css` and component styles
 - **Wedding Details**: Update venue information, dates, and timeline in respective page components
-- **Google Maps**: The location page includes Gran Villa Rosa map integration - update coordinates if needed
+- **Google Maps**: The location page includes Gran Villa Rosa map integration — update coordinates if needed
 - **FAQs**: Manage questions and answers through the admin dashboard at `/dashboard/faq-editor`
 - **Schedule**: Customize the 3-day timeline with your specific activities and timing
 
-## Database
+## Infrastructure
 
-The site uses Supabase as the database backend. You'll need to create the necessary tables in your Supabase project for features like RSVPs and FAQs.
+All resources run in AWS account `084032333902`, region `eu-west-1`:
+
+- **Amplify**: Hosts the Next.js app with auto-deploy on push to `main`
+- **Aurora Serverless v2**: PostgreSQL database accessed via RDS Data API
+- **Cognito**: Admin user authentication
+- **CloudFront + S3**: Wedding photo CDN
+- **CloudWatch**: Application logs at `/wedding/app` (90-day retention)
+
+See `docs/AWS_RESOURCES.md` for full resource inventory.
 
 ## Current Pages & Content
 
-- **Homepage** (`/`): Complete with hero image, couple introduction, and navigation to key pages
-- **Location** (`/location`): Full venue details for Gran Villa Rosa with embedded Google Maps, travel information, and parking details
-- **Schedule** (`/schedule`): Detailed 3-day wedding timeline with activities for each day including welcome events, ceremony, reception, and farewell celebration
-- **FAQs** (`/faqs`): Frequently asked questions with accordion interface, managed through admin dashboard
+- **Homepage** (`/`): Wedding photo and thank-you message
+- **Location** (`/location`): Full venue details for Gran Villa Rosa with embedded Google Maps
+- **Schedule** (`/schedule`): Detailed 3-day wedding timeline
+- **FAQs** (`/faqs`): Frequently asked questions, managed through admin dashboard
 - **RSVP** (`/rsvp`): RSVP entry page where guests enter their invitation code
-- **RSVP Form** (`/rsvp/[code]`): Dynamic RSVP form with attendance confirmation, dietary restrictions, song requests, and more
+- **RSVP Form** (`/rsvp/[code]`): Dynamic RSVP form with attendance confirmation, dietary restrictions, song requests
 - **RSVP Success** (`/rsvp/success`): Confirmation page after successful RSVP submission
 - **Login** (`/login`): Admin login page for dashboard access
 - **Dashboard** (`/dashboard`): Admin dashboard for managing FAQs and invitations (protected route)
 
 ## Development Status
 
-✅ **Complete**: Homepage, Location, Schedule pages with full content and styling  
-✅ **Complete**: Responsive navigation, custom styling, and animations  
-✅ **Complete**: Database connection setup  
-✅ **Complete**: RSVP system with invitation codes, form submission, and response tracking  
-✅ **Complete**: Admin dashboard with FAQ editor and invitation management  
-✅ **Complete**: Authentication system with protected routes  
-✅ **Complete**: Comprehensive unit testing with Vitest and React Testing Library  
-⏳ **Planned**: Photo gallery section to showcase photos once the wedding has taken place
+✅ **Complete**: Homepage, Location, Schedule pages with full content and styling
+✅ **Complete**: Responsive navigation, custom styling, and animations
+✅ **Complete**: Database connection (Aurora via RDS Data API)
+✅ **Complete**: RSVP system with invitation codes, form submission, and response tracking
+✅ **Complete**: Admin dashboard with FAQ editor and invitation management
+✅ **Complete**: Authentication system (Cognito) with protected routes
+✅ **Complete**: Comprehensive unit testing with Vitest and React Testing Library
+✅ **Complete**: E2E testing with Cypress in CI
+⏳ **Planned**: Photo gallery section to showcase photos
 
 ## Testing
 
-This project includes comprehensive testing at multiple levels. See [TESTING.md](TESTING.md) for detailed unit testing information and [cypress/README.md](cypress/README.md) for E2E testing documentation.
+This project includes comprehensive testing at multiple levels. See [docs/TESTING.md](docs/TESTING.md) for unit testing and [cypress/README.md](cypress/README.md) for E2E testing.
 
 ### Running Unit Tests
 
@@ -161,7 +171,7 @@ npm run test:ui
 ### Running E2E Tests
 
 ```bash
-# Run E2E tests (automated)
+# Run E2E tests (automated — builds, starts server, runs Cypress, stops)
 npm run test:e2e
 
 # Open Cypress in interactive mode
@@ -173,6 +183,7 @@ npm run cypress:run
 
 ## Additional Documentation
 
+- **[docs/AWS_RESOURCES.md](docs/AWS_RESOURCES.md)**: AWS resource inventory and cost estimates
 - **[docs/RSVP_SYSTEM_README.md](docs/RSVP_SYSTEM_README.md)**: Detailed documentation for the RSVP system
 - **[docs/TESTING.md](docs/TESTING.md)**: Comprehensive unit testing guide and best practices
 - **[cypress/README.md](cypress/README.md)**: E2E testing setup, configuration, and test coverage
@@ -182,10 +193,8 @@ npm run cypress:run
 
 ## Deployment
 
-The site is ready for deployment on Vercel, Netlify, or any Next.js-compatible platform.
+The site deploys automatically via AWS Amplify on every push to `main`. Environment variables are set in the Amplify console and baked into the Lambda bundle at build time via `next.config.js`.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-This wedding website template is open source and available for others to use for their own weddings or as inspiration for similar projects.
+This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -1,294 +1,157 @@
 # Cypress E2E Tests
 
-Comprehensive end-to-end tests for the Wedding RSVP application using Cypress with local Supabase.
+End-to-end tests for the Wedding RSVP application using Cypress against a real Cognito user pool.
 
 ## Setup
 
 ### Prerequisites
 
-1. **Supabase CLI** installed (`brew install supabase/tap/supabase`)
-2. **Docker** running (required for Supabase local dev)
-3. **Node.js** and **npm** installed
+1. **Node.js** and **npm** installed
+2. For auth tests locally: a valid Cognito user in pool `eu-west-1_M3B36eWfB`
 
 ### Initial Setup
-
-The Cypress tests are already configured. No additional setup needed beyond installing dependencies:
 
 ```bash
 npm install
 ```
 
-## Two Supabase Instances
-
-This project supports running **two separate Supabase instances**:
-
-| Instance | Purpose | API Port | Studio Port | Config Directory |
-|----------|---------|----------|-------------|------------------|
-| **Dev** | Manual development/testing | 54321 | 54323 | `supabase/` |
-| **Test** | E2E tests (isolated) | 54421 | 54423 | `supabase-test/supabase/` |
-
-This allows you to:
-- Run E2E tests without affecting your development data
-- Keep test data isolated and resettable
-- Work on the app while tests run in the background
-
 ## Running Tests
 
-### Automated (Recommended)
+### Automated (CI — Recommended)
 
-Run tests with automatic server startup and teardown:
+In CI, the `e2e` job in `.github/workflows/ci.yml`:
+1. Builds the app with real Cognito secrets and stub Aurora credentials
+2. Writes `cypress/fixtures/auth-data.json` from GitHub secrets
+3. Runs `next start` on port 3907
+4. Runs all Cypress specs in headless mode
 
-```bash
-# First, start the test Supabase instance
-npm run supabase:test:start
+### Local (Interactive)
 
-# Run E2E tests
-npm run test:e2e
-```
-
-This command will:
-1. Start Next.js dev server pointing to the TEST Supabase instance (port 54421)
-2. Wait for server to be ready
-3. Run all Cypress tests in headless mode
-4. Stop the dev server
-
-### Manual (Interactive)
-
-For development and debugging:
-
-1. Start the TEST Supabase instance:
+1. Build the app with your local env:
    ```bash
-   npm run supabase:test:start
+   npm run build
    ```
 
-2. Start dev server with test environment:
+2. Write a local auth fixture:
    ```bash
-   npm run dev:test
+   cat > cypress/fixtures/auth-data.json << 'EOF'
+   {
+     "validUser": { "email": "ci@matthewoneill.com", "password": "your-password" },
+     "invalidUser": { "email": "wrong@example.com", "password": "WrongPassword123!" },
+     "testUsers": []
+   }
+   EOF
    ```
 
-3. Open Cypress in interactive mode:
+3. Start the server:
+   ```bash
+   npx next start -p 3907
+   ```
+
+4. Open Cypress in interactive mode (separate terminal):
    ```bash
    npm run cypress:open
    ```
 
-4. Select a test file to run in the Cypress UI
-
-### Development Supabase (Separate)
-
-For regular development with persistent data:
+### Headless (Local)
 
 ```bash
-# Start dev instance (uses port 54321)
-npm run supabase:start
-
-# Regular dev server (uses dev Supabase)
-npm run dev
-
-# View dev data in Studio
-open http://localhost:54323
+npm run test:e2e
 ```
 
-### Other Commands
-
-- **Headless mode**: `npm run cypress:run`
-- **Headed mode (see browser)**: `npm run cypress:headed`
-- **Test Supabase Studio**: Visit http://localhost:54423 (when test instance is running)
-- **Dev Supabase Studio**: Visit http://localhost:54323 (when dev instance is running)
+This uses `start-server-and-test` to start the server, wait for it, run Cypress, and stop.
 
 ## Test Structure
 
 ```
 cypress/
 ├── e2e/
-│   ├── rsvp.cy.ts          # RSVP flow tests
-│   ├── auth.cy.ts          # Authentication tests
+│   ├── auth.cy.ts          # Authentication flow tests
 │   └── accessibility.cy.ts # Accessibility (a11y) tests
 ├── fixtures/
-│   ├── rsvp-data.json      # Test RSVP data
-│   └── auth-data.json      # Test user credentials
+│   └── auth-data.json      # Test user credentials (gitignored, written by CI)
 ├── support/
 │   ├── commands.ts         # Custom Cypress commands
-│   ├── database.ts         # Database utilities
+│   ├── database.ts         # cy.resetDb() — no-op (Aurora in private VPC)
 │   └── e2e.ts              # Support file (auto-loaded, includes cypress-axe)
-└── tsconfig.json           # Cypress TypeScript config
+└── tsconfig.json
 ```
 
 ## Test Coverage
 
-### RSVP Flow (`rsvp.cy.ts`)
-
-- ✅ Code entry and validation
-- ✅ Valid/invalid code handling
-- ✅ Uppercase conversion
-- ✅ Code length requirements
-- ✅ Complete form submission (accepting invitation)
-- ✅ Declining invitation
-- ✅ Invitee selection (all/partial/none)
-- ✅ Form validation (including guest selection requirement)
-- ✅ Villa question conditional display
-- ✅ RSVP editing (resubmission)
-- ✅ Database verification with null checks
-- ✅ Success page with query parameter verification
-- ✅ Direct link navigation
-- ✅ Error handling for non-existent codes
-
 ### Authentication Flow (`auth.cy.ts`)
 
 - ✅ Login page display
-- ✅ Form validation
+- ✅ Form validation (empty submit)
 - ✅ Invalid credentials error
-- ✅ Valid login and redirect
+- ✅ Valid login and redirect to dashboard
+- ✅ Redirect to dashboard when already logged in
 - ✅ Protected route access control
 - ✅ Logout functionality
 - ✅ Session persistence after page refresh
-- ✅ Navigation state (logged in/out)
-- ✅ Form disabling during submission
-- ✅ Password field masking
 
 ### Accessibility Tests (`accessibility.cy.ts`)
 
 - ✅ Homepage accessibility (WCAG 2.1 Level AA)
-- ✅ Location page accessibility
-- ✅ Schedule page accessibility
-- ✅ FAQs page accessibility
+- ✅ Login page accessibility
 - ✅ 404 page accessibility
-- ✅ RSVP code entry page accessibility
-- ✅ RSVP form page accessibility
-- ✅ RSVP form with modal open accessibility
-- ✅ RSVP success page accessibility (accepted)
-- ✅ RSVP success page accessibility (declined)
-- ✅ Keyboard navigation through site
-- ✅ Skip to main content link
-- ✅ Form input labels and ARIA attributes
-- ✅ Radio button ARIA attributes
-- ✅ Checkbox ARIA attributes
-- ✅ Color contrast compliance
 
 **Run accessibility tests only:**
 ```bash
 npm run test:a11y
 ```
 
-See [docs/ACCESSIBILITY_TESTING.md](../docs/ACCESSIBILITY_TESTING.md) for detailed information.
+## Database
 
-**Note**: All tests are passing in both local and CI environments.
+E2E tests do **not** interact with the database directly. Aurora Serverless runs in a private VPC and is not accessible from CI. The `cy.resetDb()` command is a no-op — auth and accessibility tests don't require specific DB state.
 
-## Database Management
+## Auth Fixture
 
-Tests automatically reset the TEST database before each test using the `cy.resetDb()` custom command.
+The `cypress/fixtures/auth-data.json` file is gitignored and must be created before running tests:
 
-### Manual Database Operations
-
-```bash
-# Reset TEST database to initial state
-npm run supabase:test:reset
-
-# Check TEST Supabase status
-npm run supabase:test:status
-
-# Stop TEST Supabase
-npm run supabase:test:stop
-
-# For DEV instance, use the same commands without :test:
-npm run supabase:reset
-npm run supabase:status
-npm run supabase:stop
+```json
+{
+  "validUser": { "email": "ci@matthewoneill.com", "password": "<password>" },
+  "invalidUser": { "email": "wrong@example.com", "password": "WrongPassword123!" },
+  "testUsers": []
+}
 ```
 
-## Creating Test Users (For Auth Tests)
-
-Auth tests require manual setup of test users in Supabase:
-
-1. Start Supabase: `npm run supabase:start`
-2. Open Supabase Studio: http://localhost:54323
-3. Navigate to **Authentication** > **Users**
-4. Click **Add User** and create:
-   - Email: `admin@wedding.test`
-   - Password: `TestPassword123!`
-5. Remove `.skip()` from auth tests in `cypress/e2e/auth.cy.ts`
+In CI this is written from `CYPRESS_TEST_EMAIL` and `CYPRESS_TEST_PASSWORD` GitHub secrets.
 
 ## Environment Configuration
 
-### Local Supabase Credentials
+E2E tests run against a production build (`next build` + `next start`). The build bakes in real Cognito credentials so login actually works against the live Cognito pool. Aurora credentials are stubbed in CI (the app doesn't call Aurora during auth or accessibility tests).
 
-**E2E Tests use the TEST instance:**
-- `NEXT_PUBLIC_SUPABASE_URL`: http://127.0.0.1:54421
-- `NEXT_PUBLIC_SUPABASE_ANON_KEY`: (Standard local Supabase anon key)
-
-**Regular development uses the DEV instance:**
-- `NEXT_PUBLIC_SUPABASE_URL`: http://127.0.0.1:54321
-
-These are configured in:
-- `package.json` scripts (environment variables are set per script)
-- `cypress/support/database.ts` (Cypress database utilities)
-
-### Test Data
-
-The database is seeded with:
-- **Invitation**: ID `1`
-- **RSVP Code**: `TEST01` (linked to above invitation)
-- **Invitees**: John Doe, Jane Doe
-- **Secondary RSVP**: Code `TEST02` for additional testing
-- **FAQ**: Test FAQ entry
-
-Seed data is defined in `supabase/seed.sql`.
+Key GitHub secrets required:
+- `COGNITO_USER_POOL_ID` / `COGNITO_CLIENT_ID` / `COGNITO_CLIENT_SECRET`
+- `CYPRESS_TEST_EMAIL` / `CYPRESS_TEST_PASSWORD`
 
 ## Troubleshooting
 
 ### Tests Failing
 
-1. **Server not ready**: Increase timeout in `start-server-and-test` config
-2. **Database errors**: Run `npm run supabase:test:reset` to reset database
-3. **Port conflicts**: Ensure ports 3907 (Next.js test server) and 54421 (Test Supabase) are available
-4. **Stale cache**: Clear Cypress cache with `npx cypress cache clear`
+1. **Auth fixture missing**: Ensure `cypress/fixtures/auth-data.json` exists with valid credentials
+2. **Server not ready**: `start-server-and-test` will retry — check the port 3907 is free
+3. **Cognito error**: Verify the test user exists in pool `eu-west-1_M3B36eWfB` with a permanent password
 
-### Supabase Issues
+### Hydration Errors
 
-1. **Docker not running**: Start Docker Desktop
-2. **Services not starting**: Run `supabase stop` then `supabase start`
-3. **Migration errors**: Check `supabase/migrations/` files for syntax errors
-
-### Environment Issues
-
-1. **Wrong Supabase instance**: Verify `npm run dev:test` is used, not `npm run dev`
-2. **Missing env vars**: Check `cypress.env.json` exists and has correct values
-
-## Debugging
-
-### Visual Debugging (Interactive Mode)
-
-Use `npm run cypress:open` to:
-- See tests run in real Chrome browser
-- Time-travel through test steps
-- Inspect DOM at each step
-- View network requests
-- See console logs
-
-### Screenshots
-
-Failed tests automatically capture screenshots in `cypress/screenshots/`
-
-### Logs
-
-- Cypress logs: Console output during test run
-- Database logs: Check Supabase logs via `supabase status`
+Minified React hydration errors are filtered in `cypress/support/e2e.ts` via regex `/Minified React error #4(1[0-9]|2[0-9])/`. If new hydration errors appear, add the error number to the regex.
 
 ## CI/CD Integration
 
-For continuous integration:
+The GitHub Actions `e2e` job (`.github/workflows/ci.yml`):
 
-```bash
-# In CI pipeline
-npm install
-npm run supabase:test:start
-npm run test:e2e
-npm run supabase:test:stop
+```yaml
+e2e:
+  runs-on: ubuntu-latest
+  needs: test
+  env:
+    AWS_APP_ID: ci        # prevents standalone output detection
+    AWS_REGION: eu-west-1
+  steps:
+    - Build with real Cognito secrets + stub Aurora ARNs
+    - Write auth fixture from CYPRESS_TEST_EMAIL/PASSWORD secrets
+    - npx start-server-and-test 'npx next start -p 3907' http://localhost:3907 'npx cypress run'
 ```
-
-Ensure Docker is available in your CI environment.
-
-The GitHub Actions workflow (`.github/workflows/ci.yml`) automatically:
-1. Starts the test Supabase instance
-2. Runs Next.js with test environment variables
-3. Executes Cypress tests
-4. Stops Supabase (even on failure)

--- a/docs/ACCESSIBILITY_TESTING.md
+++ b/docs/ACCESSIBILITY_TESTING.md
@@ -20,10 +20,9 @@ Our accessibility tests verify compliance with:
 npm run test:a11y
 ```
 This command:
-1. Starts the Supabase test database
-2. Starts the Next.js development server on port 3907
-3. Runs all accessibility tests in `cypress/e2e/accessibility.cy.ts`
-4. Stops the server when complete
+1. Starts the Next.js server on port 3907
+2. Runs all accessibility tests in `cypress/e2e/accessibility.cy.ts`
+3. Stops the server when complete
 
 ### Run Specific Accessibility Tests (Interactive)
 ```bash

--- a/docs/AWS_RESOURCES.md
+++ b/docs/AWS_RESOURCES.md
@@ -1,0 +1,133 @@
+# AWS Resources — oneill.wedding
+
+Account: **084032333902** (aws26oneill)  
+Region: **eu-west-1** (Ireland) unless noted
+
+---
+
+## Hosting
+
+### Amplify — `dpi3jr6xdlg0` (oneill-wedding)
+**What it is:** The service that hosts and serves the wedding website.  
+**What it does:** Pulls code from GitHub, builds the Next.js app, and makes it available at `oneill.wedding`. Every push to the `main` branch triggers an automatic rebuild and redeploy. It also manages the SSL certificate and custom domain.
+
+---
+
+## Database
+
+### Aurora Serverless v2 — `weddingstack-auroracluster23d869c0-hexv7uynpwda`
+**What it is:** A PostgreSQL database that scales automatically with usage.  
+**What it does:** Stores all the wedding data — RSVPs, invitation codes, guest lists, FAQ entries, and the archived historical records (`rsvp_archive`, `invitee_archive`). The dashboard reads from this database to show the "At a Glance" stats. Scales down to minimal capacity when idle to keep costs low.
+
+Tables:
+| Table | Purpose |
+|---|---|
+| `invitations` | One row per invitation group (family/couple) |
+| `invitation_codes` | The unique codes guests used to access their RSVP |
+| `rsvp_archive` | Frozen final RSVP responses |
+| `invitee_archive` | Frozen final guest attendance records |
+| `faqs` | Content for the FAQ section of the website |
+
+---
+
+## Photo Storage & Delivery
+
+### S3 Bucket — `oneill-wedding-photos`
+**What it is:** Cloud storage for the wedding photos.  
+**What it does:** Stores all wedding photos. The bucket is completely private — no direct public access. Photos are only served through CloudFront (below).
+
+### CloudFront — `dcnyn8qcxtw4k.cloudfront.net`
+**What it is:** A content delivery network (CDN) that sits in front of the photo bucket.  
+**What it does:** Serves wedding photos to website visitors from edge locations close to them, making loading fast. Also handles caching so the same photo isn't fetched from S3 every time.
+
+### Rekognition Collection — `wedding-faces-2026`
+**What it is:** An AI face recognition index.  
+**What it does:** Will allow guests to find photos of themselves in the wedding gallery — you upload a selfie, and it returns all wedding photos containing your face. Not yet wired up to the gallery; set up ready for the photo feature.
+
+---
+
+## Authentication
+
+### Cognito User Pool — `eu-west-1_M3B36eWfB` (wedding-admin)
+**What it is:** A user directory that handles login for the admin dashboard.  
+**What it does:** Stores admin credentials (currently just `matthew@matthewoneill.com`) and handles the sign-in flow at `/login`. Issues secure tokens that prove you're logged in; the dashboard checks these tokens on every request. Configured with strong password requirements (12+ chars, uppercase, number, symbol).
+
+---
+
+## Secrets
+
+### Secrets Manager — `wedding/db-credentials`
+**What it is:** A secure vault for the database password.  
+**What it does:** Stores the Aurora username and password. The app retrieves it at runtime rather than hardcoding it anywhere. Rotated automatically by AWS.
+
+### Secrets Manager — `wedding/cognito-client-secret`
+**What it is:** A secure vault for the Cognito app client secret.  
+**What it does:** Stores the secret used to authenticate server-side Cognito API calls (like signing in). Needed because the Cognito user pool client is configured with a secret for added security.
+
+---
+
+## Networking
+
+### VPC — `WeddingVpc` (10.0.0.0/16)
+**What it is:** A private, isolated network inside AWS.  
+**What it does:** The Aurora database lives inside this VPC with no direct internet access. This means the database can't be reached from the internet at all — only AWS services with the right permissions (via the Data API) can talk to it.
+
+### Default VPC (172.31.0.0/16)
+**What it is:** An empty network AWS creates automatically in every account.  
+**What it does:** Nothing for this project. It's harmless and costs nothing. Every AWS account has one.
+
+---
+
+## IAM (Access Control)
+
+### IAM User — `wedding-deploy`
+**What it is:** The admin user used for managing the site from the command line.  
+**What it does:** This is what the `[wedding]` profile in `~/.aws/credentials` authenticates as. Used for running CDK deployments, managing Amplify, and interacting with AWS from your terminal.  
+⚠️ Currently has full `AdministratorAccess` — should be scoped down to only the services needed.
+
+### IAM User — `wedding-api-lambda`
+**What it is:** A minimal-permission user for the live website to access the database.  
+**What it does:** The Amplify Lambda (which runs the server-side code on the live site) uses this user's credentials to call the Aurora Data API. It has permission to do exactly two things: query Aurora and read the DB secret. Nothing else.
+
+### IAM Role — `amplify-wedding-ssr-role`
+**What it is:** A role for Amplify's deployment and runtime service.  
+**What it does:** Amplify assumes this role when building and deploying the app. Also has Aurora and Secrets Manager permissions as a fallback, though in practice the `wedding-api-lambda` credentials are what the Lambda uses at runtime.
+
+### IAM Role — `AWSAmplifyDomainRole-*`
+**What it is:** Auto-created by Amplify when setting up the custom domain.  
+**What it does:** Allows Amplify to make DNS changes for `oneill.wedding` during domain verification and renewal. You don't interact with this directly.
+
+---
+
+## Infrastructure Management (CDK)
+
+### CloudFormation Stack — `WeddingStack`
+**What it is:** The record of everything CDK has deployed.  
+**What it does:** AWS CloudFormation tracks the Aurora cluster, VPC, Cognito pool, S3 bucket, CloudFront, and Rekognition collection as a single managed unit. If you run `cdk deploy` it updates this stack. If you run `cdk destroy` it tears all of it down cleanly.
+
+### CloudFormation Stack — `CDKToolkit`
+**What it is:** CDK's own bootstrapping stack.  
+**What it does:** Sets up the S3 bucket and IAM roles that CDK needs to deploy your infrastructure. Created once via `cdk bootstrap` and then left alone.
+
+### S3 Bucket — `cdk-hnb659fds-assets-084032333902-eu-west-1`
+**What it is:** CDK's staging bucket.  
+**What it does:** CDK uploads deployment artifacts here (Lambda code, CloudFormation templates) before deploying them. Managed entirely by CDK — don't modify it manually.
+
+### Lambda — `WeddingStack-AWS679f53fac...`
+**What it is:** A one-time setup function created by CDK.  
+**What it does:** Ran once during the CDK deployment to retrieve the Cognito client secret and store it in Secrets Manager. It's dormant now but CDK keeps it around to manage stack state.
+
+---
+
+## Cost Summary (approximate)
+
+| Service | ~Monthly Cost |
+|---|---|
+| Aurora Serverless v2 (0.5 ACU min) | ~$0.55 |
+| Amplify Hosting | ~$0.01/build + $0.15/GB served |
+| CloudFront | Free tier / cents |
+| S3 | Cents |
+| Cognito | Free (under 50 MAU) |
+| Secrets Manager | ~$0.80 (2 secrets) |
+| Rekognition | Free until used |
+| **Total** | **~$1.50–2.00/month** |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -17,12 +17,12 @@ This document outlines the security measures implemented in the wedding website.
 - **Why**: Prevents clickjacking, XSS, MIME-type sniffing, and other attacks
 - **Location**: `next.config.js`
 - **Headers Implemented**:
-    - `X-Frame-Options: DENY` - Prevents clickjacking
-    - `X-Content-Type-Options: nosniff` - Prevents MIME-type sniffing
-    - `Referrer-Policy: strict-origin-when-cross-origin` - Controls referrer information
-    - `X-XSS-Protection: 1; mode=block` - Enables XSS filtering
-    - `Permissions-Policy` - Restricts access to browser features
-    - `Content-Security-Policy` - Prevents XSS and other injection attacks
+    - `X-Frame-Options: DENY` — Prevents clickjacking
+    - `X-Content-Type-Options: nosniff` — Prevents MIME-type sniffing
+    - `Referrer-Policy: strict-origin-when-cross-origin` — Controls referrer information
+    - `X-XSS-Protection: 1; mode=block` — Enables XSS filtering
+    - `Permissions-Policy` — Restricts access to browser features
+    - `Content-Security-Policy` — Prevents XSS and other injection attacks
 
 ### 3. XSS Protection
 
@@ -40,10 +40,10 @@ This document outlines the security measures implemented in the wedding website.
 - **Why**: Prevents brute-force attacks, API abuse, and reduces costs
 - **Location**: `src/utils/api/rateLimit.ts` (reusable utility)
 - **Protected Endpoints**:
-    - `/api/rsvp/validate/[code]` - 5 requests/minute (strictest, prevents code guessing)
-    - `/api/rsvp/[code]` - 20 requests/minute (RSVP form submission)
-    - `/api/invitation/[slug]` - 30 requests/minute (invitation lookup)
-    - `/api/generate-faq-id` - 10 requests/minute (OpenAI cost protection)
+    - `/api/rsvp/validate/[code]` — 5 requests/minute (strictest, prevents code guessing)
+    - `/api/rsvp/[code]` — 20 requests/minute (RSVP form submission)
+    - `/api/invitation/[slug]` — 30 requests/minute (invitation lookup)
+    - `/api/generate-faq-id` — 10 requests/minute (OpenAI cost protection)
 - **Implementation**: In-memory rate limiter with per-IP tracking and validation
 - **Security Features**:
     - IP format validation prevents header spoofing attacks
@@ -51,92 +51,51 @@ This document outlines the security measures implemented in the wedding website.
     - Rate limit headers on all responses for client backoff
 - **Response**: Returns HTTP 429 with `Retry-After` header and rate limit metadata
 
-## 🔒 Existing Security Features
+## 🔒 Authentication & Authorization
 
-### Authentication & Authorization
+### AWS Cognito Authentication
 
-- **Supabase Authentication**: Email/password authentication via Supabase Auth
 - **Route Protection**: Middleware-based protection for admin routes (`/dashboard/*`)
-- **Session Management**: Secure session handling via Supabase with automatic refresh
+- **Session Management**: JWT tokens stored in cookies, validated on each request
+- **Challenge Handling**: `NEW_PASSWORD_REQUIRED` challenge handled at login — forced password change on first login
 
 **Authentication Flow:**
 1. User submits credentials to `/login` page
-2. `AuthContext` calls `supabase.auth.signInWithPassword()`
-3. Supabase validates credentials and returns JWT session
-4. Session stored in browser cookies (managed by Supabase)
-5. Middleware checks session on protected routes
-6. Unauthenticated users redirected to `/login` with return URL
-7. Already-authenticated users on `/login` redirected to `/dashboard`
+2. API calls Cognito `InitiateAuthCommand`
+3. If `NEW_PASSWORD_REQUIRED` challenge returned, user is prompted for new password
+4. On success, Cognito returns access/ID/refresh tokens
+5. Tokens stored in browser cookies
+6. Middleware validates token on protected routes
+7. Unauthenticated users redirected to `/login`
 
 **Protected Routes:**
-- `/dashboard/*` - Requires authenticated session
-- `/api/faqs/*` (POST, PUT, DELETE) - Requires authenticated session via RLS
+- `/dashboard/*` — Requires authenticated session
 
 ### Environment Security
 
-- **Environment Variables**: All secrets stored in `.env.local`
+- **Environment Variables**: All secrets stored in `.env.local` for dev; Amplify console for production
+- **Lambda Env Baking**: Vars explicitly listed in `next.config.js` `env` section are baked into the Lambda bundle at build time
 - **No Hardcoded Secrets**: All API keys and sensitive data externalized
+- **IAM Least Privilege**: `wedding-api-lambda` IAM user has only rds-data, secretsmanager, and cloudwatch-logs permissions
 
 ### Dependencies
 
 - **Up-to-date Packages**: All dependencies regularly updated
 - **Vulnerability Scanning**: `npm audit` shows 0 vulnerabilities
 
-### 5. Row Level Security (RLS)
-
-- **What**: PostgreSQL RLS policies to control database access
-- **Why**: Defense-in-depth security layer beyond API validation
-- **Location**: `supabase/migrations/20260106222120_secure_rls_policies.sql`
-- **Implementation**:
-
-| Table | Public SELECT | Public INSERT | Public UPDATE | Public DELETE |
-|-------|--------------|---------------|---------------|---------------|
-| invitation | ✅ | ❌ | ❌ | ❌ |
-| RSVPs | ✅ | ❌ | ✅ | ❌ |
-| invitees | ✅ | ❌ | ✅ | ❌ |
-| FAQs | ✅ | ❌ | ❌ | ❌ |
-
-**Policy Names:**
-- `invitation_public_select` / `invitation_authenticated_all`
-- `rsvps_public_select` / `rsvps_public_update` / `rsvps_authenticated_all`
-- `invitees_public_select` / `invitees_public_update` / `invitees_authenticated_all`
-- `faqs_public_select` / `faqs_authenticated_insert` / `faqs_authenticated_update` / `faqs_authenticated_delete`
-
-**Security Model:**
-- Public users can READ all data (acceptable for private wedding site)
-- Public users can UPDATE RSVPs/invitees (API validates RSVP code first)
-- Only authenticated users (admins) can INSERT/DELETE any data
-- FAQs are read-only for public users; full CRUD for admins
-
-### 6. API-Level Protections
+### 5. API-Level Protections
 
 - **What**: Server-side validation before database operations
-- **Location**: `src/app/api/rsvp/[code]/route.ts`
 - **Protections**:
     - RSVP code validation (6-character code required)
     - Invitee ownership validation (prevents cross-invitation updates)
-    - Authentication required for FAQ management
+    - Authentication required for FAQ management and dashboard
 
 ## ⚠️ Known Limitations & Accepted Risks
 
-### Anon Key Exposure
+### Over-Permissioned Admin IAM User
 
-The Supabase anon key is exposed to browsers via `NEXT_PUBLIC_SUPABASE_ANON_KEY`. This is necessary for client-side Supabase features and is an accepted trade-off:
-
-**What this means:**
-- Users could theoretically read all RSVP data via direct Supabase queries
-- RLS prevents direct INSERT/DELETE but allows SELECT/UPDATE
-
-**Why this is acceptable:**
-- Guest list is not highly sensitive information
-- Only invited guests receive the site URL
-- No financial or PII data beyond names is stored
-- API validates RSVP codes before allowing updates
-
-**Mitigations in place:**
-- RLS blocks INSERT/DELETE operations
-- API validates invitee ownership before updates
-- FAQs are read-only for public users
+The `wedding-deploy` IAM user has `AdministratorAccess`. This is flagged for reduction to only the permissions needed for Amplify CLI operations. Current risk is low since the keys are only used locally.
 
 ## 📊 Data Handling & Retention
 
@@ -149,11 +108,11 @@ The Supabase anon key is exposed to browsers via `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 ### Data Retention Policy
 - **RSVP Data**: Retained until wedding completion + 6 months for follow-up
 - **Analytics Data**: Subject to PostHog retention settings
-- **Session Data**: Automatically expires per Supabase defaults
+- **Application Logs**: CloudWatch `/wedding/app` log group — 90-day retention
 
 ### Data Access
 - Guest data accessible only via valid RSVP code or admin dashboard
-- No data sharing with third parties beyond hosting providers (Vercel, Supabase)
+- No data sharing with third parties beyond AWS (hosting, DB, auth) and PostHog (analytics)
 - PostHog analytics configured with privacy-respecting defaults
 
 ## 🇪🇺 GDPR Compliance Notes
@@ -178,28 +137,18 @@ This is a private wedding website with limited data collection:
 
 ### Security Incident Procedures
 
-1. **Detection**: Monitor for unusual activity in Supabase logs and Vercel analytics
-2. **Containment**: Disable affected RSVP codes or rotate API keys if needed
+1. **Detection**: Monitor CloudWatch logs at `/wedding/app` for unusual activity
+2. **Containment**: Rotate IAM keys or disable Cognito user if needed
 3. **Assessment**: Determine scope and impact of incident
 4. **Notification**: Inform affected parties if personal data compromised
-5. **Recovery**: Restore from database backups if necessary
+5. **Recovery**: Restore from Aurora automated backups if necessary
 6. **Review**: Document incident and update security measures
 
 ### Emergency Actions
-- **Rotate Supabase Keys**: Via Supabase Dashboard > Settings > API
-- **Disable Public Access**: Update RLS policies to restrict SELECT
-- **Reset Admin Passwords**: Via Supabase Dashboard > Authentication
-
-## 🛡️ Additional Recommendations
-
-For production deployment, consider:
-
-1. ~~**Database Security**: Enable Row Level Security (RLS) policies in Supabase~~ ✅ Done
-2. **HTTPS Only**: Ensure all traffic uses HTTPS
-3. **Domain Validation**: Implement CORS policies for specific domains
-4. **Monitoring**: Add security monitoring and alerting
-5. **Backup Strategy**: Regular database backups
-6. **Access Logging**: Monitor admin access patterns
+- **Rotate IAM Keys**: AWS Console > IAM > Users > `wedding-api-lambda` > Security credentials
+- **Rotate Cognito Client Secret**: Cognito console > App clients
+- **Disable Admin Access**: Cognito console > Users > Disable user
+- **Check Logs**: CloudWatch > Log groups > `/wedding/app`
 
 ## 📝 Security Checklist
 
@@ -211,10 +160,11 @@ For production deployment, consider:
 - [x] Validate all user inputs
 - [x] Use environment variables for secrets
 - [x] Keep dependencies updated
-- [x] Implement proper authentication
+- [x] Implement proper authentication (Cognito)
 - [x] Protect admin routes
-- [x] Enable Row Level Security (RLS) policies
-- [x] Add invitee ownership validation
+- [x] Handle NEW_PASSWORD_REQUIRED Cognito challenge
+- [x] CloudWatch structured logging for API errors
+- [ ] Scope down `wedding-deploy` IAM from AdministratorAccess
 
 ## 🚨 Security Contact
 
@@ -222,5 +172,5 @@ For security issues or concerns, please contact the website administrator.
 
 ---
 
-Last updated: January 10, 2026
-Risk Level: **LOW** - Suitable for personal wedding website with basic admin functionality.
+Last updated: June 2026
+Risk Level: **LOW** — Suitable for personal wedding website with basic admin functionality.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,7 +4,7 @@ This project uses comprehensive testing at multiple levels: unit tests and end-t
 
 ## Unit Testing Stack
 
-- **Test Runner**: [Vitest](https://vitest.dev/) - Fast, modern test runner
+- **Test Runner**: [Vitest](https://vitest.dev/) — Fast, modern test runner
 - **Component Testing**: [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/)
 - **Test Environment**: jsdom for browser-like testing environment
 - **Mocking**: Vitest's built-in mocking capabilities
@@ -12,10 +12,10 @@ This project uses comprehensive testing at multiple levels: unit tests and end-t
 
 ## E2E Testing Stack
 
-- **Test Framework**: [Cypress](https://www.cypress.io/) - Modern E2E testing framework
-- **Test Database**: Local Supabase instance (isolated from development data)
-- **Test Server**: Next.js dev server on port 3907
-- **Custom Commands**: Database utilities and authentication helpers
+- **Test Framework**: [Cypress](https://www.cypress.io/) — Modern E2E testing framework
+- **Auth**: Real Cognito user pool (`ci@matthewoneill.com`) — credentials in GitHub secrets
+- **Test Server**: Next.js production build served with `next start` on port 3907
+- **Custom Commands**: Authentication helpers and no-op database reset
 - **CI/CD**: Automated testing in GitHub Actions
 
 For detailed E2E testing documentation, see [cypress/README.md](cypress/README.md).
@@ -24,7 +24,7 @@ For detailed E2E testing documentation, see [cypress/README.md](cypress/README.m
 
 ### Unit Tests
 
-Unit tests are organized using the `__tests__` folder pattern near the System Under Test (SUT):
+Unit tests are organised using the `__tests__` folder pattern near the System Under Test (SUT):
 
 ```
 src/
@@ -50,17 +50,18 @@ src/
 
 ### E2E Tests
 
-E2E tests are organized in the `cypress/` directory:
+E2E tests are organised in the `cypress/` directory:
 
 ```
 cypress/
 ├── e2e/
 │   ├── auth.cy.ts          # Authentication flow tests
-│   └── rsvp.cy.ts          # RSVP system tests
-├── fixtures/               # Test data
+│   └── accessibility.cy.ts # Accessibility (a11y) tests
+├── fixtures/               # Test data (auth-data.json written by CI)
 ├── support/
 │   ├── commands.ts         # Custom Cypress commands
-│   └── database.ts         # Database utilities
+│   ├── database.ts         # Database reset (no-op — Aurora in private VPC)
+│   └── e2e.ts              # Support file (auto-loaded, includes cypress-axe)
 └── tsconfig.json
 ```
 
@@ -85,7 +86,7 @@ npm run test:ui
 ### E2E Tests
 
 ```bash
-# Run E2E tests (automated - starts server, runs tests, stops server)
+# Run E2E tests (automated — builds, starts server, runs Cypress, stops)
 npm run test:e2e
 
 # Open Cypress in interactive mode
@@ -97,8 +98,6 @@ npm run cypress:run
 # Run Cypress tests with browser visible
 npm run cypress:headed
 ```
-
-For detailed E2E testing instructions, including Supabase setup and troubleshooting, see [cypress/README.md](cypress/README.md).
 
 ## Test Configuration
 
@@ -119,7 +118,6 @@ For detailed E2E testing instructions, including Supabase setup and troubleshoot
 ### Test Utils (`src/test/test-utils.tsx`)
 
 - Custom render function with providers
-- Mocked Supabase client for consistent testing
 - Re-exports all React Testing Library utilities
 
 ## Testing Patterns
@@ -166,11 +164,9 @@ it("handles sign in", async () => {
 
 ## Mocking Strategy
 
-### Supabase
+### AWS / Database
 
-- Mocked at the client level in `test-utils.tsx`
-- Consistent mock responses across all tests
-- Easy to override for specific test scenarios
+In unit tests, the Aurora Data API client and Cognito auth are mocked at the module level. E2E tests use a real Cognito user (`ci@matthewoneill.com`) and do not hit the database directly — the database reset command (`cy.resetDb()`) is a no-op since Aurora runs in a private VPC.
 
 ### Next.js Features
 
@@ -181,7 +177,6 @@ it("handles sign in", async () => {
 ### External APIs
 
 - Fetch: Mocked globally for API route tests
-- OpenAI: Mocked in specific test files
 
 ## Coverage Goals
 
@@ -192,7 +187,7 @@ it("handles sign in", async () => {
 
 ## Best Practices
 
-1. **Test Behavior, Not Implementation**: Focus on what the user sees and does
+1. **Test Behaviour, Not Implementation**: Focus on what the user sees and does
 2. **Use Descriptive Test Names**: Tests should read like documentation
 3. **Arrange-Act-Assert Pattern**: Clear test structure
 4. **Mock External Dependencies**: Keep tests isolated and fast
@@ -245,8 +240,10 @@ it('handles button click', async () => {
 
 Tests run automatically on:
 
-- Git commits (pre-commit hook)
-- Pull requests
-- Main branch pushes
+- Git commits (pre-commit hook — unit tests only)
+- Pull requests and pushes to `main`/`develop` — full CI suite (lint, unit, build, e2e, type-check)
 
-Coverage reports are generated and can be viewed in the coverage/ directory.
+The GitHub Actions workflow runs three jobs:
+- **test**: lint + unit tests + build (Node 20 & 22)
+- **e2e**: build with real Cognito secrets, run Cypress against `next start`
+- **type-check**: `tsc --noEmit`


### PR DESCRIPTION
## Summary

- Removes all Supabase and Vercel references from docs, env example, and agent config
- Updates README, AGENTS.md, SECURITY.md, TESTING.md, cypress/README.md, ACCESSIBILITY_TESTING.md, and .env.example to reflect the current AWS infrastructure (Cognito, Aurora Serverless, Amplify, CloudFront)
- Adds docs/AWS_RESOURCES.md (carried over from previous work)

## Test plan

- [ ] Docs-only change — no code affected, no tests needed
- [ ] Verify .env.example has correct AWS var names before local dev setup