### PR TITLE
ci: fix Claude Code Review workflow no longer posting comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,62 +1,49 @@
 name: Claude Code Review
 
 on:
-  # Run after CI workflow completes successfully
-  workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
-    branches:
-      - '**'
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
 
 # Cancel in-progress runs for the same PR to avoid duplicate reviews
 concurrency:
-  group: claude-review-${{ github.event.workflow_run.head_branch }}
+  group: claude-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   claude-review:
-    # Only run if CI passed and it's a PR (not a push to main/develop)
+    # Skip drafts and bot PRs (e.g. dependabot version bumps)
     if: |
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request'
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.type != 'Bot'
 
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
     steps:
-      - name: Get PR number
-        id: pr
-        run: |
-          # Get PR number from workflow_run event
-          PR_NUMBER=$(echo '${{ toJson(github.event.workflow_run.pull_requests) }}' | jq -r '.[0].number // empty')
-          if [ -z "$PR_NUMBER" ]; then
-            echo "No PR number found, skipping review"
-            echo "skip=true" >> $GITHUB_OUTPUT
-          else
-            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-            echo "skip=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Checkout repository
-        if: steps.pr.outputs.skip != 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
-        if: steps.pr.outputs.skip != 'true'
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        # Pinned: the floating v1 tag has changed behaviour under us before.
+        # Bump deliberately after checking the release notes.
+        uses: anthropics/claude-code-action@v1.0.162
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Posts a tracking comment on the PR and updates it in place with
+          # the review, so re-reviews don't pile up as new comments.
+          track_progress: true
+
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ steps.pr.outputs.pr_number }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
             Please review this pull request and provide feedback on:
             - Code quality and best practices
@@ -67,8 +54,10 @@ jobs:
 
             Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
-            Use `gh pr comment --edit-last` with your Bash tool to leave your review as a comment on the PR. This will update the previous review comment rather than creating a new one. If there is no previous comment, it will create a new one.
+            Use inline comments for feedback tied to specific lines, and put
+            the overall review summary in the tracking comment.
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,6 +337,7 @@ const handleSubmit = async (values: FormData) => {
 
 This project uses external AI agents for PR review:
 
+- **Claude Code Review** (`.github/workflows/claude-code-review.yml`): reviews every non-draft, non-bot PR on open and on each push. Posts a single tracking comment that it updates in place, plus inline comments on specific lines. The action version is pinned; bump it deliberately.
 - **Codex (OpenAI)**: Automated code analysis on pull requests
 - **Cursor Bot**: AI-powered code review assistant
 


### PR DESCRIPTION
## Problem

Claude reviews stopped appearing on PRs. Investigation showed the reviews were still running and finishing green, but with dozens of permission denials — the `gh pr comment --edit-last` prompt hack was being blocked by the action's tool permission layer after an update to the floating `@v1` tag. Runs triggered by dependabot PRs also started hard-failing on a new non-human-actor check. (The old review comment on #163 appears to have been deleted by one of these broken runs.)

## Changes

- Trigger directly on `pull_request` (opened / synchronize / ready_for_review / reopened) instead of `workflow_run` after CI — this is the pattern the action currently supports and documents
- Skip draft PRs and bot PRs (dependabot)
- Use `track_progress: true` so the action itself posts a tracking comment and updates it in place — no more prompting Claude to shell out to `gh pr comment`
- Allow the `mcp__github_inline_comment__create_inline_comment` tool so line-level feedback lands as inline comments
- Grant `pull-requests: write` (was read-only)
- Pin the action to `v1.0.162` so a future `@v1` update can't silently change behaviour again
- Document the review bot setup in AGENTS.md

## Trade-off

Reviews now start when a PR is opened/pushed rather than waiting for CI to pass. If we want CI-gating back, the supported alternative is adding a first step that polls for CI status, but the simpler trigger seemed worth it.