### PR TITLE
feat: guest-facing Find My Photos page

### DIFF
--- a/src/app/api/gallery/my-photos/__tests__/route.test.ts
+++ b/src/app/api/gallery/my-photos/__tests__/route.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+
+const mockRequireAuth = vi.fn();
+const mockIsValidInvitationCode = vi.fn();
+const mockGetInvitationIdByCode = vi.fn();
+const mockGetInviteesWithIds = vi.fn();
+const mockGetFacesByInvitees = vi.fn();
+const mockGetPhotosByIds = vi.fn();
+const mockListCategories = vi.fn();
+
+vi.mock("@/utils/auth/requireAuth", () => ({
+    requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+}));
+vi.mock("@/utils/db/archive", () => ({
+    isValidInvitationCode: (...args: unknown[]) => mockIsValidInvitationCode(...args),
+    getInvitationIdByCode: (...args: unknown[]) => mockGetInvitationIdByCode(...args),
+    getInviteesWithIds: (...args: unknown[]) => mockGetInviteesWithIds(...args),
+}));
+vi.mock("@/utils/db/faces", () => ({
+    getFacesByInvitees: (...args: unknown[]) => mockGetFacesByInvitees(...args),
+}));
+vi.mock("@/utils/db/photos", () => ({
+    getPhotosByIds: (...args: unknown[]) => mockGetPhotosByIds(...args),
+}));
+vi.mock("@/utils/db/categories", () => ({
+    listCategories: (...args: unknown[]) => mockListCategories(...args),
+}));
+vi.mock("@/utils/storage", () => ({
+    cdnUrl: (k: string) => `https://cdn/${k}`,
+}));
+
+const photo = (over: Record<string, unknown>) => ({
+    id: "p1",
+    invitation_code: "ABC123",
+    s3_key: "uploads/original/x/p1.jpg",
+    thumbnail_key: "uploads/thumbnail/x/p1.jpg",
+    file_name: "p1.jpg",
+    width: 1200,
+    height: 800,
+    size_bytes: 1000,
+    taken_at: "2026-05-30T14:00:00",
+    category_id: null,
+    status: "approved",
+    uploaded_at: "2026-06-01T12:00:00Z",
+    approved_at: null,
+    approved_by: "admin@test.com",
+    ...over,
+});
+
+const req = (qs = "") => new NextRequest(`http://localhost/api/gallery/my-photos${qs}`);
+
+describe("GET /api/gallery/my-photos", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockRequireAuth.mockResolvedValue({
+            success: false,
+            response: new Response(null, { status: 401 }),
+        });
+        mockIsValidInvitationCode.mockResolvedValue(true);
+        mockGetInvitationIdByCode.mockResolvedValue(3);
+        mockGetInviteesWithIds.mockResolvedValue([
+            { id: 7, first_name: "Aoife" },
+            { id: 8, first_name: "Brian" },
+        ]);
+        mockListCategories.mockResolvedValue([]);
+    });
+
+    it("rejects requests without a code", async () => {
+        const res = await GET(req());
+        expect(res.status).toBe(401);
+        expect(mockGetFacesByInvitees).not.toHaveBeenCalled();
+    });
+
+    it("rejects an invalid code", async () => {
+        mockIsValidInvitationCode.mockResolvedValue(false);
+        const res = await GET(req("?code=ZZZZZZ"));
+        expect(res.status).toBe(401);
+    });
+
+    it("dedupes photos when several household members appear in the same photo", async () => {
+        mockGetFacesByInvitees.mockResolvedValue([
+            { face_id: "f1", photo_id: "p1", invitee_id: 7 },
+            { face_id: "f2", photo_id: "p1", invitee_id: 8 },
+            { face_id: "f3", photo_id: "p2", invitee_id: 7 },
+        ]);
+        mockGetPhotosByIds.mockResolvedValue([photo({ id: "p1" }), photo({ id: "p2" })]);
+
+        const res = await GET(req("?code=ABC123"));
+        const body = await res.json();
+
+        expect(mockGetPhotosByIds).toHaveBeenCalledWith(["p1", "p2"]);
+        expect(body.photos).toHaveLength(2);
+        expect(body.invitees).toEqual(["Aoife", "Brian"]);
+        expect(body.total).toBe(2);
+    });
+
+    it("filters out pending and rejected photos", async () => {
+        mockGetFacesByInvitees.mockResolvedValue([
+            { face_id: "f1", photo_id: "p1", invitee_id: 7 },
+            { face_id: "f2", photo_id: "p2", invitee_id: 7 },
+            { face_id: "f3", photo_id: "p3", invitee_id: 7 },
+        ]);
+        mockGetPhotosByIds.mockResolvedValue([
+            photo({ id: "p1" }),
+            photo({ id: "p2", status: "pending" }),
+            photo({ id: "p3", status: "rejected" }),
+        ]);
+
+        const body = await (await GET(req("?code=ABC123"))).json();
+        expect(body.photos.map((p: { id: string }) => p.id)).toEqual(["p1"]);
+        expect(body.total).toBe(1);
+    });
+
+    it("only exposes PublicPhoto fields", async () => {
+        mockGetFacesByInvitees.mockResolvedValue([
+            { face_id: "f1", photo_id: "p1", invitee_id: 7 },
+        ]);
+        mockGetPhotosByIds.mockResolvedValue([photo({})]);
+
+        const body = await (await GET(req("?code=ABC123"))).json();
+        const keys = Object.keys(body.photos[0]);
+        expect(keys).not.toContain("s3_key");
+        expect(keys).not.toContain("invitation_code");
+        expect(keys).not.toContain("approved_by");
+        expect(body.photos[0].thumbnail_url).toBe("https://cdn/uploads/thumbnail/x/p1.jpg");
+    });
+
+    it("returns an empty result for the master code (no household)", async () => {
+        mockGetInvitationIdByCode.mockResolvedValue(null);
+        const body = await (await GET(req("?code=RM2026"))).json();
+        expect(body).toEqual({ photos: [], invitees: [], page: 1, limit: 200, total: 0 });
+        expect(mockGetFacesByInvitees).not.toHaveBeenCalled();
+    });
+
+    it("admin without a code gets an empty 200, not a 401", async () => {
+        mockRequireAuth.mockResolvedValue({ success: true, payload: {} });
+        const res = await GET(req());
+        expect(res.status).toBe(200);
+        expect((await res.json()).photos).toEqual([]);
+    });
+
+    it("sorts newest first by taken_at falling back to uploaded_at", async () => {
+        mockGetFacesByInvitees.mockResolvedValue([
+            { face_id: "f1", photo_id: "p1", invitee_id: 7 },
+            { face_id: "f2", photo_id: "p2", invitee_id: 7 },
+        ]);
+        mockGetPhotosByIds.mockResolvedValue([
+            photo({ id: "p1", taken_at: "2026-05-30T10:00:00" }),
+            photo({ id: "p2", taken_at: null, uploaded_at: "2026-05-30T20:00:00" }),
+        ]);
+
+        const body = await (await GET(req("?code=ABC123"))).json();
+        expect(body.photos.map((p: { id: string }) => p.id)).toEqual(["p2", "p1"]);
+    });
+});

--- a/src/app/api/gallery/my-photos/__tests__/route.test.ts
+++ b/src/app/api/gallery/my-photos/__tests__/route.test.ts
@@ -3,7 +3,7 @@ import { NextRequest } from "next/server";
 import { GET } from "../route";
 
 const mockRequireAuth = vi.fn();
-const mockIsValidInvitationCode = vi.fn();
+const mockIsMasterCode = vi.fn();
 const mockGetInvitationIdByCode = vi.fn();
 const mockGetInviteesWithIds = vi.fn();
 const mockGetFacesByInvitees = vi.fn();
@@ -14,7 +14,7 @@ vi.mock("@/utils/auth/requireAuth", () => ({
     requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
 }));
 vi.mock("@/utils/db/archive", () => ({
-    isValidInvitationCode: (...args: unknown[]) => mockIsValidInvitationCode(...args),
+    isMasterCode: (...args: unknown[]) => mockIsMasterCode(...args),
     getInvitationIdByCode: (...args: unknown[]) => mockGetInvitationIdByCode(...args),
     getInviteesWithIds: (...args: unknown[]) => mockGetInviteesWithIds(...args),
 }));
@@ -58,7 +58,7 @@ describe("GET /api/gallery/my-photos", () => {
             success: false,
             response: new Response(null, { status: 401 }),
         });
-        mockIsValidInvitationCode.mockResolvedValue(true);
+        mockIsMasterCode.mockReturnValue(false);
         mockGetInvitationIdByCode.mockResolvedValue(3);
         mockGetInviteesWithIds.mockResolvedValue([
             { id: 7, first_name: "Aoife" },
@@ -73,10 +73,11 @@ describe("GET /api/gallery/my-photos", () => {
         expect(mockGetFacesByInvitees).not.toHaveBeenCalled();
     });
 
-    it("rejects an invalid code", async () => {
-        mockIsValidInvitationCode.mockResolvedValue(false);
+    it("rejects an invalid code with a single archive read", async () => {
+        mockGetInvitationIdByCode.mockResolvedValue(null);
         const res = await GET(req("?code=ZZZZZZ"));
         expect(res.status).toBe(401);
+        expect(mockGetInvitationIdByCode).toHaveBeenCalledTimes(1);
     });
 
     it("dedupes photos when several household members appear in the same photo", async () => {
@@ -127,10 +128,11 @@ describe("GET /api/gallery/my-photos", () => {
         expect(body.photos[0].thumbnail_url).toBe("https://cdn/uploads/thumbnail/x/p1.jpg");
     });
 
-    it("returns an empty result for the master code (no household)", async () => {
-        mockGetInvitationIdByCode.mockResolvedValue(null);
+    it("returns an empty result for the master code without touching the archive", async () => {
+        mockIsMasterCode.mockReturnValue(true);
         const body = await (await GET(req("?code=RM2026"))).json();
         expect(body).toEqual({ photos: [], invitees: [], page: 1, limit: 200, total: 0 });
+        expect(mockGetInvitationIdByCode).not.toHaveBeenCalled();
         expect(mockGetFacesByInvitees).not.toHaveBeenCalled();
     });
 

--- a/src/app/api/gallery/my-photos/route.ts
+++ b/src/app/api/gallery/my-photos/route.ts
@@ -1,9 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import {
-    isValidInvitationCode,
-    getInvitationIdByCode,
-    getInviteesWithIds,
-} from "@/utils/db/archive";
+import { isMasterCode, getInvitationIdByCode, getInviteesWithIds } from "@/utils/db/archive";
 import { getFacesByInvitees } from "@/utils/db/faces";
 import { getPhotosByIds } from "@/utils/db/photos";
 import { listCategories } from "@/utils/db/categories";
@@ -24,16 +20,22 @@ export async function GET(request: NextRequest) {
 
         const code = searchParams.get("code")?.trim().toUpperCase() ?? "";
         const auth = await requireAuth(request);
-        if (!auth.success && (!code || !(await isValidInvitationCode(code)))) {
+
+        // One archive read serves both the auth gate and the household
+        // lookup: a non-master code with no invitation behind it IS an
+        // invalid code. (isMasterCode is an env check, not a DB call.)
+        const isMaster = !!code && isMasterCode(code);
+        const invitationId = code && !isMaster ? await getInvitationIdByCode(code) : null;
+
+        if (!auth.success && !isMaster && invitationId === null) {
             return NextResponse.json(
                 { error: "A valid invitation code is required" },
                 { status: 401 }
             );
         }
 
-        // The master code (and an admin session without a code) has no
+        // The master code (and an admin session without a guest code) has no
         // archived household behind it — nothing to match, empty result.
-        const invitationId = code ? await getInvitationIdByCode(code) : null;
         if (invitationId === null) {
             return NextResponse.json({ photos: [], invitees: [], page, limit, total: 0 });
         }

--- a/src/app/api/gallery/my-photos/route.ts
+++ b/src/app/api/gallery/my-photos/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+    isValidInvitationCode,
+    getInvitationIdByCode,
+    getInviteesWithIds,
+} from "@/utils/db/archive";
+import { getFacesByInvitees } from "@/utils/db/faces";
+import { getPhotosByIds } from "@/utils/db/photos";
+import { listCategories } from "@/utils/db/categories";
+import { requireAuth } from "@/utils/auth/requireAuth";
+import { cdnUrl } from "@/utils/storage";
+import type { PublicPhoto } from "@/types/photos";
+
+// Approved photos in which anyone in the caller's household (the invitees
+// behind their invitation code) appears, per the labeled face clusters.
+// Same auth gate and response envelope as /api/photos so the gallery
+// components drop in unchanged.
+export async function GET(request: NextRequest) {
+    try {
+        const { searchParams } = new URL(request.url);
+        const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
+        const limit = Math.min(500, Math.max(1, parseInt(searchParams.get("limit") ?? "200", 10)));
+        const offset = (page - 1) * limit;
+
+        const code = searchParams.get("code")?.trim().toUpperCase() ?? "";
+        const auth = await requireAuth(request);
+        if (!auth.success && (!code || !(await isValidInvitationCode(code)))) {
+            return NextResponse.json(
+                { error: "A valid invitation code is required" },
+                { status: 401 }
+            );
+        }
+
+        // The master code (and an admin session without a code) has no
+        // archived household behind it — nothing to match, empty result.
+        const invitationId = code ? await getInvitationIdByCode(code) : null;
+        if (invitationId === null) {
+            return NextResponse.json({ photos: [], invitees: [], page, limit, total: 0 });
+        }
+
+        const invitees = await getInviteesWithIds(invitationId);
+        const faces = await getFacesByInvitees(invitees.map((i) => i.id));
+        const photoIds = [...new Set(faces.map((f) => f.photo_id))];
+
+        const [matched, categories] = await Promise.all([
+            getPhotosByIds(photoIds),
+            listCategories(),
+        ]);
+        const slugById = new Map(categories.map((c) => [c.id, c.slug]));
+
+        // Approved-only at read time: pending/rejected photos never leak, and
+        // moderation changes need no face-row cleanup.
+        const approved = matched
+            .filter((p) => p.status === "approved")
+            .sort((a, b) =>
+                (b.taken_at ?? b.uploaded_at).localeCompare(a.taken_at ?? a.uploaded_at)
+            );
+
+        const photos: PublicPhoto[] = approved.slice(offset, offset + limit).map((p) => ({
+            id: p.id,
+            thumbnail_url: p.thumbnail_key ? cdnUrl(p.thumbnail_key) : null,
+            width: p.width,
+            height: p.height,
+            file_name: p.file_name,
+            taken_at: p.taken_at,
+            category_id: p.category_id,
+            category_slug: p.category_id ? (slugById.get(p.category_id) ?? null) : null,
+            uploaded_at: p.uploaded_at,
+        }));
+
+        return NextResponse.json({
+            photos,
+            invitees: invitees.map((i) => i.first_name),
+            page,
+            limit,
+            total: approved.length,
+        });
+    } catch (error) {
+        console.error("Error in GET /api/gallery/my-photos:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/app/gallery/my-photos/page.tsx
+++ b/src/app/gallery/my-photos/page.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+    Container,
+    Title,
+    Text,
+    Stack,
+    Box,
+    Button,
+    Alert,
+    Group,
+    Loader,
+    Center,
+    Paper,
+    TextInput,
+} from "@mantine/core";
+import { IconAlertCircle, IconDownload } from "@tabler/icons-react";
+import { useSession } from "@/hooks/useSession";
+import { RowsPhotoAlbum } from "react-photo-album";
+import "react-photo-album/rows.css";
+import Lightbox from "yet-another-react-lightbox";
+import Download from "yet-another-react-lightbox/plugins/download";
+import "yet-another-react-lightbox/styles.css";
+import type { PublicPhoto } from "@/types/photos";
+import Link from "next/link";
+
+interface GalleryPhoto {
+    src: string;
+    width: number;
+    height: number;
+    alt: string;
+    id: string;
+    key: string;
+}
+
+const FALLBACK_ASPECT = { width: 4, height: 3 };
+
+// A household appears in far fewer photos than the full gallery, so one
+// fetch covers it — no category tabs or infinite scroll here.
+const LIMIT = 200;
+
+export default function MyPhotosPage() {
+    const [photos, setPhotos] = useState<GalleryPhoto[]>([]);
+    const [inviteeNames, setInviteeNames] = useState<string[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [lightboxIndex, setLightboxIndex] = useState(-1);
+    const [invitationCode, setInvitationCode] = useState<string>("");
+    const [codeChecked, setCodeChecked] = useState(false);
+    const [codeInput, setCodeInput] = useState("");
+    const [codeError, setCodeError] = useState<string | null>(null);
+    const [validatingCode, setValidatingCode] = useState(false);
+    const [loaded, setLoaded] = useState(false);
+    const { status: sessionStatus, masterCode } = useSession();
+    const isAdmin = sessionStatus === "authenticated";
+
+    const hasAccess = !!invitationCode || isAdmin;
+    const showCodeGate = codeChecked && !invitationCode && sessionStatus === "unauthenticated";
+
+    // Same storage key as the main gallery: guests who've been through the
+    // gate once are already recognised here.
+    useEffect(() => {
+        const stored = localStorage.getItem("invitation_code");
+        if (stored) setInvitationCode(stored);
+        setCodeChecked(true);
+    }, []);
+
+    useEffect(() => {
+        if (!isAdmin || invitationCode || !masterCode) return;
+        localStorage.setItem("invitation_code", masterCode);
+        setInvitationCode(masterCode);
+    }, [isAdmin, invitationCode, masterCode]);
+
+    const handleCodeSubmit = async () => {
+        const trimmed = codeInput.trim().toUpperCase();
+        if (!/^[A-Z0-9]{6}$/.test(trimmed)) {
+            setCodeError("Please enter your 6-character invitation code");
+            return;
+        }
+        setValidatingCode(true);
+        setCodeError(null);
+        try {
+            const res = await fetch("/api/photos/validate-code", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ code: trimmed }),
+            });
+            const data = await res.json();
+            if (!data.valid) {
+                setCodeError(data.error ?? "Invalid invitation code");
+                return;
+            }
+            localStorage.setItem("invitation_code", trimmed);
+            setInvitationCode(trimmed);
+        } catch {
+            setCodeError("Something went wrong — please try again");
+        } finally {
+            setValidatingCode(false);
+        }
+    };
+
+    const fetchPhotos = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const params = new URLSearchParams({ limit: String(LIMIT) });
+            if (invitationCode) params.set("code", invitationCode);
+            const res = await fetch(`/api/gallery/my-photos?${params}`);
+            if (res.status === 401) {
+                localStorage.removeItem("invitation_code");
+                setInvitationCode("");
+                setPhotos([]);
+                return;
+            }
+            if (!res.ok) throw new Error("Failed to load your photos");
+            const data = await res.json();
+            setInviteeNames(data.invitees ?? []);
+            setPhotos(
+                (data.photos as PublicPhoto[]).map((p) => ({
+                    src: p.thumbnail_url ?? "",
+                    width: p.width ?? FALLBACK_ASPECT.width,
+                    height: p.height ?? FALLBACK_ASPECT.height,
+                    alt: p.file_name,
+                    id: p.id,
+                    key: p.id,
+                }))
+            );
+            setLoaded(true);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to load your photos");
+        } finally {
+            setLoading(false);
+        }
+    }, [invitationCode]);
+
+    useEffect(() => {
+        if (!codeChecked || (!invitationCode && sessionStatus !== "authenticated")) return;
+        fetchPhotos();
+    }, [codeChecked, invitationCode, sessionStatus, fetchPhotos]);
+
+    const lightboxSlides = photos.map((p) => ({
+        src: p.src,
+        width: p.width,
+        height: p.height,
+        alt: p.alt,
+        download: {
+            url: `/api/photos/${p.id}/download-url?code=${invitationCode}`,
+            filename: p.alt,
+        },
+    }));
+
+    return (
+        <main id="main-content">
+            <Container size="xl" py="xl">
+                <Stack gap="lg">
+                    <Group justify="space-between" align="flex-end">
+                        <Box>
+                            <Title
+                                order={1}
+                                style={{
+                                    fontFamily: "var(--font-playfair), serif",
+                                    fontWeight: 300,
+                                    color: "var(--gold-dark)",
+                                    fontSize: "clamp(2rem, 5vw, 3rem)",
+                                }}
+                            >
+                                Photos of You
+                            </Title>
+                            <Text c="dimmed" size="sm" mt={4}>
+                                {inviteeNames.length > 0
+                                    ? `Photos we found of ${inviteeNames.join(", ").replace(/, ([^,]*)$/, " and $1")}`
+                                    : "Every photo from the day that you appear in"}
+                            </Text>
+                        </Box>
+                        <Button component={Link} href="/gallery" variant="light" color="yellow">
+                            Full Gallery
+                        </Button>
+                    </Group>
+
+                    {error && (
+                        <Alert icon={<IconAlertCircle size={16} />} color="red" variant="light">
+                            {error}
+                        </Alert>
+                    )}
+
+                    {showCodeGate ? (
+                        <Paper p="xl" radius="md" withBorder maw={440} mx="auto" mt="lg" w="100%">
+                            <Stack gap="sm">
+                                <Text fw={500}>Find the photos you appear in</Text>
+                                <Text size="sm" c="dimmed">
+                                    Enter the code from your invitation and we&apos;ll show you
+                                    every photo from the day that you&apos;re in.
+                                </Text>
+                                <TextInput
+                                    placeholder="e.g. ABC123"
+                                    value={codeInput}
+                                    onChange={(e) => setCodeInput(e.currentTarget.value.toUpperCase())}
+                                    maxLength={6}
+                                    error={codeError}
+                                    onKeyDown={(e) => e.key === "Enter" && handleCodeSubmit()}
+                                    styles={{ input: { textTransform: "uppercase", letterSpacing: "0.1em" } }}
+                                />
+                                <Button color="yellow" onClick={handleCodeSubmit} loading={validatingCode}>
+                                    Find my photos
+                                </Button>
+                            </Stack>
+                        </Paper>
+                    ) : !hasAccess || (loading && !loaded) ? (
+                        <Center py="xl">
+                            <Loader color="yellow" />
+                        </Center>
+                    ) : photos.length === 0 ? (
+                        <Center py="xl">
+                            <Stack align="center" gap="xs">
+                                <Text c="dimmed">
+                                    {isAdmin && (!invitationCode || invitationCode === masterCode)
+                                        ? "The couple's code has no guest household to match — enter a guest's code to preview their view."
+                                        : "We haven't spotted you in any photos yet."}
+                                </Text>
+                                <Text c="dimmed" size="sm">
+                                    More photos are still being added — check back soon, or browse
+                                    the full gallery.
+                                </Text>
+                            </Stack>
+                        </Center>
+                    ) : (
+                        <RowsPhotoAlbum
+                            photos={photos}
+                            targetRowHeight={240}
+                            onClick={({ index }) => setLightboxIndex(index)}
+                        />
+                    )}
+                </Stack>
+            </Container>
+
+            <Lightbox
+                open={lightboxIndex >= 0}
+                close={() => setLightboxIndex(-1)}
+                slides={lightboxSlides}
+                index={lightboxIndex}
+                on={{ view: ({ index }) => setLightboxIndex(index) }}
+                plugins={invitationCode ? [Download] : []}
+                render={{
+                    iconDownload: () => <IconDownload size={32} />,
+                }}
+            />
+        </main>
+    );
+}

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -269,9 +269,19 @@ function Gallery() {
                                 Share your memories from our special day
                             </Text>
                         </Box>
-                        <Button component={Link} href="/gallery/upload" variant="light" color="yellow">
-                            Upload Photos
-                        </Button>
+                        <Group gap="sm">
+                            <Button
+                                component={Link}
+                                href="/gallery/my-photos"
+                                variant="light"
+                                color="yellow"
+                            >
+                                Find My Photos
+                            </Button>
+                            <Button component={Link} href="/gallery/upload" variant="light" color="yellow">
+                                Upload Photos
+                            </Button>
+                        </Group>
                     </Group>
 
                     {error && (

--- a/src/utils/db/archive.ts
+++ b/src/utils/db/archive.ts
@@ -81,6 +81,39 @@ export async function isValidInvitationCode(code: string): Promise<boolean> {
     return result.Item !== undefined;
 }
 
+// The invitation behind a guest code, or null when the code doesn't exist.
+// The master code also resolves to null: it belongs to the couple, not an
+// archived invitation, so there is no household behind it.
+export async function getInvitationIdByCode(code: string): Promise<number | null> {
+    if (isMasterCode(code)) return null;
+    const result = await docClient.send(
+        new GetCommand({
+            TableName: ARCHIVE_TABLE,
+            Key: { PK: `CODE#${code}`, SK: "META" },
+        })
+    );
+    return (result.Item as CodeItem | undefined)?.invitation_id ?? null;
+}
+
+// The invitees of an invitation with their ids, for face-match lookups.
+export async function getInviteesWithIds(
+    invitationId: number
+): Promise<{ id: number; first_name: string }[]> {
+    const result = await docClient.send(
+        new QueryCommand({
+            TableName: ARCHIVE_TABLE,
+            KeyConditionExpression: "PK = :pk AND begins_with(SK, :sk)",
+            ExpressionAttributeValues: {
+                ":pk": `INVITATION#${invitationId}`,
+                ":sk": "INVITEE#",
+            },
+        })
+    );
+    return ((result.Items ?? []) as InviteeItem[])
+        .map((i) => ({ id: i.id, first_name: i.first_name }))
+        .sort((a, b) => a.first_name.localeCompare(b.first_name));
+}
+
 // First names of the invitees behind a code, or null when the code doesn't
 // exist. Returning names behind a valid code is fine — the code is the
 // guest's credential.


### PR DESCRIPTION
Part 3 of 3 for #162, closing out the cluster-then-label feature (#184 infra, #185 admin labeling). Guests enter the invitation code they already have and see every approved photo anyone in their household appears in — no selfies, no new credentials.

## API — `GET /api/gallery/my-photos`

Same auth gate as `/api/photos` (valid guest/master code or admin session, else 401) and the same `{photos, page, limit, total}` `PublicPhoto` envelope, so the gallery components drop in unchanged. Pipeline: code → invitation → household invitee ids → labeled faces via the sparse `byInvitee` GSI → dedupe photo ids → BatchGet → **approved-only filter at read time** (pending/rejected never leak; moderation changes need no face cleanup) → newest first by `taken_at ?? uploaded_at`. Also returns the household's first names for the page header.

The master code and an admin session without a code resolve to no archived household and get an empty 200 — handled, not an error.

## UI — `/gallery/my-photos`

A slimmed copy of the gallery page sharing its exact conventions: the same `invitation_code` localStorage key (guests who've been through the gallery gate are already recognised), the same code-gate card and `validate-code` flow, the same `RowsPhotoAlbum` grid and Lightbox with the download button wired to the existing presigned-download route, and the same 401-drops-back-to-gate behavior. No category tabs or infinite scroll — a household appears in far fewer photos than the full gallery, so it's a single fetch (limit 200). Header greets the household by name ("Photos we found of Aoife and Brian"); distinct empty states for no-matches-yet and the couple's own code. A "Find My Photos" button now sits next to "Upload Photos" in the gallery header.

## Testing

- 8 new route tests: 401 without/with-invalid code, household dedupe (two members in one photo → one result), pending/rejected filtered out, PublicPhoto allowlist (no `s3_key`/`invitation_code`/`approved_by`), master-code and admin-no-code empty 200s, sort order.
- Suite: 173 passed; `tsc --noEmit` + `eslint` clean.

## Before announcing to guests

1. Label clusters at `/dashboard/photos/faces` (needs the #184 backfill run first).
2. Re-run `scripts/index-faces.mjs` once to sweep any photos uploaded between the backfill and the #184 deploy (idempotent, cheap).
3. Smoke-test with a real labeled guest's code on `/gallery/my-photos`.