### PR TITLE
fix: allow the PostHog reverse proxy origin in the CSP

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,8 +2,11 @@
 
 const isProduction = process.env.NODE_ENV === "production";
 
-// Only include PostHog in production
-const posthogUrls = isProduction ? " https://eu.i.posthog.com https://eu-assets.i.posthog.com" : "";
+// Only include PostHog in production. When NEXT_PUBLIC_POSTHOG_HOST is set the
+// SDK talks to our reverse proxy instead of eu.i.posthog.com, so allow that
+// origin too — the direct hosts stay listed as a fallback.
+const posthogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST ? ` ${new URL(process.env.NEXT_PUBLIC_POSTHOG_HOST).origin}` : "";
+const posthogUrls = isProduction ? `${posthogHost} https://eu.i.posthog.com https://eu-assets.i.posthog.com` : "";
 
 const cloudfrontDomain = process.env.NEXT_PUBLIC_CLOUDFRONT_URL ?? "";
 // Use the origin (scheme://host:port), not the full URL. The value may include a


### PR DESCRIPTION
## Problem

Production PostHog traffic is being switched to the managed reverse proxy (`techywechy.oneill.wedding`, already provisioned and valid) via `NEXT_PUBLIC_POSTHOG_HOST` in Amplify. But the CSP hardcodes `eu.i.posthog.com` / `eu-assets.i.posthog.com`, so the browser would block every SDK request to the proxy — analytics dead and `GalleryGate` stuck on its loading spinner (flags never resolve).

The Amplify deploy that would have shipped that state was cancelled (job 28); prod is still pointing directly at PostHog until this merges.

## Fix

Derive the allowed origin from `NEXT_PUBLIC_POSTHOG_HOST` and append it to the existing PostHog CSP sources, keeping the direct hosts as fallback. Verified the generated header includes `https://techywechy.oneill.wedding` in `connect-src` and `script-src`.

## After merge

Amplify auto-deploys main with the env vars already in place — no further infra steps needed.