### PR TITLE
Give the photo-processor Lambda enough memory for large JPEGs

### DIFF
--- a/infra/lambdas/photo-processor/index.ts
+++ b/infra/lambdas/photo-processor/index.ts
@@ -16,6 +16,14 @@ const PHOTOS_TABLE = process.env.PHOTOS_TABLE ?? "wedding-photos";
 // professional photos, which ran up to ~28 MB.
 const MAX_IMAGE_BYTES = 50 * 1024 * 1024;
 
+// Memory is really driven by decoded megapixels, not file bytes — a small,
+// heavily-compressed JPEG can still decode to a huge pixel buffer. sharp
+// enforces this bound at decode time and throws a normal JS error, which the
+// per-record catch turns into graceful degradation (unlike an OOM, which
+// kills the whole execution environment). 100 MP decodes to ~300 MB of RGB,
+// comfortably inside the 1536 MB function.
+const MAX_INPUT_PIXELS = 100_000_000;
+
 // The S3 OBJECT_CREATED event can race ahead of the API route's photo insert,
 // in which case the byS3Key lookup below finds nothing. Retry a few times with
 // exponential backoff before giving up.
@@ -49,7 +57,7 @@ async function processPhoto(key: string, bucket: string): Promise<void> {
     }
     const buffer = await streamToBuffer(obj.Body as Readable, MAX_IMAGE_BYTES);
 
-    const image = sharp(buffer).rotate(); // auto-rotate using EXIF orientation
+    const image = sharp(buffer, { limitInputPixels: MAX_INPUT_PIXELS }).rotate(); // auto-rotate using EXIF orientation
     const metadata = await image.metadata();
     const takenAt = metadata.exif ? extractDateTimeOriginal(metadata.exif) : null;
 

--- a/infra/lambdas/photo-processor/index.ts
+++ b/infra/lambdas/photo-processor/index.ts
@@ -10,10 +10,11 @@ const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 
 const PHOTOS_TABLE = process.env.PHOTOS_TABLE ?? "wedding-photos";
 
-// Upper bound on the original file we will buffer into memory. The upload-url
-// API caps guest uploads at 20 MB; we allow a small margin and refuse anything
-// larger so a single oversized object cannot OOM-crash the function.
-const MAX_IMAGE_BYTES = 25 * 1024 * 1024;
+// Upper bound on the original file we will buffer into memory, so a single
+// oversized object cannot OOM-crash the function. Guest uploads are capped at
+// 20 MB by the upload-url API; the margin above that exists for bulk-imported
+// professional photos, which ran up to ~28 MB.
+const MAX_IMAGE_BYTES = 50 * 1024 * 1024;
 
 // The S3 OBJECT_CREATED event can race ahead of the API route's photo insert,
 // in which case the byS3Key lookup below finds nothing. Retry a few times with

--- a/infra/lib/wedding-stack.ts
+++ b/infra/lib/wedding-stack.ts
@@ -197,7 +197,10 @@ export class WeddingStack extends cdk.Stack {
       runtime: lambda.Runtime.NODEJS_22_X,
       architecture: lambda.Architecture.ARM_64,
       timeout: cdk.Duration.minutes(2),
-      memorySize: 512,
+      // 512 MB OOMed on large JPEGs during the professional photo import
+      // (decoded pixel buffers dwarf the file size — an 11 MB JPEG was enough).
+      // Guest uploads go up to 20 MB, so give sharp real headroom.
+      memorySize: 1536,
       bundling: {
         nodeModules: ['sharp'],
         // sharp ships per-platform binaries; force npm to stage the Lambda's


### PR DESCRIPTION
During the professional photo import (733 photos), the photo-processor Lambda hit `Runtime.OutOfMemory` at its 512 MB limit on several photos — one as small as 11 MB on disk. Sharp's decoded pixel buffer scales with megapixels, not file size, so large-sensor JPEGs blow far past their compressed size. Since guest uploads are allowed up to 20 MB, a guest photo can hit the same wall today: the thumbnail stays null and the photo sits in "Processing…" in moderation forever.

- `memorySize: 512 → 1536` for the photo-processor Lambda
- The in-function refusal limit rises from 25 MB to 50 MB so bulk-imported professional photos (observed up to ~28 MB) also process; guests remain capped at 20 MB by the upload-url API

`cdk synth` verified. Cost impact is negligible: the function runs for ~1-2 s per uploaded photo, and the ARM price per GB-second is fractions of a cent.

Needs a `cdk deploy` after merge.