### PR TITLE
feat: face recognition infra — faces table, Rekognition wiring, backfill script

### DIFF
--- a/infra/lambdas/photo-processor/index.ts
+++ b/infra/lambdas/photo-processor/index.ts
@@ -118,18 +118,19 @@ async function indexAndAssignFaces(
     thumbKey: string,
     photoId: string
 ): Promise<void> {
-    // S3 retries can re-deliver an event after a partial run; face rows for
-    // this photo mean indexing already happened.
-    const existing = await docClient.send(
-        new QueryCommand({
-            TableName: FACES_TABLE,
-            IndexName: "byPhoto",
-            KeyConditionExpression: "photo_id = :photo",
-            ExpressionAttributeValues: { ":photo": photoId },
-            Limit: 1,
+    // S3 retries can re-deliver an event after a completed run. Check the
+    // photo item's face_indexed_at marker with a strongly consistent read —
+    // a byPhoto GSI query is eventually consistent (it could miss rows
+    // written moments ago) and can't represent zero-face photos at all.
+    const photo = await docClient.send(
+        new GetCommand({
+            TableName: PHOTOS_TABLE,
+            Key: { id: photoId },
+            ConsistentRead: true,
+            ProjectionExpression: "face_indexed_at",
         })
     );
-    if ((existing.Items?.length ?? 0) > 0) return;
+    if (photo.Item?.face_indexed_at) return;
 
     const indexed = await rekognition.send(
         new IndexFacesCommand({

--- a/infra/lambdas/photo-processor/index.ts
+++ b/infra/lambdas/photo-processor/index.ts
@@ -2,13 +2,31 @@ import type { S3Event } from "aws-lambda";
 import { S3Client, GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import sharp from "sharp";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import {
+    DynamoDBDocumentClient,
+    GetCommand,
+    PutCommand,
+    QueryCommand,
+    UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+import {
+    RekognitionClient,
+    IndexFacesCommand,
+    SearchFacesCommand,
+} from "@aws-sdk/client-rekognition";
+import { randomUUID } from "node:crypto";
 import type { Readable } from "stream";
 
 const s3 = new S3Client({});
-const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}), {
+    marshallOptions: { removeUndefinedValues: true },
+});
+const rekognition = new RekognitionClient({});
 
 const PHOTOS_TABLE = process.env.PHOTOS_TABLE ?? "wedding-photos";
+const FACES_TABLE = process.env.FACES_TABLE ?? "wedding-photo-faces";
+const COLLECTION_ID = process.env.REKOGNITION_COLLECTION_ID ?? "wedding-faces-2026";
+const FACE_MATCH_THRESHOLD = Number(process.env.FACE_MATCH_THRESHOLD ?? "95");
 
 // Upper bound on the original file we will buffer into memory, so a single
 // oversized object cannot OOM-crash the function. Guest uploads are capped at
@@ -78,20 +96,149 @@ async function processPhoto(key: string, bucket: string): Promise<void> {
         })
     );
 
-    await updatePhotoRecord(key, thumbKey, info.width, info.height, takenAt);
+    const photoId = await updatePhotoRecord(key, thumbKey, info.width, info.height, takenAt);
+
+    // Face indexing is strictly best-effort: a Rekognition or faces-table
+    // failure must never break the thumbnail pipeline the gallery depends on.
+    try {
+        await indexAndAssignFaces(bucket, thumbKey, photoId);
+    } catch (err) {
+        console.error(`Face indexing failed for ${key} (photo ${photoId}):`, err);
+    }
+}
+
+// Index every face in the thumbnail into the Rekognition collection and store
+// one faces-table row per face. Each new face is searched against the
+// collection; when it matches an already-clustered face, it adopts that
+// cluster (and its invitee assignment, if labeled) — so new uploads of known
+// people surface in "Find My Photos" with no admin work. Unmatched faces
+// start a singleton cluster, which shows up as unlabeled in the admin page.
+async function indexAndAssignFaces(
+    bucket: string,
+    thumbKey: string,
+    photoId: string
+): Promise<void> {
+    // S3 retries can re-deliver an event after a partial run; face rows for
+    // this photo mean indexing already happened.
+    const existing = await docClient.send(
+        new QueryCommand({
+            TableName: FACES_TABLE,
+            IndexName: "byPhoto",
+            KeyConditionExpression: "photo_id = :photo",
+            ExpressionAttributeValues: { ":photo": photoId },
+            Limit: 1,
+        })
+    );
+    if ((existing.Items?.length ?? 0) > 0) return;
+
+    const indexed = await rekognition.send(
+        new IndexFacesCommand({
+            CollectionId: COLLECTION_ID,
+            Image: { S3Object: { Bucket: bucket, Name: thumbKey } },
+            ExternalImageId: photoId,
+            QualityFilter: "AUTO",
+            DetectionAttributes: ["DEFAULT"],
+            MaxFaces: 15,
+        })
+    );
+
+    for (const record of indexed.FaceRecords ?? []) {
+        const faceId = record.Face?.FaceId;
+        const box = record.Face?.BoundingBox;
+        if (!faceId || !box) continue;
+
+        const assignment = await findClusterForFace(faceId);
+
+        await docClient.send(
+            new PutCommand({
+                TableName: FACES_TABLE,
+                Item: {
+                    face_id: faceId,
+                    photo_id: photoId,
+                    cluster_id: assignment?.cluster_id ?? randomUUID(),
+                    invitee_id: assignment?.invitee_id,
+                    invitation_id: assignment?.invitation_id,
+                    ignored: assignment?.ignored,
+                    bounding_box: {
+                        left: box.Left ?? 0,
+                        top: box.Top ?? 0,
+                        width: box.Width ?? 0,
+                        height: box.Height ?? 0,
+                    },
+                    confidence: record.Face?.Confidence ?? 0,
+                    indexed_at: new Date().toISOString(),
+                },
+            })
+        );
+    }
+
+    // Marker doubles as the backfill script's skip guard and correctly covers
+    // photos with zero detected faces (no rows to find via byPhoto).
+    await docClient.send(
+        new UpdateCommand({
+            TableName: PHOTOS_TABLE,
+            Key: { id: photoId },
+            UpdateExpression: "SET face_indexed_at = :now",
+            ExpressionAttributeValues: { ":now": new Date().toISOString() },
+        })
+    );
+}
+
+// Search the collection for faces similar to the given one and return the
+// cluster (and any invitee assignment) of the best already-clustered match.
+async function findClusterForFace(faceId: string): Promise<{
+    cluster_id: string;
+    invitee_id?: number;
+    invitation_id?: number;
+    ignored?: boolean;
+} | null> {
+    const search = await rekognition.send(
+        new SearchFacesCommand({
+            CollectionId: COLLECTION_ID,
+            FaceId: faceId,
+            FaceMatchThreshold: FACE_MATCH_THRESHOLD,
+            MaxFaces: 10,
+        })
+    );
+
+    // Matches arrive sorted by similarity; take the first with a cluster.
+    for (const match of search.FaceMatches ?? []) {
+        const matchedId = match.Face?.FaceId;
+        if (!matchedId) continue;
+        const row = await docClient.send(
+            new GetCommand({ TableName: FACES_TABLE, Key: { face_id: matchedId } })
+        );
+        const item = row.Item as
+            | {
+                  cluster_id?: string;
+                  invitee_id?: number;
+                  invitation_id?: number;
+                  ignored?: boolean;
+              }
+            | undefined;
+        if (item?.cluster_id) {
+            return {
+                cluster_id: item.cluster_id,
+                invitee_id: item.invitee_id,
+                invitation_id: item.invitation_id,
+                ignored: item.ignored,
+            };
+        }
+    }
+    return null;
 }
 
 // Look up the photo id via the byS3Key GSI and backfill the thumbnail fields.
 // A missing item means the photo insert has not been written yet (the S3 event
 // won the race), so back off and retry rather than silently leaving
-// thumbnail_key null.
+// thumbnail_key null. Returns the photo id for the face-indexing step.
 async function updatePhotoRecord(
     key: string,
     thumbKey: string,
     width: number,
     height: number,
     takenAt: string | null
-): Promise<void> {
+): Promise<string> {
     for (let attempt = 1; attempt <= MAX_UPDATE_ATTEMPTS; attempt++) {
         const lookup = await docClient.send(
             new QueryCommand({
@@ -118,7 +265,7 @@ async function updatePhotoRecord(
                     },
                 })
             );
-            return;
+            return id;
         }
 
         if (attempt < MAX_UPDATE_ATTEMPTS) {

--- a/infra/lib/wedding-stack.ts
+++ b/infra/lib/wedding-stack.ts
@@ -155,6 +155,36 @@ export class WeddingStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.RETAIN,
     });
 
+    // One item per face Rekognition detects in a photo. Cluster assignment is
+    // denormalized onto every face row (no cluster-metadata items) — the admin
+    // labeling page reads the whole table (a few thousand tiny items) and
+    // groups in code, matching the archive table's scan-and-assemble pattern.
+    const facesTable = new dynamodb.Table(this, 'PhotoFacesTable', {
+      tableName: 'wedding-photo-faces',
+      partitionKey: { name: 'face_id', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+    // photo-processor idempotency ("is this photo already indexed?") and cleanup.
+    facesTable.addGlobalSecondaryIndex({
+      indexName: 'byPhoto',
+      partitionKey: { name: 'photo_id', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+    // Admin cluster detail + assignment fan-out (update every face in a cluster).
+    facesTable.addGlobalSecondaryIndex({
+      indexName: 'byCluster',
+      partitionKey: { name: 'cluster_id', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+    // Guest "Find My Photos": faces assigned to an invitee. Sparse — rows
+    // without an invitee_id (unassigned/ignored clusters) never appear here.
+    facesTable.addGlobalSecondaryIndex({
+      indexName: 'byInvitee',
+      partitionKey: { name: 'invitee_id', type: dynamodb.AttributeType.NUMBER },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
     // The Next.js SSR runtime authenticates as the pre-existing
     // `wedding-api-lambda` IAM user (Amplify bakes its keys into the bundle),
     // so grant it table access via an attached managed policy.
@@ -185,7 +215,15 @@ export class WeddingStack extends cdk.Stack {
             photosTable.tableArn,
             `${photosTable.tableArn}/index/*`,
             categoriesTable.tableArn,
+            facesTable.tableArn,
+            `${facesTable.tableArn}/index/*`,
           ],
+        }),
+        // Face rows are the only items the app ever deletes (admin re-cluster
+        // and cleanup), so the DeleteItem grant is scoped to that table alone.
+        new iam.PolicyStatement({
+          actions: ['dynamodb:DeleteItem'],
+          resources: [facesTable.tableArn],
         }),
         // Presigned URLs (guest photo downloads and uploads) are signed as
         // this user, so S3 evaluates ITS permissions when the URL is used —
@@ -222,6 +260,9 @@ export class WeddingStack extends cdk.Stack {
       environment: {
         PHOTOS_TABLE: photosTable.tableName,
         S3_BUCKET: photosBucket.bucketName,
+        FACES_TABLE: facesTable.tableName,
+        REKOGNITION_COLLECTION_ID: 'wedding-faces-2026',
+        FACE_MATCH_THRESHOLD: '95',
       },
     });
     photosBucket.addEventNotification(
@@ -231,6 +272,7 @@ export class WeddingStack extends cdk.Stack {
     );
     photosBucket.grantReadWrite(photoProcessor);
     photosTable.grantReadWriteData(photoProcessor);
+    facesTable.grantReadWriteData(photoProcessor);
 
     // ── Cognito User Pool ─────────────────────────────────────────────────────
     const userPool = new cognito.UserPool(this, 'AdminUserPool', {
@@ -269,7 +311,9 @@ export class WeddingStack extends cdk.Stack {
         new iam.PolicyStatement({
           actions: [
             'rekognition:IndexFaces',
+            'rekognition:SearchFaces',
             'rekognition:SearchFacesByImage',
+            'rekognition:ListFaces',
             'rekognition:DeleteFaces',
           ],
           resources: [
@@ -278,6 +322,10 @@ export class WeddingStack extends cdk.Stack {
         }),
       ],
     });
+    // Only the photo-processor talks to Rekognition at runtime — the Next.js
+    // app reads face matches from DynamoDB. The backfill script runs with
+    // local admin credentials.
+    rekognitionPolicy.attachToRole(photoProcessor.role!);
 
     // ── Outputs ───────────────────────────────────────────────────────────────
     new cdk.CfnOutput(this, 'CloudFrontDomain', {
@@ -320,6 +368,11 @@ export class WeddingStack extends cdk.Stack {
       description: 'DynamoDB photo categories table (DDB_CATEGORIES_TABLE)',
     });
 
+    new cdk.CfnOutput(this, 'PhotoFacesTableName', {
+      value: facesTable.tableName,
+      description: 'DynamoDB photo faces table (DDB_FACES_TABLE)',
+    });
+
     new cdk.CfnOutput(this, 'PhotosBucketName', {
       value: photosBucket.bucketName,
       description: 'S3 photos bucket name',
@@ -327,7 +380,7 @@ export class WeddingStack extends cdk.Stack {
 
     new cdk.CfnOutput(this, 'RekognitionPolicyArn', {
       value: rekognitionPolicy.managedPolicyArn,
-      description: 'Rekognition policy ARN — attach to Amplify execution role',
+      description: 'Rekognition policy ARN — attached to the photo-processor Lambda role',
     });
 
   }

--- a/infra/package.json
+++ b/infra/package.json
@@ -16,6 +16,7 @@
     "sharp": "^0.34.5"
   },
   "devDependencies": {
+    "@aws-sdk/client-rekognition": "^3.1090.0",
     "aws-cdk": "^2.200.0",
     "esbuild": "^0.25.0",
     "source-map-support": "^0.5.21",

--- a/next.config.js
+++ b/next.config.js
@@ -42,6 +42,7 @@ const nextConfig = {
         DDB_ARCHIVE_TABLE: process.env.DDB_ARCHIVE_TABLE ?? "",
         DDB_PHOTOS_TABLE: process.env.DDB_PHOTOS_TABLE ?? "",
         DDB_CATEGORIES_TABLE: process.env.DDB_CATEGORIES_TABLE ?? "",
+        DDB_FACES_TABLE: process.env.DDB_FACES_TABLE ?? "",
         LAMBDA_AWS_KEY_ID: process.env.LAMBDA_AWS_KEY_ID ?? "",
         LAMBDA_AWS_SECRET: process.env.LAMBDA_AWS_SECRET ?? "",
         S3_PHOTOS_BUCKET: process.env.S3_PHOTOS_BUCKET ?? "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@aws-sdk/client-cloudwatch-logs": "^3.1065.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.1058.0",
         "@aws-sdk/client-dynamodb": "^3.1083.0",
-        "@aws-sdk/client-rekognition": "^3.1058.0",
         "@aws-sdk/client-s3": "^3.1058.0",
         "@aws-sdk/lib-dynamodb": "^3.1083.0",
         "@aws-sdk/s3-request-presigner": "^3.1058.0",
@@ -30,6 +29,7 @@
         "yet-another-react-lightbox": "^3.32.0"
       },
       "devDependencies": {
+        "@aws-sdk/client-rekognition": "^3.1090.0",
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
         "@eslint/eslintrc": "^3.2.0",
@@ -235,20 +235,19 @@
       }
     },
     "node_modules/@aws-sdk/client-rekognition": {
-      "version": "3.1058.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-rekognition/-/client-rekognition-3.1058.0.tgz",
-      "integrity": "sha512-YKQzXx1udhGFb4ml7xrbALytl8aRCsKJAD6T7X4UydnVCgBoF5Won/0CdNzWozadnFgPsmbGk30Oc2liFF9Jpw==",
+      "version": "3.1090.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-rekognition/-/client-rekognition-3.1090.0.tgz",
+      "integrity": "sha512-3KRyscUxJGBnUCgGbB+vFr/Go+VBMBP/RpuQFnh171yP5Vwq2zrueLJtfa9epzb44xkq/BJVtqpA9ls+P2FGRA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/credential-provider-node": "^3.972.48",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/fetch-http-handler": "^5.4.5",
-        "@smithy/node-http-handler": "^4.7.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-node": "^3.972.70",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -285,17 +284,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.975.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
-      "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
+      "version": "3.975.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
+      "integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.0",
-        "@aws-sdk/xml-builder": "^3.972.34",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.36",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/signature-v4": "^5.6.3",
-        "@smithy/types": "^4.16.0",
+        "@smithy/core": "^3.29.4",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -317,15 +316,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.57",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
-      "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
+      "integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -333,17 +332,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.59",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
-      "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
+      "integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/fetch-http-handler": "^5.6.4",
-        "@smithy/node-http-handler": "^4.9.4",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -351,23 +350,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
-      "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.4.tgz",
+      "integrity": "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/credential-provider-env": "^3.972.57",
-        "@aws-sdk/credential-provider-http": "^3.972.59",
-        "@aws-sdk/credential-provider-login": "^3.972.63",
-        "@aws-sdk/credential-provider-process": "^3.972.57",
-        "@aws-sdk/credential-provider-sso": "^3.973.1",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/credential-provider-imds": "^4.4.7",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-login": "^3.972.66",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -375,16 +374,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.63",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
-      "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.66.tgz",
+      "integrity": "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -392,21 +391,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.66",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.66.tgz",
-      "integrity": "sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.70.tgz",
+      "integrity": "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.57",
-        "@aws-sdk/credential-provider-http": "^3.972.59",
-        "@aws-sdk/credential-provider-ini": "^3.973.1",
-        "@aws-sdk/credential-provider-process": "^3.972.57",
-        "@aws-sdk/credential-provider-sso": "^3.973.1",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/credential-provider-imds": "^4.4.7",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-ini": "^3.973.4",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -414,15 +413,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.57",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
-      "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
+      "integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -430,17 +429,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
-      "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
+      "version": "3.973.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
+      "integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/token-providers": "3.1083.0",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/token-providers": "3.1088.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -448,16 +447,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.63",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
-      "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
+      "integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -624,18 +623,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
-      "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
+      "version": "3.997.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
+      "integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/fetch-http-handler": "^5.6.4",
-        "@smithy/node-http-handler": "^4.9.4",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -660,14 +659,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
-      "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
+      "version": "3.996.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/signature-v4": "^5.6.3",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -675,16 +674,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1083.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
-      "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
+      "integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.975.1",
-        "@aws-sdk/nested-clients": "^3.997.31",
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -692,12 +691,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
-      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -732,12 +731,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
-      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3450,12 +3449,12 @@
       "license": "MIT"
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.2.tgz",
-      "integrity": "sha512-DXUk6yU0C1Q1tYvJh1VCtl8QOBcSoZpKwjTPkxT6A4MUQYHvgeKGByL8mrEdxnvhdf9nq5GyzmRb5n/vPgu3Lw==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.5.tgz",
+      "integrity": "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3463,13 +3462,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.7.tgz",
-      "integrity": "sha512-UEMLOoA0Fl4uYBxh6l0uN0H6EJe/A89OGeDNTteQeXpJ20BcpfIr4wlCY9pel1jEAUHAxaYwuqrYlrKdXE1GKQ==",
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.10.tgz",
+      "integrity": "sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3477,13 +3476,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.4.tgz",
-      "integrity": "sha512-psnst7NZWdAEvJvyW8YZEE7xNVMyLrQFfHtyrVFrxNyy+dKWkQ+rqC6oI5ZhxThpUy9RSfEshgm34zqbOxzsRw==",
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.7.tgz",
+      "integrity": "sha512-3zpg8yqqyXzoK2TsRDdkqVOj2RDBFfLXwCczOZ5c7TWB4eiaebfSCsbMjDPYB3PJ9ihV62QaeadZ+wLadZtNGA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3503,13 +3502,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.4.tgz",
-      "integrity": "sha512-BNTop/fSOptmoVk8g+efwHCofFh37g70OWGAFES1TeAAJja1K5aAI8rTE26ETSc5k8IQuWY2kAIoPla01NgYrA==",
+      "version": "4.9.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.7.tgz",
+      "integrity": "sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3517,13 +3516,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.3.tgz",
-      "integrity": "sha512-8qVKKzqh7naF27ePmx0SkUfnGP/wBI9dyaeAmhHvopnbIlItUAmB/e6PkPCU3rRb2v9BY8D4EZXSoydSibatvw==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.6.tgz",
+      "integrity": "sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.2",
-        "@smithy/types": "^4.16.0",
+        "@smithy/core": "^3.29.5",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3531,9 +3530,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.0.tgz",
-      "integrity": "sha512-aVUabzlBBmY0PfvVgLKQSOGFIL5/7R54JE3uD9a5Ay/jSED61SkuAcCYENNXJzYUvJ1NPrWO0P+rAXHCkbBUKw==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@aws-sdk/client-cloudwatch-logs": "^3.1065.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.1058.0",
     "@aws-sdk/client-dynamodb": "^3.1083.0",
-    "@aws-sdk/client-rekognition": "^3.1058.0",
     "@aws-sdk/client-s3": "^3.1058.0",
     "@aws-sdk/lib-dynamodb": "^3.1083.0",
     "@aws-sdk/s3-request-presigner": "^3.1058.0",
@@ -41,6 +40,7 @@
     "yet-another-react-lightbox": "^3.32.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-rekognition": "^3.1090.0",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
     "@eslint/eslintrc": "^3.2.0",

--- a/scripts/index-faces.mjs
+++ b/scripts/index-faces.mjs
@@ -1,0 +1,308 @@
+// Backfill face detection for the photo gallery ("Find My Photos").
+//
+// Phase A (index): every photo with a thumbnail and no face_indexed_at marker
+// has its faces indexed into the Rekognition collection, one faces-table row
+// per detected face. Thumbnails (1200px JPEGs) are used instead of originals —
+// some originals exceed Rekognition's 15 MB S3 limit.
+//
+// Phase B (cluster): every face is searched against the collection
+// (SearchFaces by FaceId) and similar faces are grouped with union-find; each
+// group gets a fresh cluster_id. The admin dashboard then labels clusters
+// with invitee names. The threshold errs high on purpose: a person split
+// across two clusters is cheap (assign both to the same guest), a cluster
+// mixing two people is not.
+//
+// Usage:
+//   node scripts/index-faces.mjs [--dry-run] [--limit N] [--index-only]
+//                                [--cluster-only] [--threshold N] [--force]
+//
+//   --dry-run       report what each phase would do without calling AWS mutators
+//   --limit N       index at most N photos (smoke-testing)
+//   --index-only    run Phase A only
+//   --cluster-only  run Phase B only (e.g. after re-tuning --threshold)
+//   --threshold N   SearchFaces similarity threshold, default 95
+//   --force         allow re-clustering even after labeling has started
+//
+// Both phases are idempotent: Phase A skips photos with face_indexed_at,
+// Phase B recomputes every cluster from scratch (which is why it refuses to
+// run once labels exist, unless --force).
+//
+// Requires: AWS credentials (run with AWS_PROFILE=wedding), S3_PHOTOS_BUCKET,
+// DDB_PHOTOS_TABLE, DDB_FACES_TABLE. AWS_ENDPOINT_URL switches DynamoDB/S3 to
+// LocalStack, but Rekognition has no LocalStack analogue — this script is
+// prod-only in practice.
+
+import {
+    RekognitionClient,
+    IndexFacesCommand,
+    SearchFacesCommand,
+} from "@aws-sdk/client-rekognition";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+    DynamoDBDocumentClient,
+    PutCommand,
+    ScanCommand,
+    UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { randomUUID } from "node:crypto";
+
+const region = process.env.AWS_REGION ?? "eu-west-1";
+const endpoint = process.env.AWS_ENDPOINT_URL;
+const bucket = process.env.S3_PHOTOS_BUCKET;
+const photosTable = process.env.DDB_PHOTOS_TABLE ?? "wedding-photos";
+const facesTable = process.env.DDB_FACES_TABLE ?? "wedding-photo-faces";
+const collectionId = process.env.REKOGNITION_COLLECTION_ID ?? "wedding-faces-2026";
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const indexOnly = args.includes("--index-only");
+const clusterOnly = args.includes("--cluster-only");
+const force = args.includes("--force");
+const limitIdx = args.indexOf("--limit");
+const limit = limitIdx !== -1 ? Number(args[limitIdx + 1]) : Infinity;
+const thresholdIdx = args.indexOf("--threshold");
+const threshold = thresholdIdx !== -1 ? Number(args[thresholdIdx + 1]) : 95;
+
+if (!bucket && !clusterOnly) {
+    console.error("S3_PHOTOS_BUCKET is required");
+    process.exit(1);
+}
+if (indexOnly && clusterOnly) {
+    console.error("--index-only and --cluster-only are mutually exclusive");
+    process.exit(1);
+}
+
+const rekognition = new RekognitionClient({ region });
+const docClient = DynamoDBDocumentClient.from(
+    new DynamoDBClient({ region, ...(endpoint && { endpoint }) }),
+    { marshallOptions: { removeUndefinedValues: true } }
+);
+
+const CONCURRENCY = 3;
+async function inBatches(items, worker) {
+    const results = [];
+    for (let i = 0; i < items.length; i += CONCURRENCY) {
+        results.push(...(await Promise.all(items.slice(i, i + CONCURRENCY).map(worker))));
+    }
+    return results;
+}
+
+// Retry throttling-ish errors with exponential backoff; rethrow anything else.
+async function withRetry(fn, label) {
+    for (let attempt = 1; ; attempt++) {
+        try {
+            return await fn();
+        } catch (err) {
+            const retryable =
+                err.name === "ThrottlingException" ||
+                err.name === "ProvisionedThroughputExceededException" ||
+                err.$metadata?.httpStatusCode === 429;
+            if (!retryable || attempt >= 5) throw err;
+            const delayMs = 500 * 2 ** (attempt - 1);
+            console.warn(`  throttled on ${label}, retrying in ${delayMs}ms`);
+            await new Promise((r) => setTimeout(r, delayMs));
+        }
+    }
+}
+
+async function scanAll(tableName, extra = {}) {
+    const items = [];
+    let lastKey;
+    do {
+        const page = await docClient.send(
+            new ScanCommand({ TableName: tableName, ExclusiveStartKey: lastKey, ...extra })
+        );
+        items.push(...(page.Items ?? []));
+        lastKey = page.LastEvaluatedKey;
+    } while (lastKey);
+    return items;
+}
+
+// ── Phase A: index faces ────────────────────────────────────────────────────
+
+async function indexPhotos() {
+    const photos = await scanAll(photosTable);
+    const noThumbnail = photos.filter((p) => !p.thumbnail_key);
+    const done = photos.filter((p) => p.thumbnail_key && p.face_indexed_at);
+    const todo = photos
+        .filter((p) => p.thumbnail_key && !p.face_indexed_at)
+        .slice(0, limit);
+
+    console.log(
+        `Phase A: ${todo.length} photos to index ` +
+            `(${done.length} already indexed, ${noThumbnail.length} without thumbnails skipped)`
+    );
+    if (dryRun) {
+        for (const p of todo.slice(0, 20)) console.log(`  would index: ${p.thumbnail_key}`);
+        if (todo.length > 20) console.log(`  … and ${todo.length - 20} more`);
+        return;
+    }
+
+    let indexed = 0;
+    let faces = 0;
+    let failed = 0;
+
+    await inBatches(todo, async (photo) => {
+        try {
+            const result = await withRetry(
+                () =>
+                    rekognition.send(
+                        new IndexFacesCommand({
+                            CollectionId: collectionId,
+                            Image: { S3Object: { Bucket: bucket, Name: photo.thumbnail_key } },
+                            ExternalImageId: photo.id,
+                            QualityFilter: "AUTO",
+                            DetectionAttributes: ["DEFAULT"],
+                            MaxFaces: 15,
+                        })
+                    ),
+                photo.thumbnail_key
+            );
+
+            for (const record of result.FaceRecords ?? []) {
+                const face = record.Face;
+                if (!face?.FaceId || !face.BoundingBox) continue;
+                await docClient.send(
+                    new PutCommand({
+                        TableName: facesTable,
+                        Item: {
+                            face_id: face.FaceId,
+                            photo_id: photo.id,
+                            bounding_box: {
+                                left: face.BoundingBox.Left ?? 0,
+                                top: face.BoundingBox.Top ?? 0,
+                                width: face.BoundingBox.Width ?? 0,
+                                height: face.BoundingBox.Height ?? 0,
+                            },
+                            confidence: face.Confidence ?? 0,
+                            indexed_at: new Date().toISOString(),
+                        },
+                    })
+                );
+                faces++;
+            }
+
+            await docClient.send(
+                new UpdateCommand({
+                    TableName: photosTable,
+                    Key: { id: photo.id },
+                    UpdateExpression: "SET face_indexed_at = :now",
+                    ExpressionAttributeValues: { ":now": new Date().toISOString() },
+                })
+            );
+
+            indexed++;
+            if (indexed % 25 === 0) console.log(`  …${indexed}/${todo.length} photos indexed`);
+        } catch (err) {
+            failed++;
+            console.error(`FAILED ${photo.thumbnail_key}: ${err.message}`);
+        }
+    });
+
+    console.log(`Phase A done: ${indexed} photos indexed, ${faces} faces found, ${failed} failed`);
+    if (failed > 0) {
+        console.warn("Failed photos keep no face_indexed_at marker — re-run to retry them.");
+    }
+}
+
+// ── Phase B: cluster faces ──────────────────────────────────────────────────
+
+async function clusterFaces() {
+    const faces = await scanAll(facesTable);
+    if (faces.length === 0) {
+        console.log("Phase B: no faces to cluster");
+        return;
+    }
+
+    const labeled = faces.filter((f) => f.invitee_id != null || f.ignored);
+    if (labeled.length > 0 && !force) {
+        console.error(
+            `Phase B refused: ${labeled.length} faces already carry labels. ` +
+                `Re-clustering replaces every cluster_id and orphans that work. ` +
+                `Run with --force if you really want this.`
+        );
+        process.exit(1);
+    }
+
+    console.log(
+        `Phase B: clustering ${faces.length} faces at threshold ${threshold}` +
+            (dryRun ? " (dry-run: no SearchFaces calls, no writes)" : "")
+    );
+    if (dryRun) return;
+
+    // Union-find over face ids, fed by SearchFaces matches.
+    const parent = new Map(faces.map((f) => [f.face_id, f.face_id]));
+    const find = (id) => {
+        let root = id;
+        while (parent.get(root) !== root) root = parent.get(root);
+        while (parent.get(id) !== root) {
+            const next = parent.get(id);
+            parent.set(id, root);
+            id = next;
+        }
+        return root;
+    };
+    const union = (a, b) => parent.set(find(a), find(b));
+
+    let searched = 0;
+    await inBatches(faces, async (face) => {
+        const result = await withRetry(
+            () =>
+                rekognition.send(
+                    new SearchFacesCommand({
+                        CollectionId: collectionId,
+                        FaceId: face.face_id,
+                        FaceMatchThreshold: threshold,
+                        MaxFaces: 50,
+                    })
+                ),
+            face.face_id
+        );
+        for (const match of result.FaceMatches ?? []) {
+            // The collection can hold faces whose rows were deleted; only
+            // union faces we actually track.
+            if (match.Face?.FaceId && parent.has(match.Face.FaceId)) {
+                union(face.face_id, match.Face.FaceId);
+            }
+        }
+        searched++;
+        if (searched % 100 === 0) console.log(`  …${searched}/${faces.length} faces searched`);
+    });
+
+    const clusterIds = new Map(); // root face_id -> cluster uuid
+    for (const face of faces) {
+        const root = find(face.face_id);
+        if (!clusterIds.has(root)) clusterIds.set(root, randomUUID());
+    }
+
+    let updated = 0;
+    await inBatches(faces, async (face) => {
+        await docClient.send(
+            new UpdateCommand({
+                TableName: facesTable,
+                Key: { face_id: face.face_id },
+                UpdateExpression: "SET cluster_id = :cluster",
+                ExpressionAttributeValues: { ":cluster": clusterIds.get(find(face.face_id)) },
+            })
+        );
+        updated++;
+        if (updated % 200 === 0) console.log(`  …${updated}/${faces.length} rows updated`);
+    });
+
+    const sizes = [...clusterIds.keys()].map(
+        (root) => faces.filter((f) => find(f.face_id) === root).length
+    );
+    const singletons = sizes.filter((s) => s === 1).length;
+    console.log(
+        `Phase B done: ${clusterIds.size} clusters over ${faces.length} faces ` +
+            `(${singletons} singletons, largest ${Math.max(...sizes)})`
+    );
+    console.log(
+        "Spot-check the biggest clusters before labeling — a cluster mixing two " +
+            "people means the threshold is too low; re-run with --cluster-only --threshold 97."
+    );
+}
+
+if (!clusterOnly) await indexPhotos();
+if (!indexOnly) await clusterFaces();
+console.log("Done.");

--- a/scripts/index-faces.mjs
+++ b/scripts/index-faces.mjs
@@ -218,8 +218,9 @@ async function clusterFaces() {
     if (labeled.length > 0 && !force) {
         console.error(
             `Phase B refused: ${labeled.length} faces already carry labels. ` +
-                `Re-clustering replaces every cluster_id and orphans that work. ` +
-                `Run with --force if you really want this.`
+                `Re-clustering replaces every cluster_id and WIPES all labels ` +
+                `(they belong to the old clusters). Run with --force if you ` +
+                `really want to start labeling over.`
         );
         process.exit(1);
     }
@@ -281,7 +282,12 @@ async function clusterFaces() {
             new UpdateCommand({
                 TableName: facesTable,
                 Key: { face_id: face.face_id },
-                UpdateExpression: "SET cluster_id = :cluster",
+                // Faces can land in a different cluster than last time, so any
+                // label denormalized from the old clustering is stale — wipe
+                // it rather than leave clusters with conflicting members.
+                // (A no-op unless --force allowed re-clustering after labeling.)
+                UpdateExpression:
+                    "SET cluster_id = :cluster REMOVE invitee_id, invitation_id, ignored",
                 ExpressionAttributeValues: { ":cluster": clusterIds.get(find(face.face_id)) },
             })
         );

--- a/src/types/faces.ts
+++ b/src/types/faces.ts
@@ -1,0 +1,28 @@
+// Rekognition-relative bounding box: all values are fractions of the image
+// dimensions, so a crop computed from the thumbnail needs no unit conversion.
+export interface FaceBoundingBox {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+}
+
+// One row per face Rekognition detected in a photo. Cluster assignment
+// (invitee_id / invitation_id / ignored) is denormalized onto every face row.
+export interface PhotoFace {
+    face_id: string;
+    photo_id: string;
+    cluster_id: string;
+    invitee_id?: number;
+    invitation_id?: number;
+    ignored?: boolean;
+    bounding_box: FaceBoundingBox;
+    confidence: number;
+    indexed_at: string;
+}
+
+// What the admin PATCH route applies to every face in a cluster.
+export type ClusterAssignment =
+    | { invitee_id: number; invitation_id: number }
+    | { ignored: true }
+    | null; // clear assignment

--- a/src/utils/db/__tests__/faces.test.ts
+++ b/src/utils/db/__tests__/faces.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockSend = vi.fn();
+
+vi.mock("../dynamo", () => ({
+    docClient: { send: (...args: unknown[]) => mockSend(...args) },
+    FACES_TABLE: "wedding-photo-faces",
+}));
+
+import { getFacesByInvitees, updateClusterAssignment } from "../faces";
+
+interface SentCommand {
+    input: {
+        IndexName?: string;
+        UpdateExpression?: string;
+        ExpressionAttributeValues?: Record<string, unknown>;
+        Key?: Record<string, unknown>;
+    };
+}
+
+const sentCommand = (call: number): SentCommand["input"] =>
+    (mockSend.mock.calls[call][0] as SentCommand).input;
+
+describe("getFacesByInvitees", () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it("queries the byInvitee GSI per invitee and flattens the results", async () => {
+        mockSend
+            .mockResolvedValueOnce({ Items: [{ face_id: "f1", invitee_id: 1 }] })
+            .mockResolvedValueOnce({ Items: [{ face_id: "f2", invitee_id: 2 }] });
+
+        const faces = await getFacesByInvitees([1, 2]);
+
+        expect(faces.map((f) => f.face_id).sort()).toEqual(["f1", "f2"]);
+        expect(mockSend).toHaveBeenCalledTimes(2);
+        expect(sentCommand(0).IndexName).toBe("byInvitee");
+    });
+
+    it("returns empty for an empty household", async () => {
+        expect(await getFacesByInvitees([])).toEqual([]);
+        expect(mockSend).not.toHaveBeenCalled();
+    });
+});
+
+describe("updateClusterAssignment", () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    const clusterFaces = [{ face_id: "f1" }, { face_id: "f2" }];
+
+    it("assigns invitee and invitation to every face and clears ignored", async () => {
+        mockSend.mockResolvedValueOnce({ Items: clusterFaces }).mockResolvedValue({});
+
+        const count = await updateClusterAssignment("c1", {
+            invitee_id: 7,
+            invitation_id: 3,
+        });
+
+        expect(count).toBe(2);
+        // 1 cluster query + 2 face updates
+        expect(mockSend).toHaveBeenCalledTimes(3);
+        const update = sentCommand(1);
+        expect(update.UpdateExpression).toBe(
+            "SET invitee_id = :invitee, invitation_id = :invitation REMOVE ignored"
+        );
+        expect(update.ExpressionAttributeValues).toEqual({ ":invitee": 7, ":invitation": 3 });
+        expect(sentCommand(2).Key).toEqual({ face_id: "f2" });
+    });
+
+    it("ignoring a cluster removes any invitee assignment", async () => {
+        mockSend.mockResolvedValueOnce({ Items: clusterFaces }).mockResolvedValue({});
+
+        await updateClusterAssignment("c1", { ignored: true });
+
+        const update = sentCommand(1);
+        expect(update.UpdateExpression).toBe(
+            "SET ignored = :ignored REMOVE invitee_id, invitation_id"
+        );
+        expect(update.ExpressionAttributeValues).toEqual({ ":ignored": true });
+    });
+
+    it("clearing removes assignment and ignored flags", async () => {
+        mockSend.mockResolvedValueOnce({ Items: clusterFaces }).mockResolvedValue({});
+
+        await updateClusterAssignment("c1", null);
+
+        expect(sentCommand(1).UpdateExpression).toBe(
+            "REMOVE invitee_id, invitation_id, ignored"
+        );
+    });
+
+    it("returns 0 and writes nothing for an unknown cluster", async () => {
+        mockSend.mockResolvedValueOnce({ Items: [] });
+
+        expect(await updateClusterAssignment("nope", { ignored: true })).toBe(0);
+        expect(mockSend).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/utils/db/dynamo.ts
+++ b/src/utils/db/dynamo.ts
@@ -27,3 +27,4 @@ export const docClient = DynamoDBDocumentClient.from(client, {
 export const ARCHIVE_TABLE = process.env["DDB_ARCHIVE_TABLE"] ?? "wedding-archive";
 export const PHOTOS_TABLE = process.env["DDB_PHOTOS_TABLE"] ?? "wedding-photos";
 export const CATEGORIES_TABLE = process.env["DDB_CATEGORIES_TABLE"] ?? "wedding-photo-categories";
+export const FACES_TABLE = process.env["DDB_FACES_TABLE"] ?? "wedding-photo-faces";

--- a/src/utils/db/faces.ts
+++ b/src/utils/db/faces.ts
@@ -1,0 +1,122 @@
+import { QueryCommand, ScanCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { docClient, FACES_TABLE } from "./dynamo";
+import type { ClusterAssignment, PhotoFace } from "@/types/faces";
+
+// The whole table, for the admin labeling page (which groups by cluster in
+// code). A few thousand tiny items — one or two scan pages.
+export async function listAllFaces(): Promise<PhotoFace[]> {
+    const faces: PhotoFace[] = [];
+    let lastKey: Record<string, unknown> | undefined;
+    do {
+        const result = await docClient.send(
+            new ScanCommand({ TableName: FACES_TABLE, ExclusiveStartKey: lastKey })
+        );
+        faces.push(...((result.Items ?? []) as PhotoFace[]));
+        lastKey = result.LastEvaluatedKey;
+    } while (lastKey);
+    return faces;
+}
+
+export async function getFacesByCluster(clusterId: string): Promise<PhotoFace[]> {
+    const faces: PhotoFace[] = [];
+    let lastKey: Record<string, unknown> | undefined;
+    do {
+        const result = await docClient.send(
+            new QueryCommand({
+                TableName: FACES_TABLE,
+                IndexName: "byCluster",
+                KeyConditionExpression: "cluster_id = :cluster",
+                ExpressionAttributeValues: { ":cluster": clusterId },
+                ExclusiveStartKey: lastKey,
+            })
+        );
+        faces.push(...((result.Items ?? []) as PhotoFace[]));
+        lastKey = result.LastEvaluatedKey;
+    } while (lastKey);
+    return faces;
+}
+
+export async function getFacesByPhoto(photoId: string): Promise<PhotoFace[]> {
+    const result = await docClient.send(
+        new QueryCommand({
+            TableName: FACES_TABLE,
+            IndexName: "byPhoto",
+            KeyConditionExpression: "photo_id = :photo",
+            ExpressionAttributeValues: { ":photo": photoId },
+        })
+    );
+    return (result.Items ?? []) as PhotoFace[];
+}
+
+// Faces assigned to any of the given invitees (a household). The byInvitee
+// GSI is sparse, so unassigned faces never appear. Households are ≤ ~6
+// people, so parallel queries are fine.
+export async function getFacesByInvitees(inviteeIds: number[]): Promise<PhotoFace[]> {
+    const results = await Promise.all(
+        inviteeIds.map(async (inviteeId) => {
+            const faces: PhotoFace[] = [];
+            let lastKey: Record<string, unknown> | undefined;
+            do {
+                const result = await docClient.send(
+                    new QueryCommand({
+                        TableName: FACES_TABLE,
+                        IndexName: "byInvitee",
+                        KeyConditionExpression: "invitee_id = :invitee",
+                        ExpressionAttributeValues: { ":invitee": inviteeId },
+                        ExclusiveStartKey: lastKey,
+                    })
+                );
+                faces.push(...((result.Items ?? []) as PhotoFace[]));
+                lastKey = result.LastEvaluatedKey;
+            } while (lastKey);
+            return faces;
+        })
+    );
+    return results.flat();
+}
+
+// Apply an assignment to every face in a cluster. Not transactional: a crash
+// mid-way leaves a partial assignment, but re-applying converges (each face
+// update is idempotent), so the admin just clicks again.
+export async function updateClusterAssignment(
+    clusterId: string,
+    assignment: ClusterAssignment
+): Promise<number> {
+    const faces = await getFacesByCluster(clusterId);
+
+    for (const face of faces) {
+        if (assignment === null) {
+            await docClient.send(
+                new UpdateCommand({
+                    TableName: FACES_TABLE,
+                    Key: { face_id: face.face_id },
+                    UpdateExpression: "REMOVE invitee_id, invitation_id, ignored",
+                })
+            );
+        } else if ("ignored" in assignment) {
+            await docClient.send(
+                new UpdateCommand({
+                    TableName: FACES_TABLE,
+                    Key: { face_id: face.face_id },
+                    UpdateExpression: "SET ignored = :ignored REMOVE invitee_id, invitation_id",
+                    ExpressionAttributeValues: { ":ignored": true },
+                })
+            );
+        } else {
+            await docClient.send(
+                new UpdateCommand({
+                    TableName: FACES_TABLE,
+                    Key: { face_id: face.face_id },
+                    UpdateExpression:
+                        "SET invitee_id = :invitee, invitation_id = :invitation REMOVE ignored",
+                    ExpressionAttributeValues: {
+                        ":invitee": assignment.invitee_id,
+                        ":invitation": assignment.invitation_id,
+                    },
+                })
+            );
+        }
+    }
+
+    return faces.length;
+}


### PR DESCRIPTION
Part 1 of 3 for #162 (Find My Photos), using the revised **cluster-then-label** approach: index every face in the existing gallery into the `wedding-faces-2026` Rekognition collection, cluster them into distinct people, then (PR 2) label clusters with guest names in the dashboard and (PR 3) let guests see their photos with just their invitation code — no selfies.

## Infrastructure (CDK)

- **New DynamoDB table `wedding-photo-faces`** — one item per detected face, with GSIs `byPhoto` (Lambda idempotency), `byCluster` (labeling fan-out), and `byInvitee` (sparse; powers guest my-photos). Cluster assignment is denormalized onto every face row, matching the archive table's scan-and-assemble pattern.
- **IAM**: `DynamoAccessPolicy` now covers the faces table (plus `DeleteItem` scoped to it alone); `RekognitionPolicy` gains `SearchFaces`/`ListFaces` and is finally **attached to the photo-processor Lambda role** — it was previously created but attached to nothing. The Next.js app never calls Rekognition, so `wedding-api-lambda` gets no Rekognition permissions.
- photo-processor env: `FACES_TABLE`, `REKOGNITION_COLLECTION_ID`, `FACE_MATCH_THRESHOLD` (95).

## photo-processor Lambda

After thumbnailing, new uploads are face-indexed and searched against the collection: a match to an already-clustered face adopts that cluster (and its invitee label, if any), so future uploads of known people surface in Find My Photos with zero admin work. The face step runs in its own try/catch — a Rekognition failure can never break thumbnail generation. All face calls use the 1200px thumbnail (originals can exceed Rekognition's 15 MB S3 limit).

## Backfill — `scripts/index-faces.mjs`

Run locally with prod credentials (same pattern as the S3 photo import):

- **Phase A**: `IndexFaces` for every photo with a thumbnail; `face_indexed_at` on the photo row makes it idempotent/resumable (and covers zero-face photos).
- **Phase B**: `SearchFaces`-by-FaceId + union-find clustering at threshold 95 (biased so mistakes split a person into two clusters — cheap to fix by labeling both — rather than merging two people). Refuses to re-cluster once labeling has started unless `--force`.
- Flags: `--dry-run`, `--limit N`, `--index-only`, `--cluster-only`, `--threshold N`, `--force`. Estimated cost for the full ~733-photo backfill: under $5.

## App plumbing

`src/utils/db/faces.ts` + `src/types/faces.ts` (used by PR 2/3 routes), `FACES_TABLE` export, `DDB_FACES_TABLE` in the `next.config.js` env block.

## Testing

- `npm run test:run`: 141 passed; `tsc --noEmit` and `eslint` clean.
- `cdk synth` succeeds (infra tsc has two pre-existing errors on main — `aws-lambda` types and `withMetadata(false)` — unchanged by this PR).
- Real Rekognition behavior is verified post-deploy: `--limit 5 --dry-run` → `--limit 5` → inspect `wedding-photo-faces` → full run.

## Deployment notes

1. `cdk deploy` from `infra/`.
2. Set `DDB_FACES_TABLE=wedding-photo-faces` in Amplify (app-level) — code falls back to the right name if unset, but keeping it explicit matches the other tables.
3. Run the backfill: `AWS_PROFILE=wedding S3_PHOTOS_BUCKET=oneill-wedding-photos node scripts/index-faces.mjs --limit 5` then the full run, and spot-check cluster purity before labeling.