### PR TITLE
feat: show Dashboard and Logout in the nav when logged in

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { PostHogProvider } from "@/components/PostHogProvider";
 import { PageViewTracker } from "@/components/PageViewTracker";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { Footer } from "@/components/Footer";
+import { Navigation } from "@/components/Navigation";
 import { Suspense } from "react";
 
 const geist = Geist({
@@ -110,6 +111,7 @@ export default function RootLayout({
                             <Suspense fallback={null}>
                                 <PageViewTracker />
                             </Suspense>
+                            <Navigation />
                             <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
                                 {children}
                             </div>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -4,7 +4,6 @@ import { useEffect } from 'react';
 import { Container, Title, Text, Button, Stack, Paper } from '@mantine/core';
 import { IconError404 } from '@tabler/icons-react';
 import Link from 'next/link';
-import { Navigation } from '@/components/Navigation';
 import { useTracking, SiteEvents } from '@/hooks';
 
 export default function NotFound() {
@@ -20,9 +19,8 @@ export default function NotFound() {
 
     return (
         <>
-            <Navigation />
             <main id="main-content">
-                <Container size="sm" py="xl" style={{ paddingTop: 120 }}>
+                <Container size="sm" py="xl" style={{ paddingTop: 64 }}>
                     <Paper shadow="md" radius="lg" p="xl">
                         <Stack gap="xl" align="center">
                             <IconError404 size={100} color="var(--gold-dark)" stroke={1.5} />

--- a/src/components/Navigation.module.css
+++ b/src/components/Navigation.module.css
@@ -1,8 +1,8 @@
 .header {
-    position: fixed;
+    /* Sticky (not fixed) so the header occupies flow space and pages
+       don't need to compensate with their own top padding. */
+    position: sticky;
     top: 0;
-    left: 0;
-    right: 0;
     z-index: 1000;
     background-color: rgba(255, 255, 255, 0.98);
     backdrop-filter: blur(12px);

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,12 +1,36 @@
 "use client";
 
-import { Container, Anchor } from "@mantine/core";
+import { useState } from "react";
+import { Container, Anchor, Button, Group } from "@mantine/core";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useGalleryFlag } from "@/hooks/useGalleryFlag";
+import { useSession } from "@/hooks/useSession";
 import classes from "./Navigation.module.css";
+
+const navLinkStyle = {
+    color: "var(--gold-dark)",
+    textDecoration: "none",
+    letterSpacing: "0.05em",
+    transition: "opacity 0.2s",
+} as const;
 
 export function Navigation() {
     const galleryFlag = useGalleryFlag();
+    const { status, refresh } = useSession();
+    const router = useRouter();
+    const [loggingOut, setLoggingOut] = useState(false);
+
+    const handleLogout = async () => {
+        setLoggingOut(true);
+        try {
+            await fetch("/api/auth/logout", { method: "POST" });
+            await refresh();
+            router.refresh();
+        } finally {
+            setLoggingOut(false);
+        }
+    };
 
     return (
         <header className={classes.header} role="banner">
@@ -30,22 +54,29 @@ export function Navigation() {
                 >
                     Rebecca & Matthew
                 </Anchor>
-                {galleryFlag === "on" && (
-                    <Anchor
-                        component={Link}
-                        href="/gallery"
-                        size="sm"
-                        fw={400}
-                        style={{
-                            color: "var(--gold-dark)",
-                            textDecoration: "none",
-                            letterSpacing: "0.05em",
-                            transition: "opacity 0.2s",
-                        }}
-                    >
-                        Gallery
-                    </Anchor>
-                )}
+                <Group gap="md" wrap="nowrap">
+                    {galleryFlag === "on" && (
+                        <Anchor component={Link} href="/gallery" size="sm" fw={400} style={navLinkStyle}>
+                            Gallery
+                        </Anchor>
+                    )}
+                    {status === "authenticated" && (
+                        <>
+                            <Anchor component={Link} href="/dashboard" size="sm" fw={400} style={navLinkStyle}>
+                                Dashboard
+                            </Anchor>
+                            <Button
+                                variant="subtle"
+                                color="gray"
+                                size="compact-sm"
+                                onClick={handleLogout}
+                                loading={loggingOut}
+                            >
+                                Logout
+                            </Button>
+                        </>
+                    )}
+                </Group>
             </Container>
         </header>
     );

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Container, Anchor, Button, Group } from "@mantine/core";
+import { Container, Anchor, Button, Group, Text } from "@mantine/core";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useGalleryFlag } from "@/hooks/useGalleryFlag";
@@ -20,13 +20,18 @@ export function Navigation() {
     const { status, refresh } = useSession();
     const router = useRouter();
     const [loggingOut, setLoggingOut] = useState(false);
+    const [logoutError, setLogoutError] = useState<string | null>(null);
 
     const handleLogout = async () => {
         setLoggingOut(true);
+        setLogoutError(null);
         try {
-            await fetch("/api/auth/logout", { method: "POST" });
+            const res = await fetch("/api/auth/logout", { method: "POST" });
+            if (!res.ok) throw new Error(`Logout failed: ${res.status}`);
             await refresh();
             router.refresh();
+        } catch {
+            setLogoutError("Logout failed — please try again");
         } finally {
             setLoggingOut(false);
         }
@@ -62,6 +67,11 @@ export function Navigation() {
                     )}
                     {status === "authenticated" && (
                         <>
+                            {logoutError && (
+                                <Text size="xs" c="red" role="alert">
+                                    {logoutError}
+                                </Text>
+                            )}
                             <Anchor component={Link} href="/dashboard" size="sm" fw={400} style={navLinkStyle}>
                                 Dashboard
                             </Anchor>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Container, Anchor, Button, Group, Text } from "@mantine/core";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useGalleryFlag } from "@/hooks/useGalleryFlag";
 import { useSession } from "@/hooks/useSession";
 import classes from "./Navigation.module.css";
@@ -19,6 +19,7 @@ export function Navigation() {
     const galleryFlag = useGalleryFlag();
     const { status, refresh } = useSession();
     const router = useRouter();
+    const pathname = usePathname();
     const [loggingOut, setLoggingOut] = useState(false);
     const [logoutError, setLogoutError] = useState<string | null>(null);
 
@@ -36,6 +37,11 @@ export function Navigation() {
             setLoggingOut(false);
         }
     };
+
+    // The dashboard has its own header (see src/app/dashboard/layout.tsx).
+    if (pathname?.startsWith("/dashboard")) {
+        return null;
+    }
 
     return (
         <header className={classes.header} role="banner">

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -43,6 +43,12 @@ export function Navigation() {
         return null;
     }
 
+    // Keep the homepage headerless for guests until the gallery feature
+    // flag is flipped; a logged-in admin always gets the nav.
+    if (pathname === "/" && galleryFlag !== "on" && status !== "authenticated") {
+        return null;
+    }
+
     return (
         <header className={classes.header} role="banner">
             <a href="#main-content" className="skip-link">

--- a/src/components/__tests__/Navigation.test.tsx
+++ b/src/components/__tests__/Navigation.test.tsx
@@ -83,6 +83,26 @@ describe("Navigation", () => {
         expect(screen.getByRole("button", { name: "Logout" })).toBeInTheDocument();
     });
 
+    it("keeps the buttons and shows an error when logout fails", async () => {
+        mockFetch.mockImplementation((url: string) => {
+            if (url === "/api/auth/me") {
+                return Promise.resolve(new Response(null, { status: 200 }));
+            }
+            if (url === "/api/auth/logout") {
+                return Promise.resolve(new Response(null, { status: 500 }));
+            }
+            return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+        });
+        render(<Navigation />);
+        const logout = await screen.findByRole("button", { name: "Logout" });
+
+        await userEvent.click(logout);
+
+        expect(await screen.findByRole("alert")).toHaveTextContent("Logout failed — please try again");
+        expect(screen.getByRole("link", { name: "Dashboard" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Logout" })).toBeInTheDocument();
+    });
+
     it("removes Dashboard and Logout after logging out", async () => {
         stubSession(true);
         render(<Navigation />);

--- a/src/components/__tests__/Navigation.test.tsx
+++ b/src/components/__tests__/Navigation.test.tsx
@@ -9,6 +9,20 @@ vi.mock("../Navigation.module.css", () => ({
     },
 }));
 
+const route = vi.hoisted(() => ({ pathname: "/" }));
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({
+        push: vi.fn(),
+        replace: vi.fn(),
+        back: vi.fn(),
+        forward: vi.fn(),
+        refresh: vi.fn(),
+        prefetch: vi.fn(),
+    }),
+    usePathname: () => route.pathname,
+    useSearchParams: () => new URLSearchParams(),
+}));
+
 import { Navigation } from "../Navigation";
 
 const mockFetch = vi.fn();
@@ -30,6 +44,7 @@ describe("Navigation", () => {
     beforeEach(() => {
         vi.stubGlobal("fetch", mockFetch);
         stubSession(false);
+        route.pathname = "/";
     });
 
     afterEach(() => {
@@ -81,6 +96,13 @@ describe("Navigation", () => {
         const dashboard = await screen.findByRole("link", { name: "Dashboard" });
         expect(dashboard).toHaveAttribute("href", "/dashboard");
         expect(screen.getByRole("button", { name: "Logout" })).toBeInTheDocument();
+    });
+
+    it("renders nothing on dashboard routes (dashboard has its own header)", () => {
+        stubSession(true);
+        route.pathname = "/dashboard/photos";
+        render(<Navigation />);
+        expect(screen.queryByRole("banner")).not.toBeInTheDocument();
     });
 
     it("keeps the buttons and shows an error when logout fails", async () => {

--- a/src/components/__tests__/Navigation.test.tsx
+++ b/src/components/__tests__/Navigation.test.tsx
@@ -10,6 +10,10 @@ vi.mock("../Navigation.module.css", () => ({
 }));
 
 const route = vi.hoisted(() => ({ pathname: "/" }));
+const galleryFlag = vi.hoisted(() => ({ value: "on" as "on" | "off" | "loading" }));
+vi.mock("@/hooks/useGalleryFlag", () => ({
+    useGalleryFlag: () => galleryFlag.value,
+}));
 vi.mock("next/navigation", () => ({
     useRouter: () => ({
         push: vi.fn(),
@@ -45,6 +49,7 @@ describe("Navigation", () => {
         vi.stubGlobal("fetch", mockFetch);
         stubSession(false);
         route.pathname = "/";
+        galleryFlag.value = "on";
     });
 
     afterEach(() => {
@@ -96,6 +101,29 @@ describe("Navigation", () => {
         const dashboard = await screen.findByRole("link", { name: "Dashboard" });
         expect(dashboard).toHaveAttribute("href", "/dashboard");
         expect(screen.getByRole("button", { name: "Logout" })).toBeInTheDocument();
+    });
+
+    it("hides on the homepage when the gallery flag is off and logged out", async () => {
+        galleryFlag.value = "off";
+        render(<Navigation />);
+        await waitFor(() => expect(mockFetch).toHaveBeenCalledWith("/api/auth/me"));
+        expect(screen.queryByRole("banner")).not.toBeInTheDocument();
+    });
+
+    it("shows on the homepage when the gallery flag is off but logged in", async () => {
+        galleryFlag.value = "off";
+        stubSession(true);
+        render(<Navigation />);
+        expect(await screen.findByRole("banner")).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: "Dashboard" })).toBeInTheDocument();
+        expect(screen.queryByRole("link", { name: "Gallery" })).not.toBeInTheDocument();
+    });
+
+    it("shows on non-home pages even when the gallery flag is off", () => {
+        galleryFlag.value = "off";
+        route.pathname = "/rsvp";
+        render(<Navigation />);
+        expect(screen.getByRole("banner")).toBeInTheDocument();
     });
 
     it("renders nothing on dashboard routes (dashboard has its own header)", () => {

--- a/src/components/__tests__/Navigation.test.tsx
+++ b/src/components/__tests__/Navigation.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "../../test/test-utils";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor } from "../../test/test-utils";
+import userEvent from "@testing-library/user-event";
 
 vi.mock("../Navigation.module.css", () => ({
     default: {
@@ -10,7 +11,32 @@ vi.mock("../Navigation.module.css", () => ({
 
 import { Navigation } from "../Navigation";
 
+const mockFetch = vi.fn();
+
+function stubSession(loggedIn: boolean) {
+    mockFetch.mockImplementation((url: string) => {
+        if (url === "/api/auth/me") {
+            return Promise.resolve(new Response(null, { status: loggedIn ? 200 : 401 }));
+        }
+        if (url === "/api/auth/logout") {
+            loggedIn = false;
+            return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+        }
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+}
+
 describe("Navigation", () => {
+    beforeEach(() => {
+        vi.stubGlobal("fetch", mockFetch);
+        stubSession(false);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        mockFetch.mockReset();
+    });
+
     it("renders wedding title linking to home", () => {
         render(<Navigation />);
         const link = screen.getByRole("link", { name: "Rebecca & Matthew" });
@@ -40,5 +66,34 @@ describe("Navigation", () => {
     it("does not render mobile menu button", () => {
         render(<Navigation />);
         expect(screen.queryByRole("button", { name: /navigation menu/i })).not.toBeInTheDocument();
+    });
+
+    it("hides Dashboard and Logout when logged out", async () => {
+        render(<Navigation />);
+        await waitFor(() => expect(mockFetch).toHaveBeenCalledWith("/api/auth/me"));
+        expect(screen.queryByRole("link", { name: "Dashboard" })).not.toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "Logout" })).not.toBeInTheDocument();
+    });
+
+    it("shows Dashboard and Logout when logged in", async () => {
+        stubSession(true);
+        render(<Navigation />);
+        const dashboard = await screen.findByRole("link", { name: "Dashboard" });
+        expect(dashboard).toHaveAttribute("href", "/dashboard");
+        expect(screen.getByRole("button", { name: "Logout" })).toBeInTheDocument();
+    });
+
+    it("removes Dashboard and Logout after logging out", async () => {
+        stubSession(true);
+        render(<Navigation />);
+        const logout = await screen.findByRole("button", { name: "Logout" });
+
+        await userEvent.click(logout);
+
+        await waitFor(() => {
+            expect(mockFetch).toHaveBeenCalledWith("/api/auth/logout", { method: "POST" });
+            expect(screen.queryByRole("link", { name: "Dashboard" })).not.toBeInTheDocument();
+            expect(screen.queryByRole("button", { name: "Logout" })).not.toBeInTheDocument();
+        });
     });
 });

--- a/src/hooks/__tests__/useSession.test.ts
+++ b/src/hooks/__tests__/useSession.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useSession } from "../useSession";
+
+const mockFetch = vi.fn();
+
+describe("useSession", () => {
+    beforeEach(() => {
+        vi.stubGlobal("fetch", mockFetch);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        mockFetch.mockReset();
+    });
+
+    it("resolves to authenticated on a 200 from /api/auth/me", async () => {
+        mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+        const { result } = renderHook(() => useSession());
+        expect(result.current.status).toBe("loading");
+        await waitFor(() => expect(result.current.status).toBe("authenticated"));
+    });
+
+    it("resolves to unauthenticated on a 401", async () => {
+        mockFetch.mockResolvedValue(new Response(null, { status: 401 }));
+        const { result } = renderHook(() => useSession());
+        await waitFor(() => expect(result.current.status).toBe("unauthenticated"));
+    });
+
+    it("fails closed when the initial check throws", async () => {
+        mockFetch.mockRejectedValue(new Error("network down"));
+        const { result } = renderHook(() => useSession());
+        await waitFor(() => expect(result.current.status).toBe("unauthenticated"));
+    });
+
+    it("keeps an established session when a re-check throws", async () => {
+        mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+        const { result } = renderHook(() => useSession());
+        await waitFor(() => expect(result.current.status).toBe("authenticated"));
+
+        mockFetch.mockRejectedValue(new Error("network blip"));
+        await act(() => result.current.refresh());
+
+        expect(result.current.status).toBe("authenticated");
+    });
+
+    it("drops the session when a re-check returns 401", async () => {
+        mockFetch.mockResolvedValue(new Response(null, { status: 200 }));
+        const { result } = renderHook(() => useSession());
+        await waitFor(() => expect(result.current.status).toBe("authenticated"));
+
+        mockFetch.mockResolvedValue(new Response(null, { status: 401 }));
+        await act(() => result.current.refresh());
+
+        expect(result.current.status).toBe("unauthenticated");
+    });
+});

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -19,7 +19,9 @@ export function useSession(): { status: SessionStatus; refresh: () => Promise<vo
             const res = await fetch("/api/auth/me");
             setStatus(res.ok ? "authenticated" : "unauthenticated");
         } catch {
-            setStatus("unauthenticated");
+            // Network blip, not a 401: don't drop an established session.
+            // Only fail closed while the initial check is unresolved.
+            setStatus((prev) => (prev === "authenticated" ? prev : "unauthenticated"));
         }
     }, []);
 

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export type SessionStatus = "loading" | "authenticated" | "unauthenticated";
+
+/**
+ * Resolves whether an admin session is active. The session cookie is httpOnly
+ * so the client can't inspect it directly; instead this asks /api/auth/me,
+ * which returns 200 for a valid session and 401 otherwise.
+ *
+ * `refresh` re-checks the session, e.g. after logging out.
+ */
+export function useSession(): { status: SessionStatus; refresh: () => Promise<void> } {
+    const [status, setStatus] = useState<SessionStatus>("loading");
+
+    const refresh = useCallback(async () => {
+        try {
+            const res = await fetch("/api/auth/me");
+            setStatus(res.ok ? "authenticated" : "unauthenticated");
+        } catch {
+            setStatus("unauthenticated");
+        }
+    }, []);
+
+    useEffect(() => {
+        refresh();
+    }, [refresh]);
+
+    return { status, refresh };
+}


### PR DESCRIPTION
Closes #170

## What

When an admin session is active, the site navigation shows a **Dashboard** link and a **Logout** button next to the Gallery link. Logged-out visitors see no change.

The navigation is now also rendered globally from the root layout — previously it was only mounted by the 404 page, so the Gallery link (and these new buttons) were unreachable in normal use.

## How

- New `useSession` hook asks `GET /api/auth/me` whether a session is active — the `wedding_session` cookie is httpOnly, so the client can't inspect it directly. A thrown fetch (network blip) keeps an established session; only a real 401 drops it.
- Logout calls `POST /api/auth/logout`, re-checks the session so the buttons disappear without a manual reload, and calls `router.refresh()`. On failure it shows an inline error and keeps the buttons.
- `<Navigation />` is mounted once in the root layout, hidden on `/dashboard` routes (which have their own header). The header is now `position: sticky` instead of `fixed`, so it occupies flow space and pages don't need top-padding workarounds (removed from `not-found.tsx`).

## Visual impact

All public pages (homepage, gallery, RSVP, login, 404) now show the site header; content shifts down by its 56px height. Worth a quick visual check on the homepage before merging.

## Testing

- Navigation tests cover logged-out, logged-in, logout success, logout failure, and dashboard-route hiding
- New `useSession` hook tests cover initial check, 401, network-error fail-closed, and transient re-check errors
- Full suite: 101 tests passing, lint and `tsc --noEmit` clean