### PR TITLE
Keep admins signed in with a Cognito refresh-token flow

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -55,7 +55,9 @@ This document outlines the security measures implemented in the wedding website.
 ### AWS Cognito Authentication
 
 - **Route Protection**: Middleware-based protection for admin routes (`/dashboard/*`)
-- **Session Management**: JWT tokens stored in cookies, validated on each request
+- **Session Management**: JWT tokens stored in httpOnly cookies, validated on each request
+- **Session Refresh**: the ID-token session cookie lives 1 hour; middleware transparently renews it from a 30-day httpOnly refresh-token cookie (Cognito `REFRESH_TOKEN_AUTH`), so admins stay signed in for up to 30 days without re-entering credentials
+- **Revocation**: logout calls Cognito `GlobalSignOut`, which revokes the refresh token server-side — a leaked refresh cookie is useless after an explicit logout
 - **Challenge Handling**: `NEW_PASSWORD_REQUIRED` challenge handled at login — forced password change on first login
 
 **Authentication Flow:**
@@ -63,9 +65,9 @@ This document outlines the security measures implemented in the wedding website.
 2. API calls Cognito `InitiateAuthCommand`
 3. If `NEW_PASSWORD_REQUIRED` challenge returned, user is prompted for new password
 4. On success, Cognito returns access/ID/refresh tokens
-5. Tokens stored in browser cookies
-6. Middleware validates token on protected routes
-7. Unauthenticated users redirected to `/login`
+5. Tokens stored in httpOnly browser cookies (session + access for 1 hour, refresh token + immutable username for 30 days)
+6. Middleware validates the session on protected routes and APIs; when it has expired it mints fresh tokens from the refresh cookie before the request proceeds
+7. Users are redirected to `/login` only when no valid session exists and the refresh token is missing, expired, or revoked
 
 **Protected Routes:**
 - `/dashboard/*` — Requires authenticated session

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { middleware } from "../middleware";
+
+const mockJwtVerify = vi.fn();
+const mockRefreshTokens = vi.fn();
+
+vi.mock("jose", () => ({
+    jwtVerify: (...args: unknown[]) => mockJwtVerify(...args),
+    createRemoteJWKSet: () => () => ({}),
+    decodeJwt: () => ({}),
+}));
+
+vi.mock("@/utils/auth/refresh", () => ({
+    refreshTokens: (...args: unknown[]) => mockRefreshTokens(...args),
+}));
+
+const savedEnv: Record<string, string | undefined> = {};
+const ENV = { COGNITO_CLIENT_ID: "client-123", COGNITO_USER_POOL_ID: "eu-west-1_test" };
+
+function makeRequest(path: string, cookies: Record<string, string> = {}): NextRequest {
+    const cookieHeader = Object.entries(cookies)
+        .map(([k, v]) => `${k}=${v}`)
+        .join("; ");
+    return new NextRequest(`http://localhost${path}`, {
+        headers: cookieHeader ? { cookie: cookieHeader } : {},
+    });
+}
+
+const refreshCookies = { wedding_refresh: "refresh-tok", wedding_refresh_user: "uuid-1" };
+const freshTokens = { idToken: "new-id", accessToken: "new-access", expiresIn: 3600 };
+
+describe("middleware", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        for (const [k, v] of Object.entries(ENV)) {
+            savedEnv[k] = process.env[k];
+            process.env[k] = v;
+        }
+        // Each test gets unique refresh-token values where dedup matters;
+        // jwtVerify rejects (expired/invalid session) unless overridden.
+        mockJwtVerify.mockRejectedValue(new Error("expired"));
+    });
+    afterEach(() => {
+        for (const k of Object.keys(ENV)) {
+            if (savedEnv[k] === undefined) delete process.env[k];
+            else process.env[k] = savedEnv[k];
+        }
+    });
+
+    it("redirects /dashboard to /login with no cookies at all", async () => {
+        const res = await middleware(makeRequest("/dashboard"));
+        expect(res.status).toBe(307);
+        expect(res.headers.get("location")).toContain("/login?redirectedFrom=%2Fdashboard");
+        expect(mockRefreshTokens).not.toHaveBeenCalled();
+    });
+
+    it("passes through /dashboard with a valid session", async () => {
+        mockJwtVerify.mockResolvedValue({ payload: {} });
+        const res = await middleware(makeRequest("/dashboard", { wedding_session: "valid" }));
+        expect(res.status).toBe(200);
+        expect(mockRefreshTokens).not.toHaveBeenCalled();
+    });
+
+    it("refreshes an expired session and sets new cookies", async () => {
+        mockRefreshTokens.mockResolvedValue(freshTokens);
+        const req = makeRequest("/dashboard", { wedding_session: "expired", ...refreshCookies });
+        const res = await middleware(req);
+
+        expect(res.status).toBe(200);
+        expect(mockRefreshTokens).toHaveBeenCalledWith("refresh-tok", "uuid-1");
+        expect(res.cookies.get("wedding_session")?.value).toBe("new-id");
+        expect(res.cookies.get("wedding_access")?.value).toBe("new-access");
+        // The current request's handlers must see the fresh session too
+        expect(req.cookies.get("wedding_session")?.value).toBe("new-id");
+    });
+
+    it("redirects to /login when the refresh token is rejected", async () => {
+        mockRefreshTokens.mockResolvedValue(null);
+        const res = await middleware(
+            makeRequest("/dashboard", { wedding_refresh: "revoked-tok", wedding_refresh_user: "uuid-1" })
+        );
+        expect(res.status).toBe(307);
+        expect(res.headers.get("location")).toContain("/login");
+    });
+
+    it("redirects an authenticated user away from /login", async () => {
+        mockJwtVerify.mockResolvedValue({ payload: {} });
+        const res = await middleware(makeRequest("/login", { wedding_session: "valid" }));
+        expect(res.status).toBe(307);
+        expect(res.headers.get("location")).toContain("/dashboard");
+    });
+
+    it("lets unauthenticated /api requests pass through without refresh attempts", async () => {
+        const res = await middleware(makeRequest("/api/photos"));
+        expect(res.status).toBe(200);
+        expect(mockRefreshTokens).not.toHaveBeenCalled();
+    });
+
+    it("refreshes on /api requests and sets cookies for the stale-tab case", async () => {
+        mockRefreshTokens.mockResolvedValue(freshTokens);
+        const res = await middleware(
+            makeRequest("/api/dashboard/summary", { wedding_refresh: "api-tok", wedding_refresh_user: "uuid-1" })
+        );
+        expect(res.status).toBe(200);
+        expect(res.cookies.get("wedding_session")?.value).toBe("new-id");
+    });
+
+    it("de-duplicates concurrent refreshes for the same refresh token", async () => {
+        let resolveRefresh: (v: typeof freshTokens) => void;
+        mockRefreshTokens.mockReturnValue(new Promise((r) => (resolveRefresh = r)));
+
+        const cookies = { wedding_refresh: "burst-tok", wedding_refresh_user: "uuid-1" };
+        const inflight = Promise.all([
+            middleware(makeRequest("/api/dashboard/summary", cookies)),
+            middleware(makeRequest("/api/dashboard/photo-summary", cookies)),
+            middleware(makeRequest("/dashboard", cookies)),
+        ]);
+        resolveRefresh!(freshTokens);
+        const results = await inflight;
+
+        expect(mockRefreshTokens).toHaveBeenCalledTimes(1);
+        for (const res of results) {
+            expect(res.status).toBe(200);
+            expect(res.cookies.get("wedding_session")?.value).toBe("new-id");
+        }
+    });
+
+    it("does not cache failed refreshes", async () => {
+        mockRefreshTokens.mockResolvedValueOnce(null).mockResolvedValueOnce(freshTokens);
+        const cookies = { wedding_refresh: "flaky-tok", wedding_refresh_user: "uuid-1" };
+
+        const first = await middleware(makeRequest("/dashboard", cookies));
+        expect(first.status).toBe(307);
+
+        const second = await middleware(makeRequest("/dashboard", cookies));
+        expect(second.status).toBe(200);
+        expect(mockRefreshTokens).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -137,4 +137,32 @@ describe("middleware", () => {
         expect(second.status).toBe(200);
         expect(mockRefreshTokens).toHaveBeenCalledTimes(2);
     });
+
+    it("does not let a failed attempt's stale eviction timer evict a later cached success", async () => {
+        vi.useFakeTimers();
+        try {
+            const cookies = { wedding_refresh: "stale-timer-tok", wedding_refresh_user: "uuid-1" };
+
+            // t=0: refresh fails — the entry is dropped immediately, but its
+            // 30s eviction timer stays scheduled.
+            mockRefreshTokens.mockResolvedValueOnce(null);
+            const first = await middleware(makeRequest("/dashboard", cookies));
+            expect(first.status).toBe(307);
+
+            // t=5s: a retry succeeds and is cached (should live until t=35s).
+            vi.advanceTimersByTime(5000);
+            mockRefreshTokens.mockResolvedValueOnce(freshTokens);
+            const second = await middleware(makeRequest("/dashboard", cookies));
+            expect(second.status).toBe(200);
+
+            // t=30s: the failed attempt's timer fires — it must not evict the
+            // success cached at t=5s, so this request hits the cache.
+            vi.advanceTimersByTime(25001);
+            const third = await middleware(makeRequest("/dashboard", cookies));
+            expect(third.status).toBe(200);
+            expect(mockRefreshTokens).toHaveBeenCalledTimes(2);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
 });

--- a/src/app/api/auth/login/__tests__/route.test.ts
+++ b/src/app/api/auth/login/__tests__/route.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+
+const mockSignIn = vi.fn();
+const mockCompleteNewPassword = vi.fn();
+
+vi.mock("@/utils/auth/cognito", () => ({
+    signIn: (...args: unknown[]) => mockSignIn(...args),
+    completeNewPassword: (...args: unknown[]) => mockCompleteNewPassword(...args),
+    isNewPasswordChallenge: (r: Record<string, unknown>) => "challenge" in r,
+}));
+
+vi.mock("@/utils/logger", () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+}));
+
+// An unsigned JWT whose payload carries the immutable Cognito username.
+function fakeIdToken(payload: Record<string, unknown>): string {
+    const b64 = (o: object) => Buffer.from(JSON.stringify(o)).toString("base64url");
+    return `${b64({ alg: "none" })}.${b64(payload)}.`;
+}
+
+const tokens = {
+    idToken: fakeIdToken({ "cognito:username": "uuid-1234", email: "admin@test.com" }),
+    accessToken: "access-token",
+    refreshToken: "refresh-token",
+    expiresIn: 3600,
+};
+
+function makeRequest(body: unknown): NextRequest {
+    return new NextRequest("http://localhost/api/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+describe("POST /api/auth/login", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("sets session, access, refresh, and username cookies on login", async () => {
+        mockSignIn.mockResolvedValue(tokens);
+        const res = await POST(makeRequest({ email: "admin@test.com", password: "pw" }));
+        expect(res.status).toBe(200);
+
+        expect(res.cookies.get("wedding_session")?.value).toBe(tokens.idToken);
+        expect(res.cookies.get("wedding_access")?.value).toBe("access-token");
+        expect(res.cookies.get("wedding_refresh")?.value).toBe("refresh-token");
+        // The immutable username from the ID token, not the login email
+        expect(res.cookies.get("wedding_refresh_user")?.value).toBe("uuid-1234");
+
+        // Refresh cookies outlive the 1-hour session
+        expect(res.cookies.get("wedding_refresh")?.maxAge).toBe(30 * 24 * 60 * 60);
+        expect(res.cookies.get("wedding_session")?.maxAge).toBe(3600);
+        expect(res.cookies.get("wedding_refresh")?.httpOnly).toBe(true);
+    });
+
+    it("falls back to the email when the ID token has no cognito:username", async () => {
+        mockSignIn.mockResolvedValue({ ...tokens, idToken: fakeIdToken({ email: "admin@test.com" }) });
+        const res = await POST(makeRequest({ email: "admin@test.com", password: "pw" }));
+        expect(res.cookies.get("wedding_refresh_user")?.value).toBe("admin@test.com");
+    });
+
+    it("sets the same cookies after a NEW_PASSWORD_REQUIRED completion", async () => {
+        mockCompleteNewPassword.mockResolvedValue(tokens);
+        const res = await POST(
+            makeRequest({ email: "admin@test.com", password: "pw", newPassword: "new", session: "sess" })
+        );
+        expect(res.status).toBe(200);
+        expect(res.cookies.get("wedding_refresh")?.value).toBe("refresh-token");
+        expect(res.cookies.get("wedding_refresh_user")?.value).toBe("uuid-1234");
+    });
+
+    it("returns the challenge without cookies when a new password is required", async () => {
+        mockSignIn.mockResolvedValue({ challenge: "NEW_PASSWORD_REQUIRED", session: "s", username: "u" });
+        const res = await POST(makeRequest({ email: "admin@test.com", password: "pw" }));
+        const data = await res.json();
+        expect(data.challenge).toBe("NEW_PASSWORD_REQUIRED");
+        expect(res.cookies.get("wedding_refresh")).toBeUndefined();
+    });
+
+    it("rejects missing credentials", async () => {
+        const res = await POST(makeRequest({ email: "admin@test.com" }));
+        expect(res.status).toBe(400);
+    });
+
+    it("returns 401 when Cognito rejects the credentials", async () => {
+        mockSignIn.mockRejectedValue(new Error("Incorrect username or password."));
+        const res = await POST(makeRequest({ email: "admin@test.com", password: "wrong" }));
+        expect(res.status).toBe(401);
+    });
+});

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,7 +1,25 @@
 import { NextRequest, NextResponse } from "next/server";
-import { signIn, completeNewPassword, isNewPasswordChallenge } from "@/utils/auth/cognito";
-import { setSessionCookie, setAccessTokenCookie } from "@/utils/auth/session";
+import { decodeJwt } from "jose";
+import { signIn, completeNewPassword, isNewPasswordChallenge, type CognitoTokens } from "@/utils/auth/cognito";
+import {
+    setSessionCookie,
+    setAccessTokenCookie,
+    setRefreshTokenCookie,
+    setRefreshUsernameCookie,
+} from "@/utils/auth/session";
 import * as logger from "@/utils/logger";
+
+// The refresh flow's SECRET_HASH needs the immutable Cognito username (a
+// UUID when email is an alias), which only lives in the ID token we just
+// minted — capture it now, alongside the refresh token.
+function setAuthCookies(response: NextResponse, tokens: CognitoTokens, email: string) {
+    response.cookies.set(setSessionCookie(tokens.idToken, tokens.expiresIn));
+    response.cookies.set(setAccessTokenCookie(tokens.accessToken, tokens.expiresIn));
+
+    const username = (decodeJwt(tokens.idToken)["cognito:username"] as string | undefined) ?? email;
+    response.cookies.set(setRefreshTokenCookie(tokens.refreshToken));
+    response.cookies.set(setRefreshUsernameCookie(username));
+}
 
 export async function POST(request: NextRequest) {
     let email: string | undefined;
@@ -18,8 +36,7 @@ export async function POST(request: NextRequest) {
         if (newPassword && session) {
             const tokens = await completeNewPassword(email as string, newPassword as string, session as string);
             const response = NextResponse.json({ ok: true });
-            response.cookies.set(setSessionCookie(tokens.idToken, tokens.expiresIn));
-            response.cookies.set(setAccessTokenCookie(tokens.accessToken, tokens.expiresIn));
+            setAuthCookies(response, tokens, email as string);
             return response;
         }
 
@@ -36,8 +53,7 @@ export async function POST(request: NextRequest) {
 
         logger.info("POST /api/auth/login", "Login successful", { email });
         const response = NextResponse.json({ ok: true });
-        response.cookies.set(setSessionCookie(result.idToken, result.expiresIn));
-        response.cookies.set(setAccessTokenCookie(result.accessToken, result.expiresIn));
+        setAuthCookies(response, result, email as string);
 
         return response;
     } catch (err) {

--- a/src/app/api/auth/logout/__tests__/route.test.ts
+++ b/src/app/api/auth/logout/__tests__/route.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { POST } from "../route";
+
+const mockSignOut = vi.fn();
+const mockGetAccessToken = vi.fn();
+
+vi.mock("@/utils/auth/cognito", () => ({
+    signOut: (...args: unknown[]) => mockSignOut(...args),
+}));
+
+vi.mock("@/utils/auth/session", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@/utils/auth/session")>();
+    return {
+        ...actual,
+        getAccessToken: (...args: unknown[]) => mockGetAccessToken(...args),
+    };
+});
+
+describe("POST /api/auth/logout", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetAccessToken.mockResolvedValue("access-token");
+    });
+
+    it("clears all four auth cookies", async () => {
+        const res = await POST();
+        expect(res.status).toBe(200);
+        for (const name of ["wedding_session", "wedding_access", "wedding_refresh", "wedding_refresh_user"]) {
+            const cookie = res.cookies.get(name);
+            expect(cookie?.value).toBe("");
+            expect(cookie?.maxAge).toBe(0);
+        }
+    });
+
+    it("revokes the Cognito session via GlobalSignOut", async () => {
+        await POST();
+        expect(mockSignOut).toHaveBeenCalledWith("access-token");
+    });
+
+    it("still clears cookies when GlobalSignOut fails", async () => {
+        mockSignOut.mockRejectedValue(new Error("boom"));
+        const res = await POST();
+        expect(res.status).toBe(200);
+        expect(res.cookies.get("wedding_refresh")?.maxAge).toBe(0);
+    });
+});

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,5 +1,11 @@
 import { NextResponse } from "next/server";
-import { clearSessionCookie, clearAccessTokenCookie, getAccessToken } from "@/utils/auth/session";
+import {
+    clearSessionCookie,
+    clearAccessTokenCookie,
+    clearRefreshTokenCookie,
+    clearRefreshUsernameCookie,
+    getAccessToken,
+} from "@/utils/auth/session";
 import { signOut } from "@/utils/auth/cognito";
 
 export async function POST() {
@@ -7,6 +13,8 @@ export async function POST() {
 
     if (accessToken) {
         try {
+            // GlobalSignOut also revokes the refresh token server-side, so a
+            // stolen wedding_refresh cookie is dead after an explicit logout.
             await signOut(accessToken);
         } catch {
             // GlobalSignOut failure should not block local session clearing
@@ -16,5 +24,7 @@ export async function POST() {
     const response = NextResponse.json({ ok: true });
     response.cookies.set(clearSessionCookie());
     response.cookies.set(clearAccessTokenCookie());
+    response.cookies.set(clearRefreshTokenCookie());
+    response.cookies.set(clearRefreshUsernameCookie());
     return response;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -43,14 +43,23 @@ function dedupedRefresh(refreshToken: string, username: string): Promise<Refresh
     const existing = inflightRefreshes.get(refreshToken);
     if (existing) return existing;
 
+    // Evictions check identity, not just the key: the same token value recurs
+    // across bursts for the whole 30-day session, and a stale timer from an
+    // earlier (failed) attempt must not evict a newer cached entry early.
     const promise = refreshTokens(refreshToken, username).then((tokens) => {
         // Keep successes for the TTL; drop failures so a transient network
         // error doesn't pin "not authenticated" for 30 seconds.
-        if (!tokens) inflightRefreshes.delete(refreshToken);
+        if (!tokens && inflightRefreshes.get(refreshToken) === promise) {
+            inflightRefreshes.delete(refreshToken);
+        }
         return tokens;
     });
     inflightRefreshes.set(refreshToken, promise);
-    setTimeout(() => inflightRefreshes.delete(refreshToken), REFRESH_REUSE_TTL_MS);
+    setTimeout(() => {
+        if (inflightRefreshes.get(refreshToken) === promise) {
+            inflightRefreshes.delete(refreshToken);
+        }
+    }, REFRESH_REUSE_TTL_MS);
     return promise;
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { jwtVerify } from "jose";
 import { getJWKS, getJWTIssuer } from "@/utils/auth/jwks";
-import { refreshTokens } from "@/utils/auth/refresh";
+import { refreshTokens, type RefreshedTokens } from "@/utils/auth/refresh";
 import {
     SESSION_COOKIE,
     ACCESS_TOKEN_COOKIE,
@@ -30,6 +30,30 @@ async function isAuthenticated(request: NextRequest): Promise<boolean> {
 
 type CookieToSet = ReturnType<typeof setSessionCookie>;
 
+// De-duplicate refreshes: a stale page load fires several requests at once,
+// all carrying the same refresh token, and none of them can see the rotated
+// cookies until a response reaches the browser. Sharing one in-flight
+// promise (kept briefly after success for stragglers) means one Cognito
+// call per burst — and keeps this safe if refresh-token rotation is ever
+// enabled on the app client (it's off today, the Cognito default).
+const inflightRefreshes = new Map<string, Promise<RefreshedTokens | null>>();
+const REFRESH_REUSE_TTL_MS = 30_000;
+
+function dedupedRefresh(refreshToken: string, username: string): Promise<RefreshedTokens | null> {
+    const existing = inflightRefreshes.get(refreshToken);
+    if (existing) return existing;
+
+    const promise = refreshTokens(refreshToken, username).then((tokens) => {
+        // Keep successes for the TTL; drop failures so a transient network
+        // error doesn't pin "not authenticated" for 30 seconds.
+        if (!tokens) inflightRefreshes.delete(refreshToken);
+        return tokens;
+    });
+    inflightRefreshes.set(refreshToken, promise);
+    setTimeout(() => inflightRefreshes.delete(refreshToken), REFRESH_REUSE_TTL_MS);
+    return promise;
+}
+
 // When the 1-hour session has lapsed but the 30-day refresh token is still
 // good, mint fresh tokens. Returns the cookies to attach to the response, or
 // null when refresh isn't possible — the caller falls through to login.
@@ -38,7 +62,7 @@ async function tryRefresh(request: NextRequest): Promise<CookieToSet[] | null> {
     const username = request.cookies.get(REFRESH_USERNAME_COOKIE)?.value;
     if (!refreshToken || !username) return null;
 
-    const tokens = await refreshTokens(refreshToken, username);
+    const tokens = await dedupedRefresh(refreshToken, username);
     if (!tokens) return null;
 
     // Make the fresh session visible to this request's own handlers (route

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,19 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { jwtVerify } from "jose";
 import { getJWKS, getJWTIssuer } from "@/utils/auth/jwks";
+import { refreshTokens } from "@/utils/auth/refresh";
+import {
+    SESSION_COOKIE,
+    ACCESS_TOKEN_COOKIE,
+    REFRESH_COOKIE,
+    REFRESH_USERNAME_COOKIE,
+    setSessionCookie,
+    setAccessTokenCookie,
+    setRefreshTokenCookie,
+} from "@/utils/auth/session";
 
 async function isAuthenticated(request: NextRequest): Promise<boolean> {
-    const token = request.cookies.get("wedding_session")?.value;
+    const token = request.cookies.get(SESSION_COOKIE)?.value;
     if (!token) return false;
 
     const audience = process.env.COGNITO_CLIENT_ID;
@@ -18,24 +28,66 @@ async function isAuthenticated(request: NextRequest): Promise<boolean> {
     }
 }
 
+type CookieToSet = ReturnType<typeof setSessionCookie>;
+
+// When the 1-hour session has lapsed but the 30-day refresh token is still
+// good, mint fresh tokens. Returns the cookies to attach to the response, or
+// null when refresh isn't possible — the caller falls through to login.
+async function tryRefresh(request: NextRequest): Promise<CookieToSet[] | null> {
+    const refreshToken = request.cookies.get(REFRESH_COOKIE)?.value;
+    const username = request.cookies.get(REFRESH_USERNAME_COOKIE)?.value;
+    if (!refreshToken || !username) return null;
+
+    const tokens = await refreshTokens(refreshToken, username);
+    if (!tokens) return null;
+
+    // Make the fresh session visible to this request's own handlers (route
+    // handlers, server components) — the browser only gets the new cookies
+    // with the response, after the handlers have already run.
+    request.cookies.set(SESSION_COOKIE, tokens.idToken);
+    request.cookies.set(ACCESS_TOKEN_COOKIE, tokens.accessToken);
+
+    return [
+        setSessionCookie(tokens.idToken, tokens.expiresIn),
+        setAccessTokenCookie(tokens.accessToken, tokens.expiresIn),
+        // Only present when the pool rotates refresh tokens.
+        ...(tokens.refreshToken ? [setRefreshTokenCookie(tokens.refreshToken)] : []),
+    ];
+}
+
 export async function middleware(request: NextRequest) {
-    const authenticated = await isAuthenticated(request);
+    let authenticated = await isAuthenticated(request);
 
-    if (request.nextUrl.pathname.startsWith("/dashboard")) {
-        if (!authenticated) {
-            const redirectUrl = new URL("/login", request.url);
-            redirectUrl.searchParams.set("redirectedFrom", request.nextUrl.pathname);
-            return NextResponse.redirect(redirectUrl);
-        }
+    let refreshedCookies: CookieToSet[] | null = null;
+    if (!authenticated) {
+        refreshedCookies = await tryRefresh(request);
+        authenticated = refreshedCookies !== null;
     }
 
-    if (request.nextUrl.pathname === "/login" && authenticated) {
-        return NextResponse.redirect(new URL("/dashboard", request.url));
+    const withCookies = (response: NextResponse) => {
+        refreshedCookies?.forEach((cookie) => response.cookies.set(cookie));
+        return response;
+    };
+
+    const { pathname } = request.nextUrl;
+
+    if (pathname.startsWith("/dashboard") && !authenticated) {
+        const redirectUrl = new URL("/login", request.url);
+        redirectUrl.searchParams.set("redirectedFrom", pathname);
+        return NextResponse.redirect(redirectUrl);
     }
 
-    return NextResponse.next();
+    if (pathname === "/login" && authenticated) {
+        return withCookies(NextResponse.redirect(new URL("/dashboard", request.url)));
+    }
+
+    // `{ request }` forwards the mutated request cookies to the handlers.
+    return withCookies(NextResponse.next({ request }));
 }
 
 export const config = {
-    matcher: ["/dashboard/:path*", "/login"],
+    // /api is included so a stale tab's API calls (e.g. approving a photo
+    // after sitting open past the session expiry) refresh transparently
+    // instead of failing with a 401.
+    matcher: ["/dashboard/:path*", "/login", "/api/:path*"],
 };

--- a/src/utils/auth/__tests__/refresh.test.ts
+++ b/src/utils/auth/__tests__/refresh.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createHmac } from "node:crypto";
+import { refreshTokens, computeSecretHash } from "../refresh";
+
+const ENV_KEYS = ["COGNITO_CLIENT_ID", "COGNITO_CLIENT_SECRET", "AWS_ENDPOINT_URL", "AWS_REGION"] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+const mockFetch = vi.fn();
+
+describe("computeSecretHash", () => {
+    beforeEach(() => {
+        for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+        process.env.COGNITO_CLIENT_SECRET = "test-secret";
+    });
+    afterEach(() => {
+        for (const k of ENV_KEYS) {
+            if (savedEnv[k] === undefined) delete process.env[k];
+            else process.env[k] = savedEnv[k];
+        }
+    });
+
+    it("computes HMAC-SHA256(username + clientId) base64-encoded", async () => {
+        const expected = createHmac("sha256", "test-secret")
+            .update("user-uuid" + "client-123")
+            .digest("base64");
+        expect(await computeSecretHash("user-uuid", "client-123")).toBe(expected);
+    });
+
+    it("throws without COGNITO_CLIENT_SECRET", async () => {
+        delete process.env.COGNITO_CLIENT_SECRET;
+        await expect(computeSecretHash("u", "c")).rejects.toThrow("COGNITO_CLIENT_SECRET");
+    });
+});
+
+describe("refreshTokens", () => {
+    beforeEach(() => {
+        for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+        process.env.COGNITO_CLIENT_ID = "client-123";
+        process.env.COGNITO_CLIENT_SECRET = "test-secret";
+        delete process.env.AWS_ENDPOINT_URL;
+        vi.stubGlobal("fetch", mockFetch);
+        mockFetch.mockReset();
+    });
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        for (const k of ENV_KEYS) {
+            if (savedEnv[k] === undefined) delete process.env[k];
+            else process.env[k] = savedEnv[k];
+        }
+    });
+
+    it("exchanges a refresh token via REFRESH_TOKEN_AUTH", async () => {
+        mockFetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                AuthenticationResult: {
+                    IdToken: "new-id",
+                    AccessToken: "new-access",
+                    ExpiresIn: 3600,
+                },
+            }),
+        });
+
+        const result = await refreshTokens("refresh-tok", "user-uuid");
+        expect(result).toEqual({ idToken: "new-id", accessToken: "new-access", expiresIn: 3600 });
+
+        const [url, init] = mockFetch.mock.calls[0];
+        expect(url).toBe("https://cognito-idp.eu-west-1.amazonaws.com/");
+        expect(init.headers["X-Amz-Target"]).toBe("AWSCognitoIdentityProviderService.InitiateAuth");
+        const body = JSON.parse(init.body);
+        expect(body.AuthFlow).toBe("REFRESH_TOKEN_AUTH");
+        expect(body.AuthParameters.REFRESH_TOKEN).toBe("refresh-tok");
+        // SECRET_HASH is keyed on the immutable username, not the email
+        const expectedHash = createHmac("sha256", "test-secret")
+            .update("user-uuid" + "client-123")
+            .digest("base64");
+        expect(body.AuthParameters.SECRET_HASH).toBe(expectedHash);
+    });
+
+    it("includes a rotated refresh token when Cognito returns one", async () => {
+        mockFetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                AuthenticationResult: {
+                    IdToken: "id",
+                    AccessToken: "access",
+                    ExpiresIn: 3600,
+                    RefreshToken: "rotated",
+                },
+            }),
+        });
+        const result = await refreshTokens("old", "user-uuid");
+        expect(result?.refreshToken).toBe("rotated");
+    });
+
+    it("uses AWS_ENDPOINT_URL when set (LocalStack)", async () => {
+        process.env.AWS_ENDPOINT_URL = "http://localhost:4566";
+        mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+        await refreshTokens("tok", "user");
+        expect(mockFetch.mock.calls[0][0]).toBe("http://localhost:4566");
+    });
+
+    it("returns null when Cognito rejects the token", async () => {
+        mockFetch.mockResolvedValue({ ok: false, json: async () => ({ __type: "NotAuthorizedException" }) });
+        expect(await refreshTokens("revoked", "user-uuid")).toBeNull();
+    });
+
+    it("returns null on network failure", async () => {
+        mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+        expect(await refreshTokens("tok", "user-uuid")).toBeNull();
+    });
+
+    it("returns null when client env vars are missing", async () => {
+        delete process.env.COGNITO_CLIENT_ID;
+        expect(await refreshTokens("tok", "user-uuid")).toBeNull();
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+});

--- a/src/utils/auth/cognito.ts
+++ b/src/utils/auth/cognito.ts
@@ -4,6 +4,7 @@ import {
     GlobalSignOutCommand,
     RespondToAuthChallengeCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
+import { computeSecretHash } from "./refresh";
 
 const client = new CognitoIdentityProviderClient({
     region: process.env.AWS_REGION ?? "eu-west-1",
@@ -101,20 +102,4 @@ export async function completeNewPassword(
 export async function signOut(accessToken: string): Promise<void> {
     const command = new GlobalSignOutCommand({ AccessToken: accessToken });
     await client.send(command);
-}
-
-async function computeSecretHash(username: string, clientId: string): Promise<string> {
-    const clientSecret = process.env.COGNITO_CLIENT_SECRET;
-    if (!clientSecret) throw new Error("COGNITO_CLIENT_SECRET environment variable is required");
-
-    const message = username + clientId;
-    const key = await crypto.subtle.importKey(
-        "raw",
-        new TextEncoder().encode(clientSecret),
-        { name: "HMAC", hash: "SHA-256" },
-        false,
-        ["sign"]
-    );
-    const signature = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(message));
-    return btoa(String.fromCharCode(...new Uint8Array(signature)));
 }

--- a/src/utils/auth/refresh.ts
+++ b/src/utils/auth/refresh.ts
@@ -1,0 +1,81 @@
+// Cognito REFRESH_TOKEN_AUTH via plain fetch rather than the AWS SDK: this
+// runs inside Next.js middleware (edge runtime), where the SDK is not a safe
+// dependency. InitiateAuth is an unsigned API, so no credentials are needed.
+
+export interface RefreshedTokens {
+    idToken: string;
+    accessToken: string;
+    expiresIn: number;
+    // Only present when the user pool rotates refresh tokens.
+    refreshToken?: string;
+}
+
+// With a client secret, SECRET_HASH is HMAC-SHA256(username + clientId).
+// Uses Web Crypto so it works in both the Node and edge runtimes.
+export async function computeSecretHash(username: string, clientId: string): Promise<string> {
+    const clientSecret = process.env.COGNITO_CLIENT_SECRET;
+    if (!clientSecret) throw new Error("COGNITO_CLIENT_SECRET environment variable is required");
+
+    const message = username + clientId;
+    const key = await crypto.subtle.importKey(
+        "raw",
+        new TextEncoder().encode(clientSecret),
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign"]
+    );
+    const signature = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(message));
+    return btoa(String.fromCharCode(...new Uint8Array(signature)));
+}
+
+// Exchanges a refresh token for fresh ID/access tokens. Returns null on any
+// failure (expired/revoked refresh token, misconfiguration, network) — the
+// caller treats that as "not authenticated" and falls through to login.
+//
+// `username` must be the user's immutable Cognito username (the
+// `cognito:username` claim — a UUID in pools where email is an alias), not
+// the email they signed in with: SECRET_HASH for this flow is computed from
+// the real username.
+export async function refreshTokens(
+    refreshToken: string,
+    username: string
+): Promise<RefreshedTokens | null> {
+    const clientId = process.env.COGNITO_CLIENT_ID;
+    if (!clientId || !process.env.COGNITO_CLIENT_SECRET) return null;
+
+    const region = process.env.AWS_REGION ?? "eu-west-1";
+    // AWS_ENDPOINT_URL points at LocalStack Cognito in local dev.
+    const endpoint = process.env.AWS_ENDPOINT_URL ?? `https://cognito-idp.${region}.amazonaws.com/`;
+
+    try {
+        const res = await fetch(endpoint, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/x-amz-json-1.1",
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.InitiateAuth",
+            },
+            body: JSON.stringify({
+                AuthFlow: "REFRESH_TOKEN_AUTH",
+                ClientId: clientId,
+                AuthParameters: {
+                    REFRESH_TOKEN: refreshToken,
+                    SECRET_HASH: await computeSecretHash(username, clientId),
+                },
+            }),
+        });
+        if (!res.ok) return null;
+
+        const data = await res.json();
+        const auth = data.AuthenticationResult;
+        if (!auth?.IdToken || !auth?.AccessToken) return null;
+
+        return {
+            idToken: auth.IdToken,
+            accessToken: auth.AccessToken,
+            expiresIn: auth.ExpiresIn ?? 3600,
+            ...(auth.RefreshToken && { refreshToken: auth.RefreshToken }),
+        };
+    } catch {
+        return null;
+    }
+}

--- a/src/utils/auth/session.ts
+++ b/src/utils/auth/session.ts
@@ -29,9 +29,10 @@ export async function getSession(): Promise<SessionPayload | null> {
     }
 }
 
-// No refresh token flow: the session expires when the Cognito ID token does
-// (default 1 hour). Users of the admin dashboard will be silently logged out
-// after that window. This is an accepted trade-off for a low-traffic admin UI.
+// The session cookie lives as long as the Cognito ID token (default 1 hour).
+// The middleware transparently renews it from the 30-day refresh token
+// cookie, so admins only see the login page when the refresh token itself
+// has expired or been revoked.
 export function setSessionCookie(token: string, maxAge: number) {
     return {
         name: SESSION_COOKIE,
@@ -87,4 +88,46 @@ export async function getAccessToken(): Promise<string | undefined> {
     return cookieStore.get(ACCESS_TOKEN_COOKIE)?.value;
 }
 
-export { SESSION_COOKIE, ACCESS_TOKEN_COOKIE };
+const REFRESH_COOKIE = "wedding_refresh";
+const REFRESH_USERNAME_COOKIE = "wedding_refresh_user";
+
+// Matches the user pool client's 30-day refresh token validity.
+const REFRESH_MAX_AGE = 30 * 24 * 60 * 60;
+
+export function setRefreshTokenCookie(token: string) {
+    return {
+        name: REFRESH_COOKIE,
+        value: token,
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "strict" as const,
+        path: "/",
+        maxAge: REFRESH_MAX_AGE,
+    };
+}
+
+export function clearRefreshTokenCookie() {
+    return { ...setRefreshTokenCookie(""), maxAge: 0 };
+}
+
+// The immutable Cognito username (the cognito:username claim — a UUID when
+// email is an alias). REFRESH_TOKEN_AUTH's SECRET_HASH must be computed from
+// it, and it can't be recovered later: the session cookie holding the claim
+// is deleted by the browser the moment it expires.
+export function setRefreshUsernameCookie(username: string) {
+    return {
+        name: REFRESH_USERNAME_COOKIE,
+        value: username,
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "strict" as const,
+        path: "/",
+        maxAge: REFRESH_MAX_AGE,
+    };
+}
+
+export function clearRefreshUsernameCookie() {
+    return { ...setRefreshUsernameCookie(""), maxAge: 0 };
+}
+
+export { SESSION_COOKIE, ACCESS_TOKEN_COOKIE, REFRESH_COOKIE, REFRESH_USERNAME_COOKIE };


### PR DESCRIPTION
Fixes the daily re-login: the session cookie died with the 1-hour Cognito ID token, and the 30-day refresh token issued at every login was simply discarded (`session.ts` documented this as an accepted trade-off). Any dashboard visit more than an hour after the last login demanded credentials again.

## How it works

- **Login** now stores two additional 30-day httpOnly cookies: the refresh token and the immutable Cognito username (`cognito:username` claim — a UUID in this pool, since email is an alias). The username is required because `REFRESH_TOKEN_AUTH`'s `SECRET_HASH` is keyed on it rather than the sign-in email, and it can't be recovered later — the session cookie holding the claim is deleted by the browser the moment it expires.
- **Middleware** — when the session is missing/expired but refresh cookies are present, it mints fresh tokens via Cognito `REFRESH_TOKEN_AUTH`, sets the new cookies on the response, and forwards them to the current request's handlers (`NextResponse.next({ request })`), so even the request that triggered the refresh succeeds. Implemented with plain `fetch` (unsigned API) rather than the AWS SDK so it's safe in the edge runtime; honours `AWS_ENDPOINT_URL` for LocalStack.
- **Matcher extended to `/api/*`** so a stale open tab's API calls (e.g. approving a photo after the tab sat open past expiry) refresh transparently instead of failing with a 401. Public API routes are unaffected — with no cookies the middleware falls straight through.
- **Logout** clears the new cookies; the existing `GlobalSignOut` call already revokes the refresh token server-side, so a leaked refresh cookie is dead after an explicit logout.
- `computeSecretHash` moved to the shared refresh module (Web Crypto, works in both runtimes); `cognito.ts` imports it.

## Verification

End-to-end against LocalStack through the real middleware:
- Login sets all four cookies
- `/dashboard` and `/api/dashboard/photo-summary` requested with **only** refresh cookies return 200 and re-issue fresh session/access cookies
- No cookies → 307 to `/login` (unchanged); garbage refresh token → graceful 307 to `/login`
- After logout, the previously-working refresh cookies are rejected (revocation confirmed) and all four cookies are cleared

Unit tests: refresh helper (secret hash, request shape, rotation, failure modes), login cookie behavior (both auth paths, username fallback, challenge path sets nothing), logout clearing. Suite: 112 passed; `tsc --noEmit` and `eslint` clean.

## Notes

- No Cognito configuration changes needed — the pool client already issues 30-day refresh tokens.
- Sessions now last up to 30 days of inactivity; an explicit Sign Out still ends the session immediately everywhere.