### PR TITLE
Gallery & dashboard UX improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ See `docs/AWS_RESOURCES.md` for full resource inventory.
 ✅ **Complete**: Admin dashboard with invitation management
 ✅ **Complete**: Authentication system (Cognito) with protected routes
 ✅ **Complete**: Comprehensive unit testing with Vitest and React Testing Library
-⏳ **Planned**: Photo gallery section to showcase photos
+✅ **Complete**: Photo gallery with guest uploads, moderation, categories, and personal invitation links
 ⏳ **Planned**: End-to-end test suite (the previous Cypress suite was removed pending a rewrite)
 
 ## Testing

--- a/src/app/api/dashboard/photo-summary/__tests__/route.test.ts
+++ b/src/app/api/dashboard/photo-summary/__tests__/route.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+
+const mockListPhotosByStatus = vi.fn();
+const mockCountPhotosByStatus = vi.fn();
+const mockListCategories = vi.fn();
+const mockRequireAuth = vi.fn();
+
+vi.mock("@/utils/db/photos", () => ({
+    listPhotosByStatus: (...args: unknown[]) => mockListPhotosByStatus(...args),
+    countPhotosByStatus: (...args: unknown[]) => mockCountPhotosByStatus(...args),
+}));
+
+vi.mock("@/utils/db/categories", () => ({
+    listCategories: (...args: unknown[]) => mockListCategories(...args),
+}));
+
+vi.mock("@/utils/auth/requireAuth", () => ({
+    requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+}));
+
+vi.mock("@/utils/logger", () => ({
+    error: vi.fn(),
+}));
+
+const categories = [
+    { id: "cat-1", name: "The Ceremony", slug: "ceremony", sort_order: 1 },
+    { id: "cat-2", name: "Party", slug: "party", sort_order: 2 },
+];
+
+function approvedPhoto(id: string, categoryId: string | null) {
+    return { id, category_id: categoryId, status: "approved" };
+}
+
+describe("GET /api/dashboard/photo-summary", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockRequireAuth.mockResolvedValue({ success: true, payload: { email: "admin@test.com" } });
+        mockListCategories.mockResolvedValue(categories);
+    });
+
+    it("requires authentication", async () => {
+        mockRequireAuth.mockResolvedValue({
+            success: false,
+            response: new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }),
+        });
+        const res = await GET(new NextRequest("http://localhost/api/dashboard/photo-summary"));
+        expect(res.status).toBe(401);
+    });
+
+    it("aggregates status counts, recent uploads, and per-category counts", async () => {
+        mockListPhotosByStatus.mockResolvedValue([
+            approvedPhoto("p1", "cat-1"),
+            approvedPhoto("p2", "cat-1"),
+            approvedPhoto("p3", null),
+        ]);
+        // pending, rejected, then recent approved/pending/rejected
+        mockCountPhotosByStatus
+            .mockResolvedValueOnce(4)
+            .mockResolvedValueOnce(1)
+            .mockResolvedValueOnce(2)
+            .mockResolvedValueOnce(3)
+            .mockResolvedValueOnce(0);
+
+        const res = await GET(new NextRequest("http://localhost/api/dashboard/photo-summary"));
+        expect(res.status).toBe(200);
+        const { summary } = await res.json();
+
+        expect(summary.approved).toBe(3);
+        expect(summary.pending).toBe(4);
+        expect(summary.rejected).toBe(1);
+        expect(summary.total).toBe(8);
+        expect(summary.recentUploads).toBe(5);
+        expect(summary.byCategory).toEqual([
+            { id: "cat-1", name: "The Ceremony", count: 2 },
+            { id: "cat-2", name: "Party", count: 0 },
+            { id: null, name: "Uncategorised", count: 1 },
+        ]);
+    });
+
+    it("omits the Uncategorised row when every photo has a category", async () => {
+        mockListPhotosByStatus.mockResolvedValue([approvedPhoto("p1", "cat-2")]);
+        mockCountPhotosByStatus.mockResolvedValue(0);
+
+        const res = await GET(new NextRequest("http://localhost/api/dashboard/photo-summary"));
+        const { summary } = await res.json();
+        expect(summary.byCategory).toEqual([
+            { id: "cat-1", name: "The Ceremony", count: 0 },
+            { id: "cat-2", name: "Party", count: 1 },
+        ]);
+    });
+
+    it("handles database errors", async () => {
+        mockListPhotosByStatus.mockRejectedValue(new Error("DB error"));
+        mockCountPhotosByStatus.mockResolvedValue(0);
+        const res = await GET(new NextRequest("http://localhost/api/dashboard/photo-summary"));
+        expect(res.status).toBe(500);
+    });
+});

--- a/src/app/api/dashboard/photo-summary/route.ts
+++ b/src/app/api/dashboard/photo-summary/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+import { listPhotosByStatus, countPhotosByStatus } from "@/utils/db/photos";
+import { listCategories } from "@/utils/db/categories";
+import { requireAuth } from "@/utils/auth/requireAuth";
+import * as logger from "@/utils/logger";
+
+export interface PhotoSummary {
+    approved: number;
+    pending: number;
+    rejected: number;
+    total: number;
+    recentUploads: number;
+    byCategory: { id: string | null; name: string; count: number }[];
+}
+
+const RECENT_DAYS = 7;
+
+export async function GET(request: NextRequest) {
+    const auth = await requireAuth(request);
+    if (!auth.success) return auth.response;
+
+    try {
+        const since = new Date(Date.now() - RECENT_DAYS * 24 * 60 * 60 * 1000).toISOString();
+
+        // Approved photos are materialised (the per-category breakdown needs
+        // them); the rest are COUNT queries on the byStatus GSI.
+        const [approvedPhotos, pending, rejected, categories, ...recentByStatus] =
+            await Promise.all([
+                listPhotosByStatus("approved"),
+                countPhotosByStatus("pending"),
+                countPhotosByStatus("rejected"),
+                listCategories(),
+                countPhotosByStatus("approved", since),
+                countPhotosByStatus("pending", since),
+                countPhotosByStatus("rejected", since),
+            ]);
+
+        const countsByCategory = new Map<string | null, number>();
+        for (const photo of approvedPhotos) {
+            const key = photo.category_id ?? null;
+            countsByCategory.set(key, (countsByCategory.get(key) ?? 0) + 1);
+        }
+
+        const byCategory = categories.map((c) => ({
+            id: c.id as string | null,
+            name: c.name,
+            count: countsByCategory.get(c.id) ?? 0,
+        }));
+        const uncategorised = countsByCategory.get(null) ?? 0;
+        if (uncategorised > 0) {
+            byCategory.push({ id: null, name: "Uncategorised", count: uncategorised });
+        }
+
+        const summary: PhotoSummary = {
+            approved: approvedPhotos.length,
+            pending,
+            rejected,
+            total: approvedPhotos.length + pending + rejected,
+            recentUploads: recentByStatus.reduce((a, b) => a + b, 0),
+            byCategory,
+        };
+
+        return NextResponse.json({ summary });
+    } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        await logger.error("GET /api/dashboard/photo-summary", "DB query failed", error);
+        return NextResponse.json({ error: msg }, { status: 500 });
+    }
+}

--- a/src/app/api/gallery/categories/[id]/__tests__/route.test.ts
+++ b/src/app/api/gallery/categories/[id]/__tests__/route.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { PATCH } from "../route";
+
+const mockUpdateCategory = vi.fn();
+const mockRequireAuth = vi.fn();
+
+vi.mock("@/utils/db/categories", () => ({
+    updateCategory: (...args: unknown[]) => mockUpdateCategory(...args),
+}));
+
+vi.mock("@/utils/auth/requireAuth", () => ({
+    requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+}));
+
+const updatedCategory = {
+    id: "cat-1",
+    name: "The Ceremony",
+    slug: "ceremony",
+    description: null,
+    event_day: "saturday",
+    cover_photo_id: null,
+    sort_order: 1,
+    created_at: "2026-05-01T00:00:00Z",
+};
+
+function makeRequest(body: unknown) {
+    return new NextRequest("http://localhost/api/gallery/categories/cat-1", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+const params = { params: Promise.resolve({ id: "cat-1" }) };
+
+describe("PATCH /api/gallery/categories/[id]", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockRequireAuth.mockResolvedValue({ success: true, payload: { email: "admin@test.com" } });
+    });
+
+    it("requires authentication", async () => {
+        mockRequireAuth.mockResolvedValue({
+            success: false,
+            response: new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }),
+        });
+        const res = await PATCH(makeRequest({ name: "New Name" }), params);
+        expect(res.status).toBe(401);
+        expect(mockUpdateCategory).not.toHaveBeenCalled();
+    });
+
+    it("renames a category", async () => {
+        mockUpdateCategory.mockResolvedValue({ ...updatedCategory, name: "New Name" });
+        const res = await PATCH(makeRequest({ name: "  New Name  " }), params);
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.category.name).toBe("New Name");
+        expect(mockUpdateCategory).toHaveBeenCalledWith("cat-1", { name: "New Name" });
+    });
+
+    it("updates description and sort_order", async () => {
+        mockUpdateCategory.mockResolvedValue(updatedCategory);
+        const res = await PATCH(makeRequest({ description: "During the vows", sort_order: 3 }), params);
+        expect(res.status).toBe(200);
+        expect(mockUpdateCategory).toHaveBeenCalledWith("cat-1", {
+            description: "During the vows",
+            sort_order: 3,
+        });
+    });
+
+    it("normalises an empty description to null", async () => {
+        mockUpdateCategory.mockResolvedValue(updatedCategory);
+        const res = await PATCH(makeRequest({ description: "   " }), params);
+        expect(res.status).toBe(200);
+        expect(mockUpdateCategory).toHaveBeenCalledWith("cat-1", { description: null });
+    });
+
+    it("rejects slug changes", async () => {
+        const res = await PATCH(makeRequest({ slug: "new-slug" }), params);
+        expect(res.status).toBe(400);
+        expect(mockUpdateCategory).not.toHaveBeenCalled();
+    });
+
+    it("rejects an empty name", async () => {
+        const res = await PATCH(makeRequest({ name: "   " }), params);
+        expect(res.status).toBe(400);
+        expect(mockUpdateCategory).not.toHaveBeenCalled();
+    });
+
+    it("rejects a non-numeric sort_order", async () => {
+        const res = await PATCH(makeRequest({ sort_order: "first" }), params);
+        expect(res.status).toBe(400);
+        expect(mockUpdateCategory).not.toHaveBeenCalled();
+    });
+
+    it("rejects a body with no updatable fields", async () => {
+        const res = await PATCH(makeRequest({ event_day: "friday" }), params);
+        expect(res.status).toBe(400);
+        expect(mockUpdateCategory).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when the category does not exist", async () => {
+        mockUpdateCategory.mockResolvedValue(null);
+        const res = await PATCH(makeRequest({ name: "New Name" }), params);
+        expect(res.status).toBe(404);
+    });
+
+    it("handles database errors", async () => {
+        mockUpdateCategory.mockRejectedValue(new Error("DB error"));
+        const res = await PATCH(makeRequest({ name: "New Name" }), params);
+        expect(res.status).toBe(500);
+    });
+});

--- a/src/app/api/gallery/categories/[id]/__tests__/route.test.ts
+++ b/src/app/api/gallery/categories/[id]/__tests__/route.test.ts
@@ -13,6 +13,10 @@ vi.mock("@/utils/auth/requireAuth", () => ({
     requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
 }));
 
+vi.mock("@/utils/logger", () => ({
+    error: vi.fn(),
+}));
+
 const updatedCategory = {
     id: "cat-1",
     name: "The Ceremony",

--- a/src/app/api/gallery/categories/[id]/route.ts
+++ b/src/app/api/gallery/categories/[id]/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { updateCategory, type UpdateCategoryInput } from "@/utils/db/categories";
+import { requireAuth } from "@/utils/auth/requireAuth";
+
+export async function PATCH(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    const auth = await requireAuth(request);
+    if (!auth.success) return auth.response;
+
+    try {
+        const { id } = await params;
+        const body = await request.json();
+
+        if ("slug" in body) {
+            return NextResponse.json(
+                { error: "slug cannot be changed — it's the public URL key" },
+                { status: 400 }
+            );
+        }
+
+        const fields: UpdateCategoryInput = {};
+        if (body.name !== undefined) {
+            if (typeof body.name !== "string" || !body.name.trim()) {
+                return NextResponse.json({ error: "name must be a non-empty string" }, { status: 400 });
+            }
+            fields.name = body.name.trim();
+        }
+        if (body.description !== undefined) {
+            if (body.description !== null && typeof body.description !== "string") {
+                return NextResponse.json({ error: "description must be a string or null" }, { status: 400 });
+            }
+            fields.description = body.description === null ? null : body.description.trim() || null;
+        }
+        if (body.sort_order !== undefined) {
+            if (typeof body.sort_order !== "number" || !Number.isFinite(body.sort_order)) {
+                return NextResponse.json({ error: "sort_order must be a number" }, { status: 400 });
+            }
+            fields.sort_order = body.sort_order;
+        }
+
+        if (Object.keys(fields).length === 0) {
+            return NextResponse.json({ error: "No updatable fields provided" }, { status: 400 });
+        }
+
+        const category = await updateCategory(id, fields);
+        if (!category) {
+            return NextResponse.json({ error: "Category not found" }, { status: 404 });
+        }
+
+        return NextResponse.json({ category });
+    } catch (error) {
+        console.error("Error in PATCH /api/gallery/categories/[id]:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/app/api/gallery/categories/[id]/route.ts
+++ b/src/app/api/gallery/categories/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { updateCategory, type UpdateCategoryInput } from "@/utils/db/categories";
 import { requireAuth } from "@/utils/auth/requireAuth";
+import * as logger from "@/utils/logger";
 
 export async function PATCH(
     request: NextRequest,
@@ -51,7 +52,7 @@ export async function PATCH(
 
         return NextResponse.json({ category });
     } catch (error) {
-        console.error("Error in PATCH /api/gallery/categories/[id]:", error);
+        await logger.error("PATCH /api/gallery/categories/[id]", "DB update failed", error);
         return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 }

--- a/src/app/api/photos/validate-code/__tests__/route.test.ts
+++ b/src/app/api/photos/validate-code/__tests__/route.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+
+const mockGetInviteesByCode = vi.fn();
+
+vi.mock("@/utils/db/archive", () => ({
+    getInviteesByCode: (...args: unknown[]) => mockGetInviteesByCode(...args),
+}));
+
+function makeRequest(body: unknown): NextRequest {
+    return new NextRequest("http://localhost/api/photos/validate-code", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+describe("POST /api/photos/validate-code", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("returns valid with invitee first names for a known code", async () => {
+        mockGetInviteesByCode.mockResolvedValue(["Matthew", "Jim", "Sarah"]);
+        const res = await POST(makeRequest({ code: "abc123" }));
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data).toEqual({ valid: true, names: ["Matthew", "Jim", "Sarah"] });
+        // Codes are stored uppercase
+        expect(mockGetInviteesByCode).toHaveBeenCalledWith("ABC123");
+    });
+
+    it("returns invalid for an unknown code", async () => {
+        mockGetInviteesByCode.mockResolvedValue(null);
+        const res = await POST(makeRequest({ code: "ZZZZZZ" }));
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.valid).toBe(false);
+        expect(data.names).toBeUndefined();
+    });
+
+    it("rejects a missing code", async () => {
+        const res = await POST(makeRequest({}));
+        expect(res.status).toBe(400);
+    });
+
+    it("rejects a non-string code", async () => {
+        const res = await POST(makeRequest({ code: 123456 }));
+        expect(res.status).toBe(400);
+    });
+
+    it("handles database errors", async () => {
+        mockGetInviteesByCode.mockRejectedValue(new Error("DB error"));
+        const res = await POST(makeRequest({ code: "ABC123" }));
+        expect(res.status).toBe(500);
+    });
+});

--- a/src/app/api/photos/validate-code/route.ts
+++ b/src/app/api/photos/validate-code/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { isValidInvitationCode } from "@/utils/db/archive";
+import { getInviteesByCode } from "@/utils/db/archive";
 
 export async function POST(request: NextRequest) {
     try {
@@ -8,12 +8,12 @@ export async function POST(request: NextRequest) {
             return NextResponse.json({ error: "code is required" }, { status: 400 });
         }
 
-        const valid = await isValidInvitationCode(code.trim().toUpperCase());
-        if (!valid) {
+        const names = await getInviteesByCode(code.trim().toUpperCase());
+        if (names === null) {
             return NextResponse.json({ valid: false, error: "Invalid invitation code" });
         }
 
-        return NextResponse.json({ valid: true });
+        return NextResponse.json({ valid: true, names });
     } catch (error) {
         console.error("Error in POST /api/photos/validate-code:", error);
         return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/src/app/dashboard/invitations/page.tsx
+++ b/src/app/dashboard/invitations/page.tsx
@@ -36,7 +36,7 @@ export default function InvitationsPage() {
     }, []);
 
     const handleCopy = async (code: string) => {
-        const url = `${window.location.origin}/photos?code=${code}`;
+        const url = `${window.location.origin}/gallery?code=${code}`;
         await navigator.clipboard.writeText(url);
         setCopied(code);
         setTimeout(() => setCopied(null), 2000);

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Container, Tabs, Box, Anchor, Group, Title, Button } from "@mantine/core";
+import { Container, Tabs, Box, Anchor, Group, Title, Button, Badge } from "@mantine/core";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -10,6 +10,16 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     const router = useRouter();
     const [activeTab, setActiveTab] = useState<string | null>(null);
     const [signingOut, setSigningOut] = useState(false);
+    const [pendingCount, setPendingCount] = useState(0);
+
+    // Fetched once per dashboard visit — the layout wraps every dashboard
+    // page, so this must not refire on tab switches.
+    useEffect(() => {
+        fetch("/api/dashboard/photo-summary")
+            .then((r) => (r.ok ? r.json() : null))
+            .then((data) => setPendingCount(data?.summary?.pending ?? 0))
+            .catch(() => {}); // badge is best-effort
+    }, []);
 
     useEffect(() => {
         if (pathname.includes("/dashboard/invitations")) {
@@ -110,7 +120,18 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
                         <Tabs.List>
                             <Tabs.Tab value="overview">Overview</Tabs.Tab>
                             <Tabs.Tab value="invitations">Invitations</Tabs.Tab>
-                            <Tabs.Tab value="photos">Photos</Tabs.Tab>
+                            <Tabs.Tab
+                                value="photos"
+                                rightSection={
+                                    pendingCount > 0 ? (
+                                        <Badge size="sm" circle color="orange" variant="filled">
+                                            {pendingCount}
+                                        </Badge>
+                                    ) : undefined
+                                }
+                            >
+                                Photos
+                            </Tabs.Tab>
                         </Tabs.List>
 
                         <Box mt="lg">{children}</Box>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -13,12 +13,18 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     const [pendingCount, setPendingCount] = useState(0);
 
     // Fetched once per dashboard visit — the layout wraps every dashboard
-    // page, so this must not refire on tab switches.
+    // page, so this must not refire on tab switches. Moderation actions
+    // dispatch "wedding:photos-moderated" so the badge doesn't go stale.
     useEffect(() => {
-        fetch("/api/dashboard/photo-summary")
-            .then((r) => (r.ok ? r.json() : null))
-            .then((data) => setPendingCount(data?.summary?.pending ?? 0))
-            .catch(() => {}); // badge is best-effort
+        const fetchPendingCount = () => {
+            fetch("/api/dashboard/photo-summary")
+                .then((r) => (r.ok ? r.json() : null))
+                .then((data) => setPendingCount(data?.summary?.pending ?? 0))
+                .catch(() => {}); // badge is best-effort
+        };
+        fetchPendingCount();
+        window.addEventListener("wedding:photos-moderated", fetchPendingCount);
+        return () => window.removeEventListener("wedding:photos-moderated", fetchPendingCount);
     }, []);
 
     useEffect(() => {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,34 +1,43 @@
 "use client";
 
-import { Title, Text, Group, Stack, Paper, Box, SimpleGrid, Progress, Button, Alert } from "@mantine/core";
-import { IconExternalLink, IconAlertCircle } from "@tabler/icons-react";
+import { Title, Text, Group, Stack, Paper, Box, SimpleGrid, Button, Alert, Badge } from "@mantine/core";
+import { IconExternalLink, IconAlertCircle, IconPhoto } from "@tabler/icons-react";
 import { useState, useEffect } from "react";
+import Link from "next/link";
 
 interface SummaryData {
     invitations: { total: number; sent: number };
     rsvps: { total: number; received: number; accepted: number; declined: number };
     guests: { total: number; coming: number; notComing: number; undecided: number };
-    villa: { stayingYes: number; stayingNo: number; undecided: number };
+}
+
+interface PhotoSummaryData {
+    approved: number;
+    pending: number;
+    rejected: number;
+    total: number;
+    recentUploads: number;
+    byCategory: { id: string | null; name: string; count: number }[];
 }
 
 export default function DashboardPage() {
-    const [summary, setSummary] = useState<SummaryData>({
-        invitations: { total: 0, sent: 0 },
-        rsvps: { total: 0, received: 0, accepted: 0, declined: 0 },
-        guests: { total: 0, coming: 0, notComing: 0, undecided: 0 },
-        villa: { stayingYes: 0, stayingNo: 0, undecided: 0 },
-    });
+    const [summary, setSummary] = useState<SummaryData | null>(null);
+    const [photoSummary, setPhotoSummary] = useState<PhotoSummaryData | null>(null);
     const [fetchError, setFetchError] = useState<string | null>(null);
 
     useEffect(() => {
-        fetch("/api/dashboard/summary")
-            .then(async r => {
-                const data = await r.json();
-                if (!r.ok) throw new Error(data.error ?? `Request failed (${r.status})`);
-                return data;
-            })
-            .then(data => { if (data.summary) setSummary(data.summary); })
-            .catch(err => setFetchError(err instanceof Error ? err.message : "Failed to load data"));
+        const load = async (url: string) => {
+            const r = await fetch(url);
+            const data = await r.json();
+            if (!r.ok) throw new Error(data.error ?? `Request failed (${r.status})`);
+            return data;
+        };
+        load("/api/dashboard/photo-summary")
+            .then((data) => { if (data.summary) setPhotoSummary(data.summary); })
+            .catch((err) => setFetchError(err instanceof Error ? err.message : "Failed to load data"));
+        load("/api/dashboard/summary")
+            .then((data) => { if (data.summary) setSummary(data.summary); })
+            .catch((err) => setFetchError(err instanceof Error ? err.message : "Failed to load data"));
     }, []);
 
     return (
@@ -69,139 +78,125 @@ export default function DashboardPage() {
                 )}
 
                 <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="lg">
-                    <Paper shadow="md" radius="lg" p="lg" style={{ backgroundColor: "#ffffff" }}>
+                    <Paper
+                        shadow="md"
+                        radius="lg"
+                        p="lg"
+                        style={{
+                            backgroundColor:
+                                photoSummary && photoSummary.pending > 0 ? "#fffbeb" : "#ffffff",
+                        }}
+                    >
                         <Text fw={600} size="lg" mb="md" style={{ color: "#495057" }}>
-                            Invitations
+                            Pending Approvals
                         </Text>
-                        <Group justify="space-between" mb="xs">
-                            <Text size="sm" c="dimmed">Sent</Text>
-                            <Text fw={500}>{summary.invitations.sent} / {summary.invitations.total}</Text>
-                        </Group>
-                        <Progress
-                            value={
-                                summary.invitations.total > 0
-                                    ? (summary.invitations.sent / summary.invitations.total) * 100
-                                    : 0
-                            }
-                            color="#8b7355"
-                            size="lg"
-                            radius="md"
-                        />
+                        <Text
+                            fw={700}
+                            style={{
+                                fontSize: "3rem",
+                                lineHeight: 1,
+                                color:
+                                    photoSummary && photoSummary.pending > 0 ? "#d97706" : "#22c55e",
+                            }}
+                        >
+                            {photoSummary?.pending ?? "—"}
+                        </Text>
+                        <Text size="sm" c="dimmed" mt="xs">
+                            {photoSummary?.pending === 0
+                                ? "All caught up"
+                                : "guest photos waiting for review"}
+                        </Text>
+                        <Button
+                            component={Link}
+                            href="/dashboard/photos"
+                            variant="light"
+                            color="yellow"
+                            size="sm"
+                            mt="md"
+                            leftSection={<IconPhoto size={16} />}
+                        >
+                            Review photos
+                        </Button>
                     </Paper>
 
                     <Paper shadow="md" radius="lg" p="lg" style={{ backgroundColor: "#ffffff" }}>
                         <Text fw={600} size="lg" mb="md" style={{ color: "#495057" }}>
-                            RSVPs
+                            Gallery
                         </Text>
-                        <Group justify="space-between" mb="xs">
-                            <Text size="sm" c="dimmed">Received</Text>
-                            <Text fw={500}>{summary.rsvps.received} / {summary.rsvps.total}</Text>
-                        </Group>
-                        <Progress
-                            value={
-                                summary.rsvps.total > 0
-                                    ? (summary.rsvps.received / summary.rsvps.total) * 100
-                                    : 0
-                            }
-                            color="#3b82f6"
-                            size="lg"
-                            radius="md"
-                            mb="md"
-                        />
-                        <Group gap="lg">
+                        <Group gap="xl">
                             <Box>
-                                <Text size="xs" c="dimmed">Accepted</Text>
-                                <Text fw={600} style={{ color: "#22c55e" }}>{summary.rsvps.accepted}</Text>
+                                <Text size="xs" c="dimmed">Total</Text>
+                                <Text fw={600} size="xl">{photoSummary?.total ?? "—"}</Text>
                             </Box>
                             <Box>
-                                <Text size="xs" c="dimmed">Declined</Text>
-                                <Text fw={600} style={{ color: "#ef4444" }}>{summary.rsvps.declined}</Text>
+                                <Text size="xs" c="dimmed">Approved</Text>
+                                <Text fw={600} size="xl" style={{ color: "#22c55e" }}>
+                                    {photoSummary?.approved ?? "—"}
+                                </Text>
+                            </Box>
+                            <Box>
+                                <Text size="xs" c="dimmed">Rejected</Text>
+                                <Text fw={600} size="xl" style={{ color: "#ef4444" }}>
+                                    {photoSummary?.rejected ?? "—"}
+                                </Text>
                             </Box>
                         </Group>
-                    </Paper>
-
-                    <Paper shadow="md" radius="lg" p="lg" style={{ backgroundColor: "#ffffff" }}>
-                        <Text fw={600} size="lg" mb="md" style={{ color: "#495057" }}>
-                            Guests
-                        </Text>
-                        <Group justify="space-between" mb="xs">
-                            <Text size="sm" c="dimmed">Confirmed</Text>
-                            <Text fw={500}>{summary.guests.coming} / {summary.guests.total}</Text>
-                        </Group>
-                        <Progress.Root size="lg" radius="md">
-                            <Progress.Section
-                                value={
-                                    summary.guests.total > 0
-                                        ? (summary.guests.coming / summary.guests.total) * 100
-                                        : 0
-                                }
-                                color="#22c55e"
-                            />
-                            <Progress.Section
-                                value={
-                                    summary.guests.total > 0
-                                        ? (summary.guests.notComing / summary.guests.total) * 100
-                                        : 0
-                                }
-                                color="#ef4444"
-                            />
-                        </Progress.Root>
-                        <Group gap="lg" mt="md">
-                            <Box>
-                                <Text size="xs" c="dimmed">Coming</Text>
-                                <Text fw={600} style={{ color: "#22c55e" }}>{summary.guests.coming}</Text>
-                            </Box>
-                            <Box>
-                                <Text size="xs" c="dimmed">Not Coming</Text>
-                                <Text fw={600} style={{ color: "#ef4444" }}>{summary.guests.notComing}</Text>
-                            </Box>
-                            <Box>
-                                <Text size="xs" c="dimmed">Undecided</Text>
-                                <Text fw={600} style={{ color: "#9ca3af" }}>{summary.guests.undecided}</Text>
-                            </Box>
+                        <Group gap="xs" mt="md">
+                            <Badge variant="light" color="blue">
+                                {photoSummary?.recentUploads ?? 0} upload
+                                {photoSummary?.recentUploads !== 1 && "s"} in the last 7 days
+                            </Badge>
                         </Group>
                     </Paper>
 
                     <Paper shadow="md" radius="lg" p="lg" style={{ backgroundColor: "#ffffff" }}>
                         <Text fw={600} size="lg" mb="md" style={{ color: "#495057" }}>
-                            Villa Accommodation
+                            Photos by Category
                         </Text>
-                        <Group justify="space-between" mb="xs">
-                            <Text size="sm" c="dimmed">Staying at Villa</Text>
-                            <Text fw={500}>{summary.villa.stayingYes} parties</Text>
-                        </Group>
-                        <Progress.Root size="lg" radius="md">
-                            <Progress.Section
-                                value={
-                                    summary.rsvps.total > 0
-                                        ? (summary.villa.stayingYes / summary.rsvps.total) * 100
-                                        : 0
-                                }
-                                color="#8b7355"
-                            />
-                            <Progress.Section
-                                value={
-                                    summary.rsvps.total > 0
-                                        ? (summary.villa.stayingNo / summary.rsvps.total) * 100
-                                        : 0
-                                }
-                                color="#6c757d"
-                            />
-                        </Progress.Root>
-                        <Group gap="lg" mt="md">
-                            <Box>
-                                <Text size="xs" c="dimmed">Yes</Text>
-                                <Text fw={600} style={{ color: "#8b7355" }}>{summary.villa.stayingYes}</Text>
-                            </Box>
-                            <Box>
-                                <Text size="xs" c="dimmed">No</Text>
-                                <Text fw={600} style={{ color: "#6c757d" }}>{summary.villa.stayingNo}</Text>
-                            </Box>
-                            <Box>
-                                <Text size="xs" c="dimmed">Undecided</Text>
-                                <Text fw={600} style={{ color: "#9ca3af" }}>{summary.villa.undecided}</Text>
-                            </Box>
-                        </Group>
+                        {photoSummary && photoSummary.byCategory.length > 0 ? (
+                            <Stack gap={6}>
+                                {photoSummary.byCategory.map((c) => (
+                                    <Group key={c.id ?? "uncategorised"} justify="space-between">
+                                        <Text size="sm" c="dimmed">{c.name}</Text>
+                                        <Text size="sm" fw={600}>{c.count}</Text>
+                                    </Group>
+                                ))}
+                            </Stack>
+                        ) : (
+                            <Text size="sm" c="dimmed">No categories yet</Text>
+                        )}
+                    </Paper>
+
+                    <Paper shadow="md" radius="lg" p="lg" style={{ backgroundColor: "#ffffff" }}>
+                        <Text fw={600} size="lg" mb="md" style={{ color: "#495057" }}>
+                            The Big Day
+                        </Text>
+                        <Stack gap={6}>
+                            <Group justify="space-between">
+                                <Text size="sm" c="dimmed">Invitations sent</Text>
+                                <Text size="sm" fw={600}>
+                                    {summary ? `${summary.invitations.sent} / ${summary.invitations.total}` : "—"}
+                                </Text>
+                            </Group>
+                            <Group justify="space-between">
+                                <Text size="sm" c="dimmed">RSVPs accepted</Text>
+                                <Text size="sm" fw={600} style={{ color: "#22c55e" }}>
+                                    {summary?.rsvps.accepted ?? "—"}
+                                </Text>
+                            </Group>
+                            <Group justify="space-between">
+                                <Text size="sm" c="dimmed">RSVPs declined</Text>
+                                <Text size="sm" fw={600} style={{ color: "#ef4444" }}>
+                                    {summary?.rsvps.declined ?? "—"}
+                                </Text>
+                            </Group>
+                            <Group justify="space-between">
+                                <Text size="sm" c="dimmed">Guests who joined us</Text>
+                                <Text size="sm" fw={600}>
+                                    {summary ? `${summary.guests.coming} / ${summary.guests.total}` : "—"}
+                                </Text>
+                            </Group>
+                        </Stack>
                     </Paper>
                 </SimpleGrid>
             </Box>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -143,8 +143,10 @@ export default function DashboardPage() {
                         </Group>
                         <Group gap="xs" mt="md">
                             <Badge variant="light" color="blue">
-                                {photoSummary?.recentUploads ?? 0} upload
-                                {photoSummary?.recentUploads !== 1 && "s"} in the last 7 days
+                                {photoSummary
+                                    ? `${photoSummary.recentUploads} upload${photoSummary.recentUploads !== 1 ? "s" : ""}`
+                                    : "— uploads"}{" "}
+                                in the last 7 days
                             </Badge>
                         </Group>
                     </Paper>

--- a/src/app/dashboard/photos/categories/page.tsx
+++ b/src/app/dashboard/photos/categories/page.tsx
@@ -15,8 +15,9 @@ import {
     SimpleGrid,
     Badge,
     Anchor,
+    ActionIcon,
 } from "@mantine/core";
-import { IconAlertCircle, IconPlus } from "@tabler/icons-react";
+import { IconAlertCircle, IconPlus, IconPencil } from "@tabler/icons-react";
 import Link from "next/link";
 import type { PhotoCategory } from "@/types/photos";
 
@@ -40,6 +41,13 @@ export default function CategoriesPage() {
     const [submitting, setSubmitting] = useState(false);
     const [formError, setFormError] = useState<string | null>(null);
 
+    const [editingId, setEditingId] = useState<string | null>(null);
+    const [editName, setEditName] = useState("");
+    const [editDescription, setEditDescription] = useState("");
+    const [editSortOrder, setEditSortOrder] = useState<number | string>(0);
+    const [saving, setSaving] = useState(false);
+    const [editError, setEditError] = useState<string | null>(null);
+
     const fetchCategories = async () => {
         setLoading(true);
         try {
@@ -61,6 +69,44 @@ export default function CategoriesPage() {
         setName(value);
         if (!slug || slug === slugify(name)) {
             setSlug(slugify(value));
+        }
+    };
+
+    const startEditing = (category: PhotoCategory) => {
+        setEditingId(category.id);
+        setEditName(category.name);
+        setEditDescription(category.description ?? "");
+        setEditSortOrder(category.sort_order);
+        setEditError(null);
+    };
+
+    const handleSaveEdit = async () => {
+        if (!editName.trim()) {
+            setEditError("Name is required");
+            return;
+        }
+        setSaving(true);
+        setEditError(null);
+        try {
+            const res = await fetch(`/api/gallery/categories/${editingId}`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    name: editName.trim(),
+                    description: editDescription.trim() || null,
+                    sort_order: Number(editSortOrder) || 0,
+                }),
+            });
+            if (!res.ok) {
+                const data = await res.json();
+                throw new Error(data.error ?? "Failed to update category");
+            }
+            setEditingId(null);
+            fetchCategories();
+        } catch (err) {
+            setEditError(err instanceof Error ? err.message : "Failed to update category");
+        } finally {
+            setSaving(false);
         }
     };
 
@@ -188,27 +234,82 @@ export default function CategoriesPage() {
                 <SimpleGrid cols={{ base: 1, sm: 2, md: 3 }} spacing="md">
                     {categories.map((c) => (
                         <Paper key={c.id} shadow="sm" radius="md" p="md" withBorder>
-                            <Stack gap="xs">
-                                <Group justify="space-between">
-                                    <Text fw={500}>{c.name}</Text>
-                                    <Text size="xs" c="dimmed">
-                                        #{c.sort_order}
+                            {editingId === c.id ? (
+                                <Stack gap="xs">
+                                    {editError && (
+                                        <Alert icon={<IconAlertCircle size={14} />} color="red" variant="light" py="xs">
+                                            {editError}
+                                        </Alert>
+                                    )}
+                                    <TextInput
+                                        label="Name"
+                                        value={editName}
+                                        onChange={(e) => setEditName(e.currentTarget.value)}
+                                        required
+                                    />
+                                    <TextInput
+                                        label="Description"
+                                        value={editDescription}
+                                        onChange={(e) => setEditDescription(e.currentTarget.value)}
+                                    />
+                                    <NumberInput
+                                        label="Sort order"
+                                        value={editSortOrder}
+                                        onChange={setEditSortOrder}
+                                        min={0}
+                                    />
+                                    <Text size="xs" c="dimmed" ff="monospace">
+                                        {c.slug} (fixed)
                                     </Text>
-                                </Group>
-                                <Text size="xs" c="dimmed" ff="monospace">
-                                    {c.slug}
-                                </Text>
-                                {c.event_day && (
-                                    <Badge size="xs" variant="light" color="yellow" tt="capitalize">
-                                        {c.event_day}
-                                    </Badge>
-                                )}
-                                {c.description && (
-                                    <Text size="xs" c="dimmed">
-                                        {c.description}
+                                    <Group gap="xs" justify="flex-end">
+                                        <Button
+                                            size="xs"
+                                            variant="subtle"
+                                            color="gray"
+                                            onClick={() => setEditingId(null)}
+                                            disabled={saving}
+                                        >
+                                            Cancel
+                                        </Button>
+                                        <Button size="xs" color="yellow" onClick={handleSaveEdit} loading={saving}>
+                                            Save
+                                        </Button>
+                                    </Group>
+                                </Stack>
+                            ) : (
+                                <Stack gap="xs">
+                                    <Group justify="space-between">
+                                        <Text fw={500}>{c.name}</Text>
+                                        <Group gap={4}>
+                                            <Text size="xs" c="dimmed">
+                                                #{c.sort_order}
+                                            </Text>
+                                            <ActionIcon
+                                                size="sm"
+                                                variant="subtle"
+                                                color="gray"
+                                                aria-label={`Edit ${c.name}`}
+                                                onClick={() => startEditing(c)}
+                                            >
+                                                <IconPencil size={14} />
+                                            </ActionIcon>
+                                        </Group>
+                                    </Group>
+                                    <Text size="xs" c="dimmed" ff="monospace">
+                                        {c.slug}
                                     </Text>
-                                )}
-                            </Stack>
+                                    {c.event_day && (
+                                        <Badge size="xs" variant="light" color="yellow" tt="capitalize">
+                                            {c.event_day}
+                                        </Badge>
+                                    )}
+                                    {c.description && (
+                                        <Text size="xs" c="dimmed">
+                                            {c.description}
+                                        </Text>
+                                    )}
+                                </Stack>
+                            )}
                         </Paper>
                     ))}
                 </SimpleGrid>

--- a/src/app/dashboard/photos/page.tsx
+++ b/src/app/dashboard/photos/page.tsx
@@ -94,6 +94,8 @@ export default function PhotosModerationPage() {
             if (!res.ok) throw new Error("Update failed");
             setPhotos((prev) => prev.filter((p) => p.id !== id));
             fetchCounts();
+            // Tell the dashboard layout to refresh the Photos-tab pending badge
+            window.dispatchEvent(new CustomEvent("wedding:photos-moderated"));
         } catch (err) {
             setError(err instanceof Error ? err.message : "Failed to update photo");
         }

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
     Container,
     Title,
@@ -8,7 +9,6 @@ import {
     Tabs,
     Stack,
     Box,
-    TextInput,
     Button,
     Alert,
     Group,
@@ -35,7 +35,18 @@ interface GalleryPhoto {
 
 const FALLBACK_ASPECT = { width: 4, height: 3 };
 
+// useSearchParams requires a Suspense boundary in App Router client pages.
 export default function GalleryPage() {
+    return (
+        <Suspense fallback={null}>
+            <Gallery />
+        </Suspense>
+    );
+}
+
+function Gallery() {
+    const router = useRouter();
+    const searchParams = useSearchParams();
     const [photos, setPhotos] = useState<GalleryPhoto[]>([]);
     const [categories, setCategories] = useState<PhotoCategory[]>([]);
     const [activeCategory, setActiveCategory] = useState<string | null>(null);
@@ -43,17 +54,24 @@ export default function GalleryPage() {
     const [error, setError] = useState<string | null>(null);
     const [lightboxIndex, setLightboxIndex] = useState(-1);
     const [invitationCode, setInvitationCode] = useState<string>("");
-    const [codeInput, setCodeInput] = useState("");
-    const [codeError, setCodeError] = useState<string | null>(null);
     const [page, setPage] = useState(1);
     const [hasMore, setHasMore] = useState(true);
     const sentinelRef = useRef<HTMLDivElement | null>(null);
     const LIMIT = 40;
 
+    // Personal links carry ?code=XXXXXX. Store it (last link visited wins),
+    // then strip the param so copy-pasting the address doesn't share the code.
     useEffect(() => {
+        const urlCode = searchParams.get("code")?.trim().toUpperCase();
+        if (urlCode && /^[A-Z0-9]{6}$/.test(urlCode)) {
+            localStorage.setItem("invitation_code", urlCode);
+            setInvitationCode(urlCode);
+            router.replace("/gallery", { scroll: false });
+            return;
+        }
         const stored = localStorage.getItem("invitation_code");
         if (stored) setInvitationCode(stored);
-    }, []);
+    }, [searchParams, router]);
 
     const fetchPhotos = useCallback(
         async (category: string | null, pg: number) => {
@@ -117,16 +135,6 @@ export default function GalleryPage() {
         return () => observer.disconnect();
     }, [hasMore, loading, page, activeCategory, fetchPhotos]);
 
-    const handleCodeSubmit = () => {
-        if (codeInput.trim().length !== 6) {
-            setCodeError("Please enter your 6-character invitation code");
-            return;
-        }
-        localStorage.setItem("invitation_code", codeInput.trim().toUpperCase());
-        setInvitationCode(codeInput.trim().toUpperCase());
-        setCodeError(null);
-    };
-
     const lightboxSlides = photos.map((p) => ({
         src: p.src,
         width: p.width,
@@ -165,26 +173,10 @@ export default function GalleryPage() {
                     </Group>
 
                     {!invitationCode && (
-                        <Alert icon={<IconAlertCircle size={16} />} color="yellow" variant="light">
-                            <Text size="sm" mb="xs">
-                                Enter your invitation code to download full-resolution photos. Or click the
-                                link we sent you.
-                            </Text>
-                            <Group gap="xs">
-                                <TextInput
-                                    placeholder="e.g. ABC123"
-                                    value={codeInput}
-                                    onChange={(e) => setCodeInput(e.currentTarget.value.toUpperCase())}
-                                    maxLength={6}
-                                    size="xs"
-                                    error={codeError}
-                                    styles={{ input: { textTransform: "uppercase", width: 120 } }}
-                                />
-                                <Button size="xs" variant="filled" color="yellow" onClick={handleCodeSubmit}>
-                                    Save
-                                </Button>
-                            </Group>
-                        </Alert>
+                        <Text size="sm" c="dimmed">
+                            You&apos;re viewing the public gallery. If we sent you a personalised link,
+                            open it to unlock full-resolution downloads.
+                        </Text>
                     )}
 
                     {error && (
@@ -236,7 +228,7 @@ export default function GalleryPage() {
                 close={() => setLightboxIndex(-1)}
                 slides={lightboxSlides}
                 index={lightboxIndex}
-                plugins={[Download]}
+                plugins={invitationCode ? [Download] : []}
                 render={{
                     iconDownload: () => <IconDownload size={20} />,
                 }}

--- a/src/app/gallery/upload/page.tsx
+++ b/src/app/gallery/upload/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useRef, useCallback } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useRef, useCallback, useEffect } from "react";
+import Link from "next/link";
 import {
     Container,
     Title,
@@ -16,6 +16,7 @@ import {
     Paper,
     SimpleGrid,
     ActionIcon,
+    ThemeIcon,
 } from "@mantine/core";
 import { IconAlertCircle, IconUpload, IconX, IconCheck } from "@tabler/icons-react";
 import type { UploadUrlResponse } from "@/types/photos";
@@ -31,6 +32,12 @@ const MAX_FILES = 10;
 const MAX_SIZE = 20 * 1024 * 1024;
 const ALLOWED = ["image/jpeg", "image/png", "image/heic", "image/heif"];
 
+// "Matthew", "Matthew and Jim", "Matthew, Jim and Sarah" — no Oxford comma.
+function formatNames(names: string[]): string {
+    if (names.length <= 1) return names[0] ?? "";
+    return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+}
+
 // Some browsers report an empty MIME type for HEIC/HEIF files, so fall back
 // to the file extension. The result is also used as the S3 Content-Type,
 // which must match between the presign request and the actual upload.
@@ -43,7 +50,6 @@ function effectiveType(file: File): string {
 }
 
 export default function UploadPage() {
-    const router = useRouter();
     const [code, setCode] = useState<string>(() => {
         if (typeof window !== "undefined") {
             return localStorage.getItem("invitation_code") ?? "";
@@ -53,10 +59,33 @@ export default function UploadPage() {
     const [codeInput, setCodeInput] = useState(code);
     const [codeValidated, setCodeValidated] = useState(!!code);
     const [codeError, setCodeError] = useState<string | null>(null);
+    const [names, setNames] = useState<string[]>([]);
     const [files, setFiles] = useState<FileUploadState[]>([]);
     const [uploading, setUploading] = useState(false);
     const [allDone, setAllDone] = useState(false);
     const fileInputRef = useRef<HTMLInputElement>(null);
+
+    // A code inherited from localStorage (personal link or a previous visit)
+    // was never validated here — look it up to greet by name, and fall back
+    // to code entry if it's no longer valid.
+    useEffect(() => {
+        if (!code) return;
+        fetch("/api/photos/validate-code", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ code }),
+        })
+            .then((r) => r.json())
+            .then((data) => {
+                if (data.valid) {
+                    setNames(data.names ?? []);
+                } else {
+                    setCodeValidated(false);
+                    setNames([]);
+                }
+            })
+            .catch(() => {}); // greeting falls back to the code itself
+    }, [code]);
 
     const validateCode = async () => {
         const trimmed = codeInput.trim().toUpperCase();
@@ -76,6 +105,7 @@ export default function UploadPage() {
         }
         localStorage.setItem("invitation_code", trimmed);
         setCode(trimmed);
+        setNames(data.names ?? []);
         setCodeValidated(true);
         setCodeError(null);
     };
@@ -181,12 +211,22 @@ export default function UploadPage() {
             .filter(({ f }) => f.status === "pending");
         const results = await Promise.all(pending.map(({ f, i }) => uploadFile(i, f.file)));
         setUploading(false);
-        // Only celebrate and redirect if at least one file actually made it;
+        // Only celebrate if at least one file actually made it; otherwise the
         // failed files stay listed with their per-file error messages.
         if (results.some(Boolean)) {
             setAllDone(true);
-            setTimeout(() => router.push("/gallery"), 2000);
         }
+    };
+
+    // Back from the success screen: drop uploaded files, reset any failed
+    // ones so they can be retried.
+    const resetForMoreUploads = () => {
+        setFiles((prev) =>
+            prev
+                .filter((f) => f.status !== "done")
+                .map((f) => ({ file: f.file, progress: 0, status: "pending" as const }))
+        );
+        setAllDone(false);
     };
 
     return (
@@ -210,7 +250,51 @@ export default function UploadPage() {
                         </Text>
                     </Box>
 
-                    {!codeValidated ? (
+                    {allDone ? (
+                        <Paper p="xl" radius="md" withBorder>
+                            <Stack gap="md" align="center" style={{ textAlign: "center" }}>
+                                <ThemeIcon size={56} radius="xl" color="green" variant="light">
+                                    <IconCheck size={32} />
+                                </ThemeIcon>
+                                <Title
+                                    order={2}
+                                    style={{
+                                        fontFamily: "var(--font-playfair), serif",
+                                        fontWeight: 300,
+                                        color: "var(--gold-dark)",
+                                    }}
+                                >
+                                    Thank you!
+                                </Title>
+                                <Text c="dimmed">
+                                    Your {files.filter((f) => f.status === "done").length === 1
+                                        ? "photo has"
+                                        : "photos have"}{" "}
+                                    been uploaded. Matthew and Becca will review and approve them
+                                    shortly — they&apos;ll appear in the gallery once approved.
+                                </Text>
+                                {files.some((f) => f.status === "error") && (
+                                    <Alert
+                                        icon={<IconAlertCircle size={16} />}
+                                        color="orange"
+                                        variant="light"
+                                    >
+                                        {files.filter((f) => f.status === "error").length} photo
+                                        {files.filter((f) => f.status === "error").length !== 1 && "s"}{" "}
+                                        failed to upload — you can retry below.
+                                    </Alert>
+                                )}
+                                <Group gap="sm">
+                                    <Button color="yellow" onClick={resetForMoreUploads}>
+                                        Upload more photos
+                                    </Button>
+                                    <Button component={Link} href="/gallery" variant="light" color="yellow">
+                                        View the gallery
+                                    </Button>
+                                </Group>
+                            </Stack>
+                        </Paper>
+                    ) : !codeValidated ? (
                         <Paper p="lg" radius="md" withBorder>
                             <Stack gap="sm">
                                 <Text fw={500}>Your invitation code</Text>
@@ -234,7 +318,7 @@ export default function UploadPage() {
                         <Stack gap="md">
                             <Group justify="space-between" align="center">
                                 <Text size="sm" c="dimmed">
-                                    Uploading as <strong>{code}</strong>
+                                    Uploading as <strong>{names.length > 0 ? formatNames(names) : code}</strong>
                                 </Text>
                                 <Button size="xs" variant="subtle" color="gray" onClick={() => setCodeValidated(false)}>
                                     Change code
@@ -299,18 +383,11 @@ export default function UploadPage() {
                                 </SimpleGrid>
                             )}
 
-                            {allDone && (
-                                <Alert icon={<IconCheck size={16} />} color="green" variant="light">
-                                    Photos uploaded! Redirecting to gallery…
-                                </Alert>
-                            )}
-
                             {files.filter((f) => f.status === "pending").length > 0 && (
                                 <Button
                                     color="yellow"
                                     onClick={handleUpload}
                                     loading={uploading}
-                                    disabled={allDone}
                                 >
                                     Upload {files.filter((f) => f.status === "pending").length} photo
                                     {files.filter((f) => f.status === "pending").length !== 1 ? "s" : ""}

--- a/src/utils/db/archive.ts
+++ b/src/utils/db/archive.ts
@@ -1,4 +1,4 @@
-import { GetCommand, ScanCommand } from "@aws-sdk/lib-dynamodb";
+import { GetCommand, QueryCommand, ScanCommand } from "@aws-sdk/lib-dynamodb";
 import { docClient, ARCHIVE_TABLE } from "./dynamo";
 
 // The archive table holds the frozen post-wedding dataset (~141 items):
@@ -46,7 +46,6 @@ export interface ArchiveSummary {
     invitations: { total: number; sent: number };
     rsvps: { total: number; received: number; accepted: number; declined: number };
     guests: { total: number; coming: number; notComing: number; undecided: number };
-    villa: { stayingYes: number; stayingNo: number; undecided: number };
 }
 
 export interface InvitationCodeSummary {
@@ -64,6 +63,33 @@ export async function isValidInvitationCode(code: string): Promise<boolean> {
         })
     );
     return result.Item !== undefined;
+}
+
+// First names of the invitees behind a code, or null when the code doesn't
+// exist. Returning names behind a valid code is fine — the code is the
+// guest's credential.
+export async function getInviteesByCode(code: string): Promise<string[] | null> {
+    const codeResult = await docClient.send(
+        new GetCommand({
+            TableName: ARCHIVE_TABLE,
+            Key: { PK: `CODE#${code}`, SK: "META" },
+        })
+    );
+    const codeItem = codeResult.Item as CodeItem | undefined;
+    if (!codeItem) return null;
+
+    const result = await docClient.send(
+        new QueryCommand({
+            TableName: ARCHIVE_TABLE,
+            KeyConditionExpression: "PK = :pk AND begins_with(SK, :sk)",
+            ExpressionAttributeValues: {
+                ":pk": `INVITATION#${codeItem.invitation_id}`,
+                ":sk": "INVITEE#",
+            },
+        })
+    );
+    const invitees = (result.Items ?? []) as InviteeItem[];
+    return invitees.map((i) => i.first_name).sort((a, b) => a.localeCompare(b));
 }
 
 async function scanArchive(): Promise<ArchiveItem[]> {
@@ -102,11 +128,6 @@ export async function getArchiveSummary(): Promise<ArchiveSummary> {
             coming: invitees.filter((g) => g.coming === true).length,
             notComing: invitees.filter((g) => g.coming === false).length,
             undecided: invitees.filter((g) => g.coming === null).length,
-        },
-        villa: {
-            stayingYes: rsvps.filter((r) => r.staying_villa === true).length,
-            stayingNo: rsvps.filter((r) => r.staying_villa === false).length,
-            undecided: rsvps.filter((r) => r.staying_villa === null).length,
         },
     };
 }

--- a/src/utils/db/categories.ts
+++ b/src/utils/db/categories.ts
@@ -1,4 +1,5 @@
-import { PutCommand, ScanCommand } from "@aws-sdk/lib-dynamodb";
+import { PutCommand, ScanCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
 import { randomUUID } from "crypto";
 import { docClient, CATEGORIES_TABLE } from "./dynamo";
 
@@ -33,6 +34,60 @@ export interface CreateCategoryInput {
     description: string | null;
     event_day: "friday" | "saturday" | "sunday" | null;
     sort_order: number;
+}
+
+export interface UpdateCategoryInput {
+    name?: string;
+    description?: string | null;
+    sort_order?: number;
+}
+
+// Display-field updates only — slug is the public URL/filter key and stays
+// immutable. Returns the updated item, or null when no category has that id.
+export async function updateCategory(
+    id: string,
+    fields: UpdateCategoryInput
+): Promise<CategoryItem | null> {
+    const sets: string[] = [];
+    const names: Record<string, string> = {};
+    const values: Record<string, unknown> = {};
+
+    if (fields.name !== undefined) {
+        sets.push("#name = :name");
+        names["#name"] = "name";
+        values[":name"] = fields.name;
+    }
+    if (fields.description !== undefined) {
+        sets.push("#description = :description");
+        names["#description"] = "description";
+        values[":description"] = fields.description;
+    }
+    if (fields.sort_order !== undefined) {
+        sets.push("#sort_order = :sort_order");
+        names["#sort_order"] = "sort_order";
+        values[":sort_order"] = fields.sort_order;
+    }
+    if (sets.length === 0) {
+        throw new Error("updateCategory called with no fields to update");
+    }
+
+    try {
+        const result = await docClient.send(
+            new UpdateCommand({
+                TableName: CATEGORIES_TABLE,
+                Key: { id },
+                UpdateExpression: `SET ${sets.join(", ")}`,
+                ConditionExpression: "attribute_exists(id)",
+                ExpressionAttributeNames: names,
+                ExpressionAttributeValues: values,
+                ReturnValues: "ALL_NEW",
+            })
+        );
+        return result.Attributes as CategoryItem;
+    } catch (error) {
+        if (error instanceof ConditionalCheckFailedException) return null;
+        throw error;
+    }
 }
 
 // Slug uniqueness is enforced by a pre-check rather than a constraint; the

--- a/src/utils/db/photos.ts
+++ b/src/utils/db/photos.ts
@@ -83,6 +83,37 @@ export async function listPhotosByStatus(status: Photo["status"]): Promise<Photo
     return photos;
 }
 
+// Count of photos with the given status via the byStatus GSI, optionally
+// restricted to uploads after the given ISO timestamp. Select: COUNT — no
+// items are materialised.
+export async function countPhotosByStatus(
+    status: Photo["status"],
+    sinceIso?: string
+): Promise<number> {
+    let count = 0;
+    let lastKey: Record<string, unknown> | undefined;
+    do {
+        const result = await docClient.send(
+            new QueryCommand({
+                TableName: PHOTOS_TABLE,
+                IndexName: "byStatus",
+                KeyConditionExpression: sinceIso
+                    ? "#status = :status AND uploaded_at > :since"
+                    : "#status = :status",
+                ExpressionAttributeNames: { "#status": "status" },
+                ExpressionAttributeValues: sinceIso
+                    ? { ":status": status, ":since": sinceIso }
+                    : { ":status": status },
+                Select: "COUNT",
+                ExclusiveStartKey: lastKey,
+            })
+        );
+        count += result.Count ?? 0;
+        lastKey = result.LastEvaluatedKey;
+    } while (lastKey);
+    return count;
+}
+
 export interface ModerationUpdate {
     status: "approved" | "rejected";
     categoryId?: string | null;


### PR DESCRIPTION
Closes #176 — all eight items plus the follow-up comment (public-subset notice for codeless visitors).

## Guest-facing

- **Personal links work end-to-end**: `/gallery?code=XXXXXX` validates the format, stores the code in `localStorage` (last link visited wins), uses it for the session, and strips the param from the URL bar so copy-pasted addresses don't leak codes. Dashboard copy-link now builds `/gallery?code=` instead of the non-existent `/photos?code=`.
- **Named upload greeting**: `POST /api/photos/validate-code` now returns the invitee first names behind a valid code (new `getInviteesByCode` in the archive repo: GetItem on the code, Query on the invitation's `INVITEE#` items). The upload page shows "Uploading as Matthew, Jim and Sarah" and falls back to the raw code if the lookup fails. Codes inherited from localStorage are re-validated on mount, so stale codes drop back to code entry.
- **Real upload success state**: no more auto-redirect into a gallery where pending photos are invisible. Guests get a thank-you screen explaining Matthew and Becca will review and approve shortly, with upload-more and gallery buttons. Failed files survive the success screen and can be retried.
- **Code banner gone**: the yellow code-entry banner is replaced by a one-line note that codeless visitors are seeing the public subset and should use their personalised link. The lightbox download button is hidden when no code is present.

## Dashboard

- **Overview leads with live gallery data** from the new auth-required `GET /api/dashboard/photo-summary`: pending approvals (prominent, amber when non-zero, links to moderation), status totals, uploads in the last 7 days, and per-category approved counts (statuses use `Select: COUNT` on the `byStatus` GSI; approved photos are materialised once for the category breakdown). RSVP data shrinks to a compact history card; villa stats removed end-to-end.
- **Pending badge on the Photos tab**, fetched once per dashboard visit in the layout; hidden at zero.
- **Category renaming**: `PATCH /api/gallery/categories/[id]` (auth-required) for `name`/`description`/`sort_order` with an `attribute_exists(id)` condition; slug changes are rejected explicitly. Inline edit UI on the categories management page.

## Housekeeping

- `src/app/dashboard/invitations/changes.md` deleted (transcribed into #176).
- README gallery status line updated.

## Testing

- New route tests for `validate-code`, `photo-summary`, and category `PATCH` (28 new assertions); full suite 95 passed, `tsc --noEmit` and `eslint` clean.