### PR TITLE
Fix broken photo downloads/uploads: S3 grant for presigned URLs

### DIFF
--- a/infra/lib/wedding-stack.ts
+++ b/infra/lib/wedding-stack.ts
@@ -187,6 +187,14 @@ export class WeddingStack extends cdk.Stack {
             categoriesTable.tableArn,
           ],
         }),
+        // Presigned URLs (guest photo downloads and uploads) are signed as
+        // this user, so S3 evaluates ITS permissions when the URL is used —
+        // without this grant every presigned URL 403s. Originals only:
+        // thumbnails are served publicly through CloudFront's OAC instead.
+        new iam.PolicyStatement({
+          actions: ['s3:GetObject', 's3:PutObject'],
+          resources: [`${photosBucket.bucketArn}/uploads/original/*`],
+        }),
       ],
     });
 


### PR DESCRIPTION
Guest photo downloads (and guest uploads) have never worked in prod — nobody noticed until now because the gallery was flag-gated. Two independent problems, found while debugging a 500 from `/api/photos/[id]/download-url`:

1. **`S3_PHOTOS_BUCKET` was never set in Amplify** (app- or branch-level), so the baked `BUCKET` was an empty string and every `getSignedUrl` call threw → 500 on both `download-url` and `upload-url`. **Fixed outside this PR**: the env var is now set on the Amplify app and a rebuild of `main` bakes it in.
2. **`wedding-api-lambda` had no S3 permissions** — presigned URLs are signed as that user, so S3 evaluates its permissions when the URL is used; every presigned URL would 403 even once generated. This PR adds `s3:GetObject` + `s3:PutObject` on `uploads/original/*` to the CDK-managed policy (thumbnails are served through CloudFront OAC and need no user grant).

Verified locally that the route logic itself is sound (302 + working presigned URL against LocalStack); the prod failure was bisected to the presign step via the route's own status codes (bad code → 403, bad id → 404, good inputs → 500).

Needs `cdk deploy` after merge — after that, download-url should be re-verified end-to-end in prod.