### PR TITLE
fix: scoped re-cluster mode and stricter face-match threshold

### DIFF
--- a/infra/lib/wedding-stack.ts
+++ b/infra/lib/wedding-stack.ts
@@ -262,7 +262,10 @@ export class WeddingStack extends cdk.Stack {
         S3_BUCKET: photosBucket.bucketName,
         FACES_TABLE: facesTable.tableName,
         REKOGNITION_COLLECTION_ID: 'wedding-faces-2026',
-        FACE_MATCH_THRESHOLD: '95',
+        // 95 proved too loose in production: different people wearing
+        // sunglasses cross-match above it, which chained 44% of all faces
+        // into one cluster during the backfill.
+        FACE_MATCH_THRESHOLD: '97',
       },
     });
     photosBucket.addEventNotification(

--- a/scripts/index-faces.mjs
+++ b/scripts/index-faces.mjs
@@ -70,7 +70,7 @@ const threshold = thresholdIdx !== -1 ? Number(args[thresholdIdx + 1]) : 95;
 const reclusterIdx = args.indexOf("--recluster");
 const reclusterId = reclusterIdx !== -1 ? args[reclusterIdx + 1] : null;
 
-if (!bucket && !clusterOnly) {
+if (!bucket && !clusterOnly && !reclusterId) {
     console.error("S3_PHOTOS_BUCKET is required");
     process.exit(1);
 }

--- a/scripts/index-faces.mjs
+++ b/scripts/index-faces.mjs
@@ -14,12 +14,17 @@
 //
 // Usage:
 //   node scripts/index-faces.mjs [--dry-run] [--limit N] [--index-only]
-//                                [--cluster-only] [--threshold N] [--force]
+//                                [--cluster-only] [--recluster ID]
+//                                [--threshold N] [--force]
 //
 //   --dry-run       report what each phase would do without calling AWS mutators
 //   --limit N       index at most N photos (smoke-testing)
 //   --index-only    run Phase A only
 //   --cluster-only  run Phase B only (e.g. after re-tuning --threshold)
+//   --recluster ID  re-cluster ONLY the faces currently in cluster ID (implies
+//                   --cluster-only). Use with a higher --threshold to split a
+//                   drifted mega-cluster without disturbing any other cluster
+//                   or its labels
 //   --threshold N   SearchFaces similarity threshold, default 95
 //   --force         allow re-clustering even after labeling has started
 //
@@ -62,6 +67,8 @@ const limitIdx = args.indexOf("--limit");
 const limit = limitIdx !== -1 ? Number(args[limitIdx + 1]) : Infinity;
 const thresholdIdx = args.indexOf("--threshold");
 const threshold = thresholdIdx !== -1 ? Number(args[thresholdIdx + 1]) : 95;
+const reclusterIdx = args.indexOf("--recluster");
+const reclusterId = reclusterIdx !== -1 ? args[reclusterIdx + 1] : null;
 
 if (!bucket && !clusterOnly) {
     console.error("S3_PHOTOS_BUCKET is required");
@@ -208,7 +215,19 @@ async function indexPhotos() {
 // ── Phase B: cluster faces ──────────────────────────────────────────────────
 
 async function clusterFaces() {
-    const faces = await scanAll(facesTable);
+    let faces = await scanAll(facesTable);
+    if (reclusterId) {
+        // Scoped mode: only the target cluster's faces are re-clustered, and
+        // (because the union step below ignores SearchFaces matches outside
+        // the fed set) no other cluster can gain or lose members. Splitting a
+        // person off from an already-labeled cluster just creates a duplicate
+        // cluster, which labeling absorbs.
+        faces = faces.filter((f) => f.cluster_id === reclusterId);
+        if (faces.length === 0) {
+            console.error(`No faces found in cluster ${reclusterId}`);
+            process.exit(1);
+        }
+    }
     if (faces.length === 0) {
         console.log("Phase B: no faces to cluster");
         return;
@@ -227,6 +246,7 @@ async function clusterFaces() {
 
     console.log(
         `Phase B: clustering ${faces.length} faces at threshold ${threshold}` +
+            (reclusterId ? ` (scoped to cluster ${reclusterId})` : "") +
             (dryRun ? " (dry-run: no SearchFaces calls, no writes)" : "")
     );
     if (dryRun) return;
@@ -309,6 +329,6 @@ async function clusterFaces() {
     );
 }
 
-if (!clusterOnly) await indexPhotos();
+if (!clusterOnly && !reclusterId) await indexPhotos();
 if (!indexOnly) await clusterFaces();
 console.log("Done.");


### PR DESCRIPTION
Follow-up to the #162 rollout. The production backfill at similarity threshold 95 produced one 935-face mega-cluster — 44% of all 2,105 faces — containing many different people. Root cause: guests wearing sunglasses cross-match above 95 (sunglasses obscure the most discriminative facial features), and union-find transitivity chains those cross-matches into a single blob.

## Changes

- **`scripts/index-faces.mjs --recluster <cluster_id>`**: re-clusters only the faces currently in the given cluster (implies `--cluster-only`). The union step already ignores SearchFaces matches outside the fed set, so scoping is just filtering the input — no other cluster can gain or lose members, and existing labels elsewhere are untouched. This is the surgical fix for a single drifted cluster when labeling is already underway.
- **photo-processor `FACE_MATCH_THRESHOLD` 95 → 97**: new-upload auto-assign uses the same similarity search, so left at 95 it would keep making the same cross-person matches and inherit wrong assignments.

## Production remediation (already underway)

Labeling had only just started (22 assignments), so rather than the scoped fix we opted to re-run the full clustering at threshold 97 with `--force` for a uniformly consistent result, and re-label from scratch.

## Testing

Dry-run of the scoped mode against the production mega-cluster correctly targets its 935 faces and no others. `eslint` clean (commit hook). The CDK change is an env-var literal; deploy verified via `cdk deploy`.