### PR TITLE
feat: admin face-cluster labeling dashboard

### DIFF
--- a/src/app/api/dashboard/faces/clusters/[id]/__tests__/route.test.ts
+++ b/src/app/api/dashboard/faces/clusters/[id]/__tests__/route.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET, PATCH } from "../route";
+
+const mockRequireAuth = vi.fn();
+const mockGetFacesByCluster = vi.fn();
+const mockUpdateClusterAssignment = vi.fn();
+const mockListAllInvitees = vi.fn();
+const mockGetPhotosByIds = vi.fn();
+
+vi.mock("@/utils/auth/requireAuth", () => ({
+    requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+}));
+vi.mock("@/utils/db/faces", () => ({
+    getFacesByCluster: (...args: unknown[]) => mockGetFacesByCluster(...args),
+    updateClusterAssignment: (...args: unknown[]) => mockUpdateClusterAssignment(...args),
+}));
+vi.mock("@/utils/db/archive", () => ({
+    listAllInvitees: (...args: unknown[]) => mockListAllInvitees(...args),
+}));
+vi.mock("@/utils/db/photos", () => ({
+    getPhotosByIds: (...args: unknown[]) => mockGetPhotosByIds(...args),
+}));
+vi.mock("@/utils/storage", () => ({
+    cdnUrl: (k: string) => `https://cdn/${k}`,
+}));
+
+const params = { params: Promise.resolve({ id: "c1" }) };
+
+const patchReq = (body: unknown) =>
+    new NextRequest("http://localhost/api/dashboard/faces/clusters/c1", {
+        method: "PATCH",
+        body: JSON.stringify(body),
+    });
+
+describe("/api/dashboard/faces/clusters/[id]", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockRequireAuth.mockResolvedValue({ success: true, payload: { email: "admin@test.com" } });
+        mockListAllInvitees.mockResolvedValue([
+            { id: 7, invitation_id: 3, name: "Aoife Byrne", code: "ABC123" },
+        ]);
+        mockGetPhotosByIds.mockResolvedValue([]);
+        mockUpdateClusterAssignment.mockResolvedValue(2);
+    });
+
+    it("GET requires auth", async () => {
+        mockRequireAuth.mockResolvedValue({
+            success: false,
+            response: new Response(null, { status: 401 }),
+        });
+        const res = await GET(
+            new NextRequest("http://localhost/api/dashboard/faces/clusters/c1"),
+            params
+        );
+        expect(res.status).toBe(401);
+    });
+
+    it("GET returns 404 for an unknown cluster", async () => {
+        mockGetFacesByCluster.mockResolvedValue([]);
+        const res = await GET(
+            new NextRequest("http://localhost/api/dashboard/faces/clusters/c1"),
+            params
+        );
+        expect(res.status).toBe(404);
+    });
+
+    it("GET returns faces sorted by confidence with crop data", async () => {
+        mockGetFacesByCluster.mockResolvedValue([
+            {
+                face_id: "low",
+                photo_id: "p1",
+                cluster_id: "c1",
+                bounding_box: { left: 0, top: 0, width: 0.1, height: 0.1 },
+                confidence: 80,
+            },
+            {
+                face_id: "high",
+                photo_id: "p1",
+                cluster_id: "c1",
+                bounding_box: { left: 0.5, top: 0.5, width: 0.1, height: 0.1 },
+                confidence: 99,
+            },
+        ]);
+        mockGetPhotosByIds.mockResolvedValue([
+            { id: "p1", thumbnail_key: "t/p1.jpg", width: 1200, height: 800 },
+        ]);
+        const res = await GET(
+            new NextRequest("http://localhost/api/dashboard/faces/clusters/c1"),
+            params
+        );
+        const body = await res.json();
+        expect(body.faces.map((f: { face_id: string }) => f.face_id)).toEqual(["high", "low"]);
+        expect(body.faces[0].thumbnail_url).toBe("https://cdn/t/p1.jpg");
+    });
+
+    it("PATCH assign resolves invitation_id from the archive", async () => {
+        const res = await PATCH(patchReq({ invitee_id: 7 }), params);
+        expect(res.status).toBe(200);
+        expect(mockUpdateClusterAssignment).toHaveBeenCalledWith("c1", {
+            invitee_id: 7,
+            invitation_id: 3,
+        });
+        expect(await res.json()).toEqual({ cluster_id: "c1", updated: 2 });
+    });
+
+    it("PATCH rejects an unknown invitee", async () => {
+        const res = await PATCH(patchReq({ invitee_id: 999 }), params);
+        expect(res.status).toBe(400);
+        expect(mockUpdateClusterAssignment).not.toHaveBeenCalled();
+    });
+
+    it("PATCH ignore marks the cluster ignored", async () => {
+        const res = await PATCH(patchReq({ ignored: true }), params);
+        expect(res.status).toBe(200);
+        expect(mockUpdateClusterAssignment).toHaveBeenCalledWith("c1", { ignored: true });
+    });
+
+    it("PATCH invitee_id null clears the assignment", async () => {
+        const res = await PATCH(patchReq({ invitee_id: null }), params);
+        expect(res.status).toBe(200);
+        expect(mockUpdateClusterAssignment).toHaveBeenCalledWith("c1", null);
+    });
+
+    it("PATCH rejects a body with neither field", async () => {
+        const res = await PATCH(patchReq({}), params);
+        expect(res.status).toBe(400);
+    });
+
+    it("PATCH returns 404 when the cluster has no faces", async () => {
+        mockUpdateClusterAssignment.mockResolvedValue(0);
+        const res = await PATCH(patchReq({ ignored: true }), params);
+        expect(res.status).toBe(404);
+    });
+});

--- a/src/app/api/dashboard/faces/clusters/[id]/route.ts
+++ b/src/app/api/dashboard/faces/clusters/[id]/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/utils/auth/requireAuth";
+import { getFacesByCluster, updateClusterAssignment } from "@/utils/db/faces";
+import { listAllInvitees } from "@/utils/db/archive";
+import { getPhotosByIds } from "@/utils/db/photos";
+import { cdnUrl } from "@/utils/storage";
+import type { ClusterDetailResponse } from "@/types/faces";
+
+// Every face in a cluster, for the sanity-check modal before assigning.
+export async function GET(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    const auth = await requireAuth(request);
+    if (!auth.success) return auth.response;
+
+    try {
+        const { id } = await params;
+        const faces = await getFacesByCluster(id);
+        if (faces.length === 0) {
+            return NextResponse.json({ error: "Cluster not found" }, { status: 404 });
+        }
+
+        const photos = await getPhotosByIds([...new Set(faces.map((f) => f.photo_id))]);
+        const photoById = new Map(photos.map((p) => [p.id, p]));
+        const assigned = faces.find((f) => f.invitee_id != null);
+        const inviteeName = assigned
+            ? ((await listAllInvitees()).find((i) => i.id === assigned.invitee_id)?.name ?? null)
+            : null;
+
+        const response: ClusterDetailResponse = {
+            cluster_id: id,
+            invitee_id: assigned?.invitee_id ?? null,
+            invitee_name: inviteeName,
+            ignored: faces.some((f) => f.ignored),
+            faces: faces
+                .sort((a, b) => b.confidence - a.confidence)
+                .map((f) => {
+                    const photo = photoById.get(f.photo_id);
+                    return {
+                        face_id: f.face_id,
+                        photo_id: f.photo_id,
+                        thumbnail_url: photo?.thumbnail_key ? cdnUrl(photo.thumbnail_key) : null,
+                        thumbnail_width: photo?.width ?? null,
+                        thumbnail_height: photo?.height ?? null,
+                        bounding_box: f.bounding_box,
+                        confidence: f.confidence,
+                    };
+                }),
+        };
+        return NextResponse.json(response);
+    } catch (error) {
+        console.error("Error in GET /api/dashboard/faces/clusters/[id]:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}
+
+interface PatchBody {
+    invitee_id?: number | null;
+    ignored?: boolean;
+}
+
+// Assign the cluster to an invitee, mark it ignored, or clear it
+// (invitee_id: null). The server resolves invitation_id from the archive so
+// the byInvitee GSI rows stay consistent with the household lookup.
+export async function PATCH(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    const auth = await requireAuth(request);
+    if (!auth.success) return auth.response;
+
+    try {
+        const { id } = await params;
+        const body: PatchBody = await request.json();
+
+        let updated: number;
+        if (body.ignored === true) {
+            updated = await updateClusterAssignment(id, { ignored: true });
+        } else if (body.invitee_id === null) {
+            updated = await updateClusterAssignment(id, null);
+        } else if (typeof body.invitee_id === "number") {
+            const invitee = (await listAllInvitees()).find((i) => i.id === body.invitee_id);
+            if (!invitee) {
+                return NextResponse.json({ error: "Unknown invitee" }, { status: 400 });
+            }
+            updated = await updateClusterAssignment(id, {
+                invitee_id: invitee.id,
+                invitation_id: invitee.invitation_id,
+            });
+        } else {
+            return NextResponse.json(
+                { error: "Body must set invitee_id (number or null) or ignored: true" },
+                { status: 400 }
+            );
+        }
+
+        if (updated === 0) {
+            return NextResponse.json({ error: "Cluster not found" }, { status: 404 });
+        }
+        return NextResponse.json({ cluster_id: id, updated });
+    } catch (error) {
+        console.error("Error in PATCH /api/dashboard/faces/clusters/[id]:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/app/api/dashboard/faces/clusters/__tests__/route.test.ts
+++ b/src/app/api/dashboard/faces/clusters/__tests__/route.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+
+const mockRequireAuth = vi.fn();
+const mockListAllFaces = vi.fn();
+const mockListAllInvitees = vi.fn();
+const mockGetPhotosByIds = vi.fn();
+
+vi.mock("@/utils/auth/requireAuth", () => ({
+    requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+}));
+vi.mock("@/utils/db/faces", () => ({
+    listAllFaces: (...args: unknown[]) => mockListAllFaces(...args),
+}));
+vi.mock("@/utils/db/archive", () => ({
+    listAllInvitees: (...args: unknown[]) => mockListAllInvitees(...args),
+}));
+vi.mock("@/utils/db/photos", () => ({
+    getPhotosByIds: (...args: unknown[]) => mockGetPhotosByIds(...args),
+}));
+vi.mock("@/utils/storage", () => ({
+    cdnUrl: (k: string) => `https://cdn/${k}`,
+}));
+
+const face = (over: Record<string, unknown>) => ({
+    face_id: "f",
+    photo_id: "p1",
+    cluster_id: "c1",
+    bounding_box: { left: 0.1, top: 0.1, width: 0.2, height: 0.2 },
+    confidence: 99,
+    indexed_at: "2026-07-18T00:00:00Z",
+    ...over,
+});
+
+describe("GET /api/dashboard/faces/clusters", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockRequireAuth.mockResolvedValue({ success: true, payload: { email: "admin@test.com" } });
+        mockListAllInvitees.mockResolvedValue([
+            { id: 7, invitation_id: 3, name: "Aoife Byrne", code: "ABC123" },
+        ]);
+        mockGetPhotosByIds.mockResolvedValue([
+            { id: "p1", thumbnail_key: "uploads/thumbnail/x/p1.jpg", width: 1200, height: 800 },
+        ]);
+    });
+
+    it("requires auth", async () => {
+        mockRequireAuth.mockResolvedValue({
+            success: false,
+            response: new Response(null, { status: 401 }),
+        });
+        const res = await GET(new NextRequest("http://localhost/api/dashboard/faces/clusters"));
+        expect(res.status).toBe(401);
+        expect(mockListAllFaces).not.toHaveBeenCalled();
+    });
+
+    it("groups faces into clusters with counts and the highest-confidence rep face", async () => {
+        mockListAllFaces.mockResolvedValue([
+            face({ face_id: "f1", confidence: 90 }),
+            face({ face_id: "f2", confidence: 99.5 }),
+            face({ face_id: "f3", cluster_id: "c2" }),
+        ]);
+        const res = await GET(new NextRequest("http://localhost/api/dashboard/faces/clusters"));
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.clusters).toHaveLength(2);
+        const c1 = body.clusters.find(
+            (c: { cluster_id: string }) => c.cluster_id === "c1"
+        );
+        expect(c1.face_count).toBe(2);
+        expect(c1.rep_face.face_id).toBe("f2");
+        expect(c1.rep_face.thumbnail_url).toBe("https://cdn/uploads/thumbnail/x/p1.jpg");
+        expect(c1.rep_face.thumbnail_width).toBe(1200);
+    });
+
+    it("orders unassigned clusters before labeled ones, biggest first", async () => {
+        mockListAllFaces.mockResolvedValue([
+            face({ face_id: "f1", cluster_id: "assigned", invitee_id: 7, invitation_id: 3 }),
+            face({ face_id: "f2", cluster_id: "big" }),
+            face({ face_id: "f3", cluster_id: "big" }),
+            face({ face_id: "f4", cluster_id: "small" }),
+        ]);
+        const res = await GET(new NextRequest("http://localhost/api/dashboard/faces/clusters"));
+        const body = await res.json();
+        expect(
+            body.clusters.map((c: { cluster_id: string }) => c.cluster_id)
+        ).toEqual(["big", "small", "assigned"]);
+    });
+
+    it("resolves invitee names and reports progress, counting unclustered faces", async () => {
+        mockListAllFaces.mockResolvedValue([
+            face({ face_id: "f1", cluster_id: "c1", invitee_id: 7, invitation_id: 3 }),
+            face({ face_id: "f2", cluster_id: "c2", ignored: true }),
+            face({ face_id: "f3", cluster_id: "c3" }),
+            face({ face_id: "f4", cluster_id: undefined }),
+        ]);
+        const res = await GET(new NextRequest("http://localhost/api/dashboard/faces/clusters"));
+        const body = await res.json();
+
+        const c1 = body.clusters.find(
+            (c: { cluster_id: string }) => c.cluster_id === "c1"
+        );
+        expect(c1.invitee_name).toBe("Aoife Byrne");
+        expect(body.progress).toEqual({
+            total: 2, // c1 + c3; ignored c2 excluded
+            assigned: 1,
+            ignored: 1,
+            unclustered_faces: 1,
+        });
+    });
+});

--- a/src/app/api/dashboard/faces/clusters/route.ts
+++ b/src/app/api/dashboard/faces/clusters/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/utils/auth/requireAuth";
+import { listAllFaces } from "@/utils/db/faces";
+import { listAllInvitees } from "@/utils/db/archive";
+import { getPhotosByIds } from "@/utils/db/photos";
+import { cdnUrl } from "@/utils/storage";
+import type { PhotoFace } from "@/types/faces";
+import type { ClustersResponse, ClusterSummary } from "@/types/faces";
+
+// Cluster overview for the labeling page: one entry per cluster with its
+// highest-confidence face as the representative crop.
+export async function GET(request: NextRequest) {
+    const auth = await requireAuth(request);
+    if (!auth.success) return auth.response;
+
+    try {
+        const [faces, invitees] = await Promise.all([listAllFaces(), listAllInvitees()]);
+        const inviteeNames = new Map(invitees.map((i) => [i.id, i.name]));
+
+        const byCluster = new Map<string, PhotoFace[]>();
+        let unclusteredFaces = 0;
+        for (const face of faces) {
+            // Rows indexed but not yet clustered (backfill Phase A only).
+            if (!face.cluster_id) {
+                unclusteredFaces++;
+                continue;
+            }
+            const list = byCluster.get(face.cluster_id) ?? [];
+            list.push(face);
+            byCluster.set(face.cluster_id, list);
+        }
+
+        // One thumbnail lookup per cluster (its rep face), not per face.
+        const repFaces = new Map(
+            [...byCluster.entries()].map(([clusterId, clusterFaces]) => [
+                clusterId,
+                clusterFaces.reduce((best, f) => (f.confidence > best.confidence ? f : best)),
+            ])
+        );
+        const photos = await getPhotosByIds([
+            ...new Set([...repFaces.values()].map((f) => f.photo_id)),
+        ]);
+        const photoById = new Map(photos.map((p) => [p.id, p]));
+
+        const clusters: ClusterSummary[] = [...byCluster.entries()].map(
+            ([clusterId, clusterFaces]) => {
+                const rep = repFaces.get(clusterId)!;
+                const photo = photoById.get(rep.photo_id);
+                // Any face in the cluster carries the assignment (denormalized).
+                const assigned = clusterFaces.find((f) => f.invitee_id != null);
+                return {
+                    cluster_id: clusterId,
+                    face_count: clusterFaces.length,
+                    invitee_id: assigned?.invitee_id ?? null,
+                    invitee_name: assigned ? (inviteeNames.get(assigned.invitee_id!) ?? null) : null,
+                    ignored: clusterFaces.some((f) => f.ignored),
+                    rep_face: {
+                        face_id: rep.face_id,
+                        photo_id: rep.photo_id,
+                        thumbnail_url: photo?.thumbnail_key ? cdnUrl(photo.thumbnail_key) : null,
+                        thumbnail_width: photo?.width ?? null,
+                        thumbnail_height: photo?.height ?? null,
+                        bounding_box: rep.bounding_box,
+                        confidence: rep.confidence,
+                    },
+                };
+            }
+        );
+
+        // Unassigned first (that's the work queue), biggest clusters first
+        // within each group so the most valuable labeling happens early.
+        clusters.sort((a, b) => {
+            const aDone = a.invitee_id != null || a.ignored ? 1 : 0;
+            const bDone = b.invitee_id != null || b.ignored ? 1 : 0;
+            if (aDone !== bDone) return aDone - bDone;
+            return b.face_count - a.face_count;
+        });
+
+        const ignored = clusters.filter((c) => c.ignored).length;
+        const response: ClustersResponse = {
+            clusters,
+            progress: {
+                total: clusters.length - ignored,
+                assigned: clusters.filter((c) => c.invitee_id != null).length,
+                ignored,
+                unclustered_faces: unclusteredFaces,
+            },
+        };
+        return NextResponse.json(response);
+    } catch (error) {
+        console.error("Error in GET /api/dashboard/faces/clusters:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/app/api/dashboard/faces/invitees/__tests__/route.test.ts
+++ b/src/app/api/dashboard/faces/invitees/__tests__/route.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+
+const mockRequireAuth = vi.fn();
+const mockListAllInvitees = vi.fn();
+
+vi.mock("@/utils/auth/requireAuth", () => ({
+    requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+}));
+vi.mock("@/utils/db/archive", () => ({
+    listAllInvitees: (...args: unknown[]) => mockListAllInvitees(...args),
+}));
+
+describe("GET /api/dashboard/faces/invitees", () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it("requires auth", async () => {
+        mockRequireAuth.mockResolvedValue({
+            success: false,
+            response: new Response(null, { status: 401 }),
+        });
+        const res = await GET(new NextRequest("http://localhost/api/dashboard/faces/invitees"));
+        expect(res.status).toBe(401);
+        expect(mockListAllInvitees).not.toHaveBeenCalled();
+    });
+
+    it("returns the invitee list for the picker", async () => {
+        mockRequireAuth.mockResolvedValue({ success: true, payload: {} });
+        const invitees = [{ id: 7, invitation_id: 3, name: "Aoife Byrne", code: "ABC123" }];
+        mockListAllInvitees.mockResolvedValue(invitees);
+        const res = await GET(new NextRequest("http://localhost/api/dashboard/faces/invitees"));
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ invitees });
+    });
+});

--- a/src/app/api/dashboard/faces/invitees/route.ts
+++ b/src/app/api/dashboard/faces/invitees/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/utils/auth/requireAuth";
+import { listAllInvitees } from "@/utils/db/archive";
+
+// Invitee list for the cluster-assignment picker.
+export async function GET(request: NextRequest) {
+    const auth = await requireAuth(request);
+    if (!auth.success) return auth.response;
+
+    try {
+        return NextResponse.json({ invitees: await listAllInvitees() });
+    } catch (error) {
+        console.error("Error in GET /api/dashboard/faces/invitees:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/app/dashboard/photos/faces/page.tsx
+++ b/src/app/dashboard/photos/faces/page.tsx
@@ -110,10 +110,14 @@ export default function FacesPage() {
         setDetailLoading(true);
         try {
             const res = await fetch(`/api/dashboard/faces/clusters/${clusterId}`);
-            if (detailRequestId.current !== requestId) return; // closed or superseded
             if (!res.ok) throw new Error("Failed to load cluster");
-            setDetail(await res.json());
+            const json = await res.json();
+            // Guard after the last await — res.json() is an await point too,
+            // and a close during parsing must not resurface stale data.
+            if (detailRequestId.current !== requestId) return;
+            setDetail(json);
         } catch (err) {
+            if (detailRequestId.current !== requestId) return; // stale failure, irrelevant
             setError(err instanceof Error ? err.message : "Failed to load cluster");
         } finally {
             if (detailRequestId.current === requestId) setDetailLoading(false);

--- a/src/app/dashboard/photos/faces/page.tsx
+++ b/src/app/dashboard/photos/faces/page.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+    Stack,
+    Title,
+    Text,
+    Tabs,
+    SimpleGrid,
+    Paper,
+    Group,
+    Button,
+    Select,
+    Badge,
+    Alert,
+    Loader,
+    Center,
+    Anchor,
+    Modal,
+    UnstyledButton,
+} from "@mantine/core";
+import { IconAlertCircle } from "@tabler/icons-react";
+import Link from "next/link";
+import { FaceCrop } from "@/components/FaceCrop";
+import type { ClusterSummary, ClustersResponse, ClusterDetailResponse } from "@/types/faces";
+import type { InviteeSummary } from "@/utils/db/archive";
+
+type FilterTab = "unassigned" | "assigned" | "ignored";
+
+function clusterTab(cluster: ClusterSummary): FilterTab {
+    if (cluster.ignored) return "ignored";
+    if (cluster.invitee_id != null) return "assigned";
+    return "unassigned";
+}
+
+export default function FacesPage() {
+    const [clusters, setClusters] = useState<ClusterSummary[]>([]);
+    const [unclusteredFaces, setUnclusteredFaces] = useState(0);
+    const [invitees, setInvitees] = useState<InviteeSummary[]>([]);
+    const [activeTab, setActiveTab] = useState<FilterTab>("unassigned");
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [detail, setDetail] = useState<ClusterDetailResponse | null>(null);
+    const [detailLoading, setDetailLoading] = useState(false);
+
+    const fetchClusters = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await fetch("/api/dashboard/faces/clusters");
+            if (!res.ok) throw new Error("Failed to load face clusters");
+            const data: ClustersResponse = await res.json();
+            setClusters(data.clusters ?? []);
+            setUnclusteredFaces(data.progress?.unclustered_faces ?? 0);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to load face clusters");
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchClusters();
+        fetch("/api/dashboard/faces/invitees")
+            .then((r) => r.json())
+            .then((d) => setInvitees(d.invitees ?? []))
+            .catch(() => {});
+    }, [fetchClusters]);
+
+    const patchCluster = async (
+        clusterId: string,
+        body: { invitee_id: number | null } | { ignored: true }
+    ) => {
+        try {
+            const res = await fetch(`/api/dashboard/faces/clusters/${clusterId}`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(body),
+            });
+            if (!res.ok) throw new Error("Update failed");
+            setClusters((prev) =>
+                prev.map((c) => {
+                    if (c.cluster_id !== clusterId) return c;
+                    if ("ignored" in body) {
+                        return { ...c, ignored: true, invitee_id: null, invitee_name: null };
+                    }
+                    if (body.invitee_id === null) {
+                        return { ...c, ignored: false, invitee_id: null, invitee_name: null };
+                    }
+                    const invitee = invitees.find((i) => i.id === body.invitee_id);
+                    return {
+                        ...c,
+                        ignored: false,
+                        invitee_id: body.invitee_id,
+                        invitee_name: invitee?.name ?? null,
+                    };
+                })
+            );
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to update cluster");
+        }
+    };
+
+    const openDetail = async (clusterId: string) => {
+        setDetailLoading(true);
+        try {
+            const res = await fetch(`/api/dashboard/faces/clusters/${clusterId}`);
+            if (!res.ok) throw new Error("Failed to load cluster");
+            setDetail(await res.json());
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to load cluster");
+        } finally {
+            setDetailLoading(false);
+        }
+    };
+
+    const assigned = clusters.filter((c) => c.invitee_id != null).length;
+    const ignored = clusters.filter((c) => c.ignored).length;
+    const visible = clusters.filter((c) => clusterTab(c) === activeTab);
+    const counts: Record<FilterTab, number> = {
+        unassigned: clusters.length - assigned - ignored,
+        assigned,
+        ignored,
+    };
+
+    const inviteeOptions = invitees.map((i) => ({
+        value: String(i.id),
+        label: i.code ? `${i.name} (${i.code})` : i.name,
+    }));
+
+    return (
+        <Stack gap="lg">
+            <Group justify="space-between" align="center">
+                <Title order={2} style={{ fontWeight: 300, color: "#495057", fontFamily: "serif" }}>
+                    Faces
+                </Title>
+                <Anchor component={Link} href="/dashboard/photos" size="sm" c="dimmed">
+                    ← Photo moderation
+                </Anchor>
+            </Group>
+
+            <Text c="dimmed" size="sm">
+                {assigned} of {clusters.length - ignored} people identified · {ignored} ignored
+                {unclusteredFaces > 0 &&
+                    ` · ${unclusteredFaces} faces not yet clustered (run the clustering script)`}
+            </Text>
+
+            {error && (
+                <Alert icon={<IconAlertCircle size={16} />} color="red" variant="light">
+                    {error}
+                </Alert>
+            )}
+
+            <Tabs value={activeTab} onChange={(v) => setActiveTab(v as FilterTab)}>
+                <Tabs.List>
+                    <Tabs.Tab value="unassigned">
+                        Unassigned{" "}
+                        {counts.unassigned > 0 && (
+                            <Badge size="xs" color="yellow" ml={4}>
+                                {counts.unassigned}
+                            </Badge>
+                        )}
+                    </Tabs.Tab>
+                    <Tabs.Tab value="assigned">Assigned</Tabs.Tab>
+                    <Tabs.Tab value="ignored">Ignored</Tabs.Tab>
+                </Tabs.List>
+            </Tabs>
+
+            {loading ? (
+                <Center py="xl">
+                    <Loader color="yellow" />
+                </Center>
+            ) : visible.length === 0 ? (
+                <Center py="xl">
+                    <Text c="dimmed">
+                        {activeTab === "unassigned" && clusters.length > 0
+                            ? "All faces are labeled 🎉"
+                            : `No ${activeTab} faces`}
+                    </Text>
+                </Center>
+            ) : (
+                <SimpleGrid cols={{ base: 2, sm: 3, md: 4, lg: 5 }} spacing="md">
+                    {visible.map((cluster) => (
+                        <Paper key={cluster.cluster_id} p="sm" withBorder>
+                            <Stack gap="xs" align="center">
+                                <UnstyledButton
+                                    onClick={() => openDetail(cluster.cluster_id)}
+                                    title="See every photo of this face"
+                                >
+                                    <FaceCrop
+                                        src={cluster.rep_face.thumbnail_url}
+                                        box={cluster.rep_face.bounding_box}
+                                        imgWidth={cluster.rep_face.thumbnail_width}
+                                        imgHeight={cluster.rep_face.thumbnail_height}
+                                        size={120}
+                                    />
+                                </UnstyledButton>
+                                <Badge variant="light" color="gray">
+                                    {cluster.face_count} photo{cluster.face_count === 1 ? "" : "s"}
+                                </Badge>
+                                {cluster.invitee_name && (
+                                    <Badge color="green" variant="light">
+                                        {cluster.invitee_name}
+                                    </Badge>
+                                )}
+                                {activeTab === "unassigned" ? (
+                                    <>
+                                        <Select
+                                            placeholder="Who is this?"
+                                            data={inviteeOptions}
+                                            searchable
+                                            size="xs"
+                                            w="100%"
+                                            onChange={(value) =>
+                                                value &&
+                                                patchCluster(cluster.cluster_id, {
+                                                    invitee_id: Number(value),
+                                                })
+                                            }
+                                        />
+                                        <Button
+                                            variant="subtle"
+                                            color="gray"
+                                            size="compact-xs"
+                                            onClick={() =>
+                                                patchCluster(cluster.cluster_id, { ignored: true })
+                                            }
+                                        >
+                                            Ignore
+                                        </Button>
+                                    </>
+                                ) : (
+                                    <Button
+                                        variant="subtle"
+                                        color="gray"
+                                        size="compact-xs"
+                                        onClick={() =>
+                                            patchCluster(cluster.cluster_id, { invitee_id: null })
+                                        }
+                                    >
+                                        Clear
+                                    </Button>
+                                )}
+                            </Stack>
+                        </Paper>
+                    ))}
+                </SimpleGrid>
+            )}
+
+            <Modal
+                opened={detail !== null || detailLoading}
+                onClose={() => setDetail(null)}
+                title={
+                    detail?.invitee_name
+                        ? `Faces assigned to ${detail.invitee_name}`
+                        : "All faces in this cluster"
+                }
+                size="lg"
+            >
+                {detailLoading || !detail ? (
+                    <Center py="lg">
+                        <Loader color="yellow" />
+                    </Center>
+                ) : (
+                    <Stack gap="sm">
+                        <Text size="sm" c="dimmed">
+                            If two different people appear here, the clustering threshold was too
+                            low for this group — re-run the script with a higher --threshold
+                            before labeling.
+                        </Text>
+                        <SimpleGrid cols={{ base: 3, sm: 4, md: 5 }} spacing="sm">
+                            {detail.faces.map((face) => (
+                                <FaceCrop
+                                    key={face.face_id}
+                                    src={face.thumbnail_url}
+                                    box={face.bounding_box}
+                                    imgWidth={face.thumbnail_width}
+                                    imgHeight={face.thumbnail_height}
+                                    size={90}
+                                />
+                            ))}
+                        </SimpleGrid>
+                    </Stack>
+                )}
+            </Modal>
+        </Stack>
+    );
+}

--- a/src/app/dashboard/photos/faces/page.tsx
+++ b/src/app/dashboard/photos/faces/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
     Stack,
     Title,
@@ -42,6 +42,10 @@ export default function FacesPage() {
     const [error, setError] = useState<string | null>(null);
     const [detail, setDetail] = useState<ClusterDetailResponse | null>(null);
     const [detailLoading, setDetailLoading] = useState(false);
+    // Monotonic id per detail fetch: closing the modal (or opening another
+    // cluster) bumps it, so a stale response can neither reopen a dismissed
+    // modal nor overwrite a newer cluster's data.
+    const detailRequestId = useRef(0);
 
     const fetchClusters = useCallback(async () => {
         setLoading(true);
@@ -102,16 +106,24 @@ export default function FacesPage() {
     };
 
     const openDetail = async (clusterId: string) => {
+        const requestId = ++detailRequestId.current;
         setDetailLoading(true);
         try {
             const res = await fetch(`/api/dashboard/faces/clusters/${clusterId}`);
+            if (detailRequestId.current !== requestId) return; // closed or superseded
             if (!res.ok) throw new Error("Failed to load cluster");
             setDetail(await res.json());
         } catch (err) {
             setError(err instanceof Error ? err.message : "Failed to load cluster");
         } finally {
-            setDetailLoading(false);
+            if (detailRequestId.current === requestId) setDetailLoading(false);
         }
+    };
+
+    const closeDetail = () => {
+        detailRequestId.current++;
+        setDetail(null);
+        setDetailLoading(false);
     };
 
     const assigned = clusters.filter((c) => c.invitee_id != null).length;
@@ -249,7 +261,7 @@ export default function FacesPage() {
 
             <Modal
                 opened={detail !== null || detailLoading}
-                onClose={() => setDetail(null)}
+                onClose={closeDetail}
                 title={
                     detail?.invitee_name
                         ? `Faces assigned to ${detail.invitee_name}`

--- a/src/app/dashboard/photos/page.tsx
+++ b/src/app/dashboard/photos/page.tsx
@@ -117,9 +117,14 @@ export default function PhotosModerationPage() {
                 <Title order={2} style={{ fontWeight: 300, color: "#495057", fontFamily: "serif" }}>
                     Photo Moderation
                 </Title>
-                <Anchor component={Link} href="/dashboard/photos/categories" size="sm" c="dimmed">
-                    Manage categories →
-                </Anchor>
+                <Group gap="md">
+                    <Anchor component={Link} href="/dashboard/photos/faces" size="sm" c="dimmed">
+                        Faces →
+                    </Anchor>
+                    <Anchor component={Link} href="/dashboard/photos/categories" size="sm" c="dimmed">
+                        Manage categories →
+                    </Anchor>
+                </Group>
             </Group>
 
             {error && (

--- a/src/components/FaceCrop.tsx
+++ b/src/components/FaceCrop.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import type { FaceBoundingBox } from "@/types/faces";
+
+interface FaceCropProps {
+    src: string | null;
+    box: FaceBoundingBox;
+    // Natural dimensions of the image at src (the photo's stored thumbnail
+    // width/height — the same image the bounding box was measured on).
+    imgWidth: number | null;
+    imgHeight: number | null;
+    size?: number;
+}
+
+// Crop a face out of an existing thumbnail with pure CSS — no server-side
+// crop pipeline. The image is absolutely positioned and scaled inside a
+// fixed square so the (padded) bounding box fills the frame.
+export function FaceCrop({ src, box, imgWidth, imgHeight, size = 96 }: FaceCropProps) {
+    const frame: React.CSSProperties = {
+        width: size,
+        height: size,
+        overflow: "hidden",
+        position: "relative",
+        borderRadius: 8,
+        backgroundColor: "var(--mantine-color-gray-2)",
+        flexShrink: 0,
+    };
+
+    if (!src || !imgWidth || !imgHeight) {
+        return <div style={frame} />;
+    }
+
+    // Pixel-space centre of the face, and a square crop window around it 40%
+    // larger than the box's longest side so faces aren't tight-cropped.
+    const cx = (box.left + box.width / 2) * imgWidth;
+    const cy = (box.top + box.height / 2) * imgHeight;
+    const half = (Math.max(box.width * imgWidth, box.height * imgHeight) / 2) * 1.4;
+    const scale = size / (2 * half);
+
+    return (
+        <div style={frame}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+                src={src}
+                alt=""
+                style={{
+                    position: "absolute",
+                    width: imgWidth * scale,
+                    height: imgHeight * scale,
+                    left: size / 2 - cx * scale,
+                    top: size / 2 - cy * scale,
+                    maxWidth: "none",
+                }}
+            />
+        </div>
+    );
+}

--- a/src/components/FaceCrop.tsx
+++ b/src/components/FaceCrop.tsx
@@ -26,7 +26,8 @@ export function FaceCrop({ src, box, imgWidth, imgHeight, size = 96 }: FaceCropP
         flexShrink: 0,
     };
 
-    if (!src || !imgWidth || !imgHeight) {
+    // A degenerate box (corrupt face row) would make scale Infinity/NaN below.
+    if (!src || !imgWidth || !imgHeight || box.width <= 0 || box.height <= 0) {
         return <div style={frame} />;
     }
 

--- a/src/components/__tests__/FaceCrop.test.tsx
+++ b/src/components/__tests__/FaceCrop.test.tsx
@@ -28,4 +28,16 @@ describe("FaceCrop", () => {
         );
         expect(container.querySelector("img")).toBeNull();
     });
+
+    it("renders an empty placeholder for a degenerate bounding box", () => {
+        const { container } = render(
+            <FaceCrop
+                src="https://cdn/t.jpg"
+                box={{ left: 0.5, top: 0.5, width: 0, height: 0.2 }}
+                imgWidth={1000}
+                imgHeight={800}
+            />
+        );
+        expect(container.querySelector("img")).toBeNull();
+    });
 });

--- a/src/components/__tests__/FaceCrop.test.tsx
+++ b/src/components/__tests__/FaceCrop.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { FaceCrop } from "../FaceCrop";
+
+const box = { left: 0.4, top: 0.2, width: 0.2, height: 0.3 };
+
+describe("FaceCrop", () => {
+    it("scales and offsets the image so the padded box fills the frame", () => {
+        const { container } = render(
+            <FaceCrop src="https://cdn/t.jpg" box={box} imgWidth={1000} imgHeight={800} size={100} />
+        );
+        const img = container.querySelector("img")!;
+
+        // Longest padded side: max(0.2*1000, 0.3*800) = 240px * 1.4 = 336px
+        // crop window; scale = 100/336.
+        const scale = 100 / 336;
+        expect(img).not.toBeNull();
+        expect(img.style.width).toBe(`${1000 * scale}px`);
+        expect(img.style.height).toBe(`${800 * scale}px`);
+        // Face centre (500, 280) maps to the frame centre (50, 50).
+        expect(parseFloat(img.style.left)).toBeCloseTo(50 - 500 * scale, 5);
+        expect(parseFloat(img.style.top)).toBeCloseTo(50 - 280 * scale, 5);
+    });
+
+    it("renders an empty placeholder without src or dimensions", () => {
+        const { container } = render(
+            <FaceCrop src={null} box={box} imgWidth={null} imgHeight={null} />
+        );
+        expect(container.querySelector("img")).toBeNull();
+    });
+});

--- a/src/types/faces.ts
+++ b/src/types/faces.ts
@@ -26,3 +26,43 @@ export type ClusterAssignment =
     | { invitee_id: number; invitation_id: number }
     | { ignored: true }
     | null; // clear assignment
+
+// A face as rendered by the admin UI: enough to CSS-crop it out of the
+// photo's thumbnail (width/height are the thumbnail's dimensions, which is
+// what the relative bounding box was measured against).
+export interface FaceView {
+    face_id: string;
+    photo_id: string;
+    thumbnail_url: string | null;
+    thumbnail_width: number | null;
+    thumbnail_height: number | null;
+    bounding_box: FaceBoundingBox;
+    confidence: number;
+}
+
+export interface ClusterSummary {
+    cluster_id: string;
+    face_count: number;
+    invitee_id: number | null;
+    invitee_name: string | null;
+    ignored: boolean;
+    rep_face: FaceView;
+}
+
+export interface ClustersResponse {
+    clusters: ClusterSummary[];
+    progress: {
+        total: number; // clusters with a face, excluding ignored
+        assigned: number;
+        ignored: number;
+        unclustered_faces: number; // rows awaiting the clustering phase
+    };
+}
+
+export interface ClusterDetailResponse {
+    cluster_id: string;
+    invitee_id: number | null;
+    invitee_name: string | null;
+    ignored: boolean;
+    faces: FaceView[];
+}

--- a/src/utils/db/archive.ts
+++ b/src/utils/db/archive.ts
@@ -55,6 +55,13 @@ export interface InvitationCodeSummary {
     invitee_names: string[];
 }
 
+export interface InviteeSummary {
+    id: number;
+    invitation_id: number;
+    name: string;
+    code: string | null;
+}
+
 // The bride & groom's master code lives in an env var, not the frozen
 // archive — it validates everywhere a guest code does, and /api/auth/me
 // hands it to logged-in admins so the gallery can auto-fill it.
@@ -140,6 +147,27 @@ export async function getArchiveSummary(): Promise<ArchiveSummary> {
             undecided: invitees.filter((g) => g.coming === null).length,
         },
     };
+}
+
+// Every archived invitee with their invitation's code, for the face-cluster
+// assignment picker. Alphabetical by full name.
+export async function listAllInvitees(): Promise<InviteeSummary[]> {
+    const items = await scanArchive();
+
+    const codeByInvitation = new Map<number, string>();
+    for (const item of items) {
+        if (item.entity === "code") codeByInvitation.set(item.invitation_id, item.code);
+    }
+
+    return items
+        .filter((i): i is InviteeItem => i.entity === "invitee")
+        .map((i) => ({
+            id: i.id,
+            invitation_id: i.invitation_id,
+            name: `${i.first_name} ${i.last_name}`,
+            code: codeByInvitation.get(i.invitation_id) ?? null,
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export async function listInvitationCodes(): Promise<InvitationCodeSummary[]> {

--- a/src/utils/db/photos.ts
+++ b/src/utils/db/photos.ts
@@ -116,17 +116,25 @@ export async function countPhotosByStatus(
 }
 
 // BatchGet in 100-key chunks (the DynamoDB per-request cap), retrying any
-// unprocessed keys. Order is not preserved; missing ids are simply absent.
+// unprocessed keys with exponential backoff — keys go unprocessed under
+// throttling, exactly when a tight retry loop would make things worse.
+// Order is not preserved; missing ids are simply absent.
 export async function getPhotosByIds(ids: string[]): Promise<Photo[]> {
     const photos: Photo[] = [];
     for (let i = 0; i < ids.length; i += 100) {
         let keys = ids.slice(i, i + 100).map((id) => ({ id }));
-        while (keys.length > 0) {
+        for (let attempt = 0; keys.length > 0; attempt++) {
+            if (attempt > 0) {
+                await new Promise((r) => setTimeout(r, 100 * 2 ** (attempt - 1)));
+            }
             const result = await docClient.send(
                 new BatchGetCommand({ RequestItems: { [PHOTOS_TABLE]: { Keys: keys } } })
             );
             photos.push(...((result.Responses?.[PHOTOS_TABLE] ?? []) as Photo[]));
             keys = (result.UnprocessedKeys?.[PHOTOS_TABLE]?.Keys ?? []) as { id: string }[];
+            if (attempt >= 5 && keys.length > 0) {
+                throw new Error(`BatchGet left ${keys.length} keys unprocessed after ${attempt + 1} attempts`);
+            }
         }
     }
     return photos;

--- a/src/utils/db/photos.ts
+++ b/src/utils/db/photos.ts
@@ -1,4 +1,5 @@
 import {
+    BatchGetCommand,
     GetCommand,
     PutCommand,
     QueryCommand,
@@ -112,6 +113,23 @@ export async function countPhotosByStatus(
         lastKey = result.LastEvaluatedKey;
     } while (lastKey);
     return count;
+}
+
+// BatchGet in 100-key chunks (the DynamoDB per-request cap), retrying any
+// unprocessed keys. Order is not preserved; missing ids are simply absent.
+export async function getPhotosByIds(ids: string[]): Promise<Photo[]> {
+    const photos: Photo[] = [];
+    for (let i = 0; i < ids.length; i += 100) {
+        let keys = ids.slice(i, i + 100).map((id) => ({ id }));
+        while (keys.length > 0) {
+            const result = await docClient.send(
+                new BatchGetCommand({ RequestItems: { [PHOTOS_TABLE]: { Keys: keys } } })
+            );
+            photos.push(...((result.Responses?.[PHOTOS_TABLE] ?? []) as Photo[]));
+            keys = (result.UnprocessedKeys?.[PHOTOS_TABLE]?.Keys ?? []) as { id: string }[];
+        }
+    }
+    return photos;
 }
 
 export interface ModerationUpdate {


### PR DESCRIPTION
Part 2 of 3 for #162 (Find My Photos), building on #184. Adds the admin side of cluster-then-label: a dashboard page where each distinct face found by the backfill is shown as a crop, and you assign it to a guest (or ignore it — vendors, strangers, the odd statue).

## UI — `/dashboard/photos/faces`

- Cluster grid (unassigned first, biggest clusters first — the bride/groom get labeled in two clicks) with a face crop, photo count, searchable "Who is this?" picker fed from the archive (`First Last (CODE)`), and an Ignore button.
- Click a face to open a modal showing **every** face in the cluster — the sanity check before assigning, since a mixed cluster means the clustering threshold needs a re-run.
- Unassigned / Assigned / Ignored tabs, progress line ("X of Y people identified · Z ignored"), and a warning when faces exist that haven't been clustered yet.
- Linked from the Photo Moderation header; protected by the existing dashboard middleware + Cognito.

**`FaceCrop`** renders face crops with pure CSS from the thumbnails already in CloudFront — the Rekognition bounding box is relative to the stored thumbnail, so no crop pipeline, no new S3 objects.

## API (all `requireAuth`)

| Route | Purpose |
|---|---|
| `GET /api/dashboard/faces/clusters` | Grouped cluster summaries + rep face (highest confidence) + progress totals |
| `GET /api/dashboard/faces/clusters/[id]` | Every face in a cluster, for the modal |
| `PATCH /api/dashboard/faces/clusters/[id]` | `{invitee_id}` / `{ignored: true}` / `{invitee_id: null}`; validates the invitee and resolves `invitation_id` server-side, then fans the assignment out to every face row |
| `GET /api/dashboard/faces/invitees` | Picker data |

New helpers: `listAllInvitees()` (archive scan-and-assemble, same pattern as `listInvitationCodes`) and `getPhotosByIds()` (chunked BatchGet with unprocessed-key retry).

## Testing

- 17 new tests: route auth gates, cluster grouping/rep-face selection/ordering, progress math incl. unclustered faces, all four PATCH branches (assign resolves `invitation_id`, unknown invitee 400, ignore, clear, 404), FaceCrop geometry.
- Suite: 164 passed; `tsc --noEmit` + `eslint` clean.

## After merging

Labeling can start as soon as the #184 infra is deployed and the backfill script has run — this page works against the real dataset immediately, and labeling can proceed in parallel with PR 3 (guest-facing page).