### PR TITLE
feat: per-person face review tab with reject button

### DIFF
--- a/src/app/api/dashboard/faces/[faceId]/__tests__/route.test.ts
+++ b/src/app/api/dashboard/faces/[faceId]/__tests__/route.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { PATCH } from "../route";
+
+const mockRequireAuth = vi.fn();
+const mockDetachFace = vi.fn();
+
+vi.mock("@/utils/auth/requireAuth", () => ({
+    requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+}));
+vi.mock("@/utils/db/faces", () => ({
+    detachFace: (...args: unknown[]) => mockDetachFace(...args),
+}));
+
+const params = { params: Promise.resolve({ faceId: "face-1" }) };
+const req = (body: unknown) =>
+    new NextRequest("http://localhost/api/dashboard/faces/face-1", {
+        method: "PATCH",
+        body: JSON.stringify(body),
+    });
+
+describe("PATCH /api/dashboard/faces/[faceId]", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockRequireAuth.mockResolvedValue({ success: true, payload: {} });
+        mockDetachFace.mockResolvedValue(true);
+    });
+
+    it("requires auth", async () => {
+        mockRequireAuth.mockResolvedValue({
+            success: false,
+            response: new Response(null, { status: 401 }),
+        });
+        const res = await PATCH(req({ detach: true }), params);
+        expect(res.status).toBe(401);
+        expect(mockDetachFace).not.toHaveBeenCalled();
+    });
+
+    it("detaches the face", async () => {
+        const res = await PATCH(req({ detach: true }), params);
+        expect(res.status).toBe(200);
+        expect(mockDetachFace).toHaveBeenCalledWith("face-1");
+        expect(await res.json()).toEqual({ face_id: "face-1", detached: true });
+    });
+
+    it("rejects a body without detach: true", async () => {
+        const res = await PATCH(req({}), params);
+        expect(res.status).toBe(400);
+        expect(mockDetachFace).not.toHaveBeenCalled();
+    });
+
+    it("404s for an unknown face", async () => {
+        mockDetachFace.mockResolvedValue(false);
+        const res = await PATCH(req({ detach: true }), params);
+        expect(res.status).toBe(404);
+    });
+});

--- a/src/app/api/dashboard/faces/[faceId]/route.ts
+++ b/src/app/api/dashboard/faces/[faceId]/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/utils/auth/requireAuth";
+import { detachFace } from "@/utils/db/faces";
+
+interface PatchBody {
+    detach?: boolean;
+}
+
+// Reject a single face from its person/cluster: it becomes an unassigned
+// singleton (see detachFace). This is the "that's not them" button on the
+// per-person verification tab.
+export async function PATCH(
+    request: NextRequest,
+    { params }: { params: Promise<{ faceId: string }> }
+) {
+    const auth = await requireAuth(request);
+    if (!auth.success) return auth.response;
+
+    try {
+        const { faceId } = await params;
+        const body: PatchBody = await request.json();
+        if (body.detach !== true) {
+            return NextResponse.json(
+                { error: "Body must set detach: true" },
+                { status: 400 }
+            );
+        }
+
+        const found = await detachFace(faceId);
+        if (!found) {
+            return NextResponse.json({ error: "Face not found" }, { status: 404 });
+        }
+        return NextResponse.json({ face_id: faceId, detached: true });
+    } catch (error) {
+        console.error("Error in PATCH /api/dashboard/faces/[faceId]:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/app/api/dashboard/faces/by-invitee/[id]/__tests__/route.test.ts
+++ b/src/app/api/dashboard/faces/by-invitee/[id]/__tests__/route.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+
+const mockRequireAuth = vi.fn();
+const mockGetFacesByInvitees = vi.fn();
+const mockGetPhotosByIds = vi.fn();
+
+vi.mock("@/utils/auth/requireAuth", () => ({
+    requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+}));
+vi.mock("@/utils/db/faces", () => ({
+    getFacesByInvitees: (...args: unknown[]) => mockGetFacesByInvitees(...args),
+}));
+vi.mock("@/utils/db/photos", () => ({
+    getPhotosByIds: (...args: unknown[]) => mockGetPhotosByIds(...args),
+}));
+vi.mock("@/utils/storage", () => ({
+    cdnUrl: (k: string) => `https://cdn/${k}`,
+}));
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+const req = () => new NextRequest("http://localhost/api/dashboard/faces/by-invitee/7");
+
+describe("GET /api/dashboard/faces/by-invitee/[id]", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockRequireAuth.mockResolvedValue({ success: true, payload: {} });
+        mockGetPhotosByIds.mockResolvedValue([
+            { id: "p1", thumbnail_key: "t/p1.jpg", width: 1200, height: 800 },
+        ]);
+    });
+
+    it("requires auth", async () => {
+        mockRequireAuth.mockResolvedValue({
+            success: false,
+            response: new Response(null, { status: 401 }),
+        });
+        const res = await GET(req(), params("7"));
+        expect(res.status).toBe(401);
+        expect(mockGetFacesByInvitees).not.toHaveBeenCalled();
+    });
+
+    it("rejects a non-numeric id", async () => {
+        const res = await GET(req(), params("clusters"));
+        expect(res.status).toBe(400);
+    });
+
+    it("returns the person's faces, least detection-confidence first, with crop data", async () => {
+        mockGetFacesByInvitees.mockResolvedValue([
+            {
+                face_id: "sharp",
+                photo_id: "p1",
+                bounding_box: { left: 0.1, top: 0.1, width: 0.2, height: 0.2 },
+                confidence: 99,
+            },
+            {
+                face_id: "blurry",
+                photo_id: "p1",
+                bounding_box: { left: 0.5, top: 0.5, width: 0.1, height: 0.1 },
+                confidence: 71,
+            },
+        ]);
+        const res = await GET(req(), params("7"));
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(mockGetFacesByInvitees).toHaveBeenCalledWith([7]);
+        expect(body.faces.map((f: { face_id: string }) => f.face_id)).toEqual([
+            "blurry",
+            "sharp",
+        ]);
+        expect(body.faces[0].thumbnail_url).toBe("https://cdn/t/p1.jpg");
+        expect(body.faces[0].thumbnail_width).toBe(1200);
+    });
+
+    it("returns an empty list for a person with no faces", async () => {
+        mockGetFacesByInvitees.mockResolvedValue([]);
+        const body = await (await GET(req(), params("7"))).json();
+        expect(body.faces).toEqual([]);
+    });
+});

--- a/src/app/api/dashboard/faces/by-invitee/[id]/route.ts
+++ b/src/app/api/dashboard/faces/by-invitee/[id]/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/utils/auth/requireAuth";
+import { getFacesByInvitees } from "@/utils/db/faces";
+import { getPhotosByIds } from "@/utils/db/photos";
+import { cdnUrl } from "@/utils/storage";
+import type { FaceView } from "@/types/faces";
+
+// Every face currently attributed to an invitee (across all their clusters),
+// for the per-person verification tab.
+export async function GET(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    const auth = await requireAuth(request);
+    if (!auth.success) return auth.response;
+
+    try {
+        const { id } = await params;
+        const inviteeId = Number(id);
+        if (!Number.isInteger(inviteeId)) {
+            return NextResponse.json({ error: "Invalid invitee id" }, { status: 400 });
+        }
+
+        const faces = await getFacesByInvitees([inviteeId]);
+        const photos = await getPhotosByIds([...new Set(faces.map((f) => f.photo_id))]);
+        const photoById = new Map(photos.map((p) => [p.id, p]));
+
+        const views: FaceView[] = faces
+            // Lowest confidence first: the faces most likely to be wrong are
+            // the ones the admin should see at the top.
+            .sort((a, b) => a.confidence - b.confidence)
+            .map((f) => {
+                const photo = photoById.get(f.photo_id);
+                return {
+                    face_id: f.face_id,
+                    photo_id: f.photo_id,
+                    thumbnail_url: photo?.thumbnail_key ? cdnUrl(photo.thumbnail_key) : null,
+                    thumbnail_width: photo?.width ?? null,
+                    thumbnail_height: photo?.height ?? null,
+                    bounding_box: f.bounding_box,
+                    confidence: f.confidence,
+                };
+            });
+
+        return NextResponse.json({ invitee_id: inviteeId, faces: views });
+    } catch (error) {
+        console.error("Error in GET /api/dashboard/faces/by-invitee/[id]:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/app/dashboard/photos/faces/page.tsx
+++ b/src/app/dashboard/photos/faces/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import {
     Stack,
     Title,
@@ -17,15 +17,22 @@ import {
     Center,
     Anchor,
     Modal,
+    Tooltip,
+    ActionIcon,
     UnstyledButton,
 } from "@mantine/core";
-import { IconAlertCircle } from "@tabler/icons-react";
+import { IconAlertCircle, IconX } from "@tabler/icons-react";
 import Link from "next/link";
 import { FaceCrop } from "@/components/FaceCrop";
-import type { ClusterSummary, ClustersResponse, ClusterDetailResponse } from "@/types/faces";
+import type {
+    ClusterSummary,
+    ClustersResponse,
+    ClusterDetailResponse,
+    FaceView,
+} from "@/types/faces";
 import type { InviteeSummary } from "@/utils/db/archive";
 
-type FilterTab = "unassigned" | "assigned" | "ignored";
+type FilterTab = "unassigned" | "assigned" | "ignored" | "by-person";
 
 function clusterTab(cluster: ClusterSummary): FilterTab {
     if (cluster.ignored) return "ignored";
@@ -133,7 +140,27 @@ export default function FacesPage() {
     const assigned = clusters.filter((c) => c.invitee_id != null).length;
     const ignored = clusters.filter((c) => c.ignored).length;
     const visible = clusters.filter((c) => clusterTab(c) === activeTab);
-    const counts: Record<FilterTab, number> = {
+
+    // People with at least one assigned face, for the By Person review tab.
+    const personOptions = useMemo(() => {
+        const byInvitee = new Map<number, { name: string; count: number }>();
+        for (const c of clusters) {
+            if (c.invitee_id == null) continue;
+            const entry = byInvitee.get(c.invitee_id) ?? {
+                name: c.invitee_name ?? `Guest #${c.invitee_id}`,
+                count: 0,
+            };
+            entry.count += c.face_count;
+            byInvitee.set(c.invitee_id, entry);
+        }
+        return [...byInvitee.entries()]
+            .sort((a, b) => a[1].name.localeCompare(b[1].name))
+            .map(([id, v]) => ({
+                value: String(id),
+                label: `${v.name} (${v.count} face${v.count === 1 ? "" : "s"})`,
+            }));
+    }, [clusters]);
+    const counts: Record<Exclude<FilterTab, "by-person">, number> = {
         unassigned: clusters.length - assigned - ignored,
         assigned,
         ignored,
@@ -179,10 +206,17 @@ export default function FacesPage() {
                     </Tabs.Tab>
                     <Tabs.Tab value="assigned">Assigned</Tabs.Tab>
                     <Tabs.Tab value="ignored">Ignored</Tabs.Tab>
+                    <Tabs.Tab value="by-person">By Person</Tabs.Tab>
                 </Tabs.List>
             </Tabs>
 
-            {loading ? (
+            {activeTab === "by-person" ? (
+                <PersonReview
+                    options={personOptions}
+                    onError={setError}
+                    onDetached={fetchClusters}
+                />
+            ) : loading ? (
                 <Center py="xl">
                     <Loader color="yellow" />
                 </Center>
@@ -299,6 +333,124 @@ export default function FacesPage() {
                     </Stack>
                 )}
             </Modal>
+        </Stack>
+    );
+}
+
+interface PersonReviewProps {
+    options: { value: string; label: string }[];
+    onError: (message: string) => void;
+    onDetached: () => void;
+}
+
+// "Show me every face of the selected person" with a reject button per face.
+// Rejecting detaches the face into an unassigned singleton — it leaves this
+// person (and guest results) immediately and reappears in the Unassigned tab.
+function PersonReview({ options, onError, onDetached }: PersonReviewProps) {
+    const [personId, setPersonId] = useState<string | null>(null);
+    const [faces, setFaces] = useState<FaceView[] | null>(null);
+    const [loading, setLoading] = useState(false);
+    // Guards against a slow response landing after the admin switched person.
+    const requestId = useRef(0);
+
+    const loadFaces = async (id: string) => {
+        const reqId = ++requestId.current;
+        setLoading(true);
+        try {
+            const res = await fetch(`/api/dashboard/faces/by-invitee/${id}`);
+            if (!res.ok) throw new Error("Failed to load this person's faces");
+            const data = await res.json();
+            if (requestId.current !== reqId) return;
+            setFaces(data.faces ?? []);
+        } catch (err) {
+            if (requestId.current !== reqId) return;
+            onError(err instanceof Error ? err.message : "Failed to load this person's faces");
+        } finally {
+            if (requestId.current === reqId) setLoading(false);
+        }
+    };
+
+    const rejectFace = async (faceId: string) => {
+        const previous = faces;
+        setFaces((prev) => (prev ?? []).filter((f) => f.face_id !== faceId));
+        try {
+            const res = await fetch(`/api/dashboard/faces/${faceId}`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ detach: true }),
+            });
+            if (!res.ok) throw new Error("Failed to reject face");
+            onDetached();
+        } catch (err) {
+            setFaces(previous);
+            onError(err instanceof Error ? err.message : "Failed to reject face");
+        }
+    };
+
+    return (
+        <Stack gap="md">
+            <Select
+                label="Show me all faces of"
+                placeholder={options.length === 0 ? "No one assigned yet" : "Pick a person"}
+                data={options}
+                searchable
+                value={personId}
+                disabled={options.length === 0}
+                maw={360}
+                onChange={(value) => {
+                    setPersonId(value);
+                    setFaces(null);
+                    if (value) loadFaces(value);
+                }}
+            />
+
+            {personId && (
+                <Text size="sm" c="dimmed">
+                    Blurriest, least-certain faces first — mistakes tend to be near the top.
+                    Click ✕ on any face that isn&apos;t them; it moves back to the Unassigned
+                    tab.
+                </Text>
+            )}
+
+            {loading ? (
+                <Center py="xl">
+                    <Loader color="yellow" />
+                </Center>
+            ) : !personId ? (
+                <Center py="xl">
+                    <Text c="dimmed">Pick a person to verify every face assigned to them.</Text>
+                </Center>
+            ) : faces && faces.length === 0 ? (
+                <Center py="xl">
+                    <Text c="dimmed">No faces are assigned to this person.</Text>
+                </Center>
+            ) : faces ? (
+                <SimpleGrid cols={{ base: 3, sm: 5, md: 7, lg: 8 }} spacing="sm">
+                    {faces.map((face) => (
+                        <div key={face.face_id} style={{ position: "relative" }}>
+                            <FaceCrop
+                                src={face.thumbnail_url}
+                                box={face.bounding_box}
+                                imgWidth={face.thumbnail_width}
+                                imgHeight={face.thumbnail_height}
+                                size={104}
+                            />
+                            <Tooltip label="Not them — move to Unassigned">
+                                <ActionIcon
+                                    size="sm"
+                                    variant="filled"
+                                    color="red"
+                                    aria-label="Reject face"
+                                    style={{ position: "absolute", top: 2, right: 2 }}
+                                    onClick={() => rejectFace(face.face_id)}
+                                >
+                                    <IconX size={14} />
+                                </ActionIcon>
+                            </Tooltip>
+                        </div>
+                    ))}
+                </SimpleGrid>
+            ) : null}
         </Stack>
     );
 }

--- a/src/app/dashboard/photos/faces/page.tsx
+++ b/src/app/dashboard/photos/faces/page.tsx
@@ -370,11 +370,11 @@ function PersonReview({ options, onError, onDetached }: PersonReviewProps) {
         }
     };
 
-    const rejectFace = async (faceId: string) => {
-        const previous = faces;
-        setFaces((prev) => (prev ?? []).filter((f) => f.face_id !== faceId));
+    const rejectFace = async (face: FaceView) => {
+        const reqId = requestId.current;
+        setFaces((prev) => (prev ?? []).filter((f) => f.face_id !== face.face_id));
         try {
-            const res = await fetch(`/api/dashboard/faces/${faceId}`, {
+            const res = await fetch(`/api/dashboard/faces/${face.face_id}`, {
                 method: "PATCH",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ detach: true }),
@@ -382,7 +382,16 @@ function PersonReview({ options, onError, onDetached }: PersonReviewProps) {
             if (!res.ok) throw new Error("Failed to reject face");
             onDetached();
         } catch (err) {
-            setFaces(previous);
+            // If the admin switched person meanwhile, this list no longer
+            // belongs to the face — leave it alone (the face was never
+            // detached server-side, so it returns on the next load).
+            if (requestId.current !== reqId) return;
+            // Additive restore of just this face: a wholesale snapshot
+            // rollback would resurrect other faces whose rejects succeeded
+            // while this request was in flight.
+            setFaces((prev) =>
+                [...(prev ?? []), face].sort((a, b) => a.confidence - b.confidence)
+            );
             onError(err instanceof Error ? err.message : "Failed to reject face");
         }
     };
@@ -442,7 +451,7 @@ function PersonReview({ options, onError, onDetached }: PersonReviewProps) {
                                     color="red"
                                     aria-label="Reject face"
                                     style={{ position: "absolute", top: 2, right: 2 }}
-                                    onClick={() => rejectFace(face.face_id)}
+                                    onClick={() => rejectFace(face)}
                                 >
                                     <IconX size={14} />
                                 </ActionIcon>

--- a/src/utils/db/__tests__/faces.test.ts
+++ b/src/utils/db/__tests__/faces.test.ts
@@ -7,7 +7,7 @@ vi.mock("../dynamo", () => ({
     FACES_TABLE: "wedding-photo-faces",
 }));
 
-import { getFacesByInvitees, updateClusterAssignment } from "../faces";
+import { getFacesByInvitees, updateClusterAssignment, detachFace } from "../faces";
 
 interface SentCommand {
     input: {
@@ -93,5 +93,30 @@ describe("updateClusterAssignment", () => {
 
         expect(await updateClusterAssignment("nope", { ignored: true })).toBe(0);
         expect(mockSend).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("detachFace", () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it("moves the face to a fresh cluster and strips assignment fields", async () => {
+        mockSend.mockResolvedValue({});
+
+        expect(await detachFace("f1")).toBe(true);
+        const update = sentCommand(0);
+        expect(update.Key).toEqual({ face_id: "f1" });
+        expect(update.UpdateExpression).toBe(
+            "SET cluster_id = :fresh REMOVE invitee_id, invitation_id, ignored"
+        );
+        // A real (random) uuid, not a fixed sentinel.
+        expect(update.ExpressionAttributeValues?.[":fresh"]).toMatch(/^[0-9a-f-]{36}$/);
+    });
+
+    it("returns false when the face does not exist", async () => {
+        const { ConditionalCheckFailedException } = await import("@aws-sdk/client-dynamodb");
+        mockSend.mockRejectedValue(
+            new ConditionalCheckFailedException({ message: "nope", $metadata: {} })
+        );
+        expect(await detachFace("missing")).toBe(false);
     });
 });

--- a/src/utils/db/faces.ts
+++ b/src/utils/db/faces.ts
@@ -1,4 +1,6 @@
 import { QueryCommand, ScanCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
+import { randomUUID } from "crypto";
 import { docClient, FACES_TABLE } from "./dynamo";
 import type { ClusterAssignment, PhotoFace } from "@/types/faces";
 
@@ -73,6 +75,30 @@ export async function getFacesByInvitees(inviteeIds: number[]): Promise<PhotoFac
         })
     );
     return results.flat();
+}
+
+// An admin rejected this face from its person: sever it into a fresh,
+// unassigned singleton cluster. It disappears from the person (and from
+// guest results) immediately, but reappears in the Unassigned tab — if it's
+// really a different guest, it can be labeled correctly from there. Returns
+// false when no such face exists.
+export async function detachFace(faceId: string): Promise<boolean> {
+    try {
+        await docClient.send(
+            new UpdateCommand({
+                TableName: FACES_TABLE,
+                Key: { face_id: faceId },
+                UpdateExpression:
+                    "SET cluster_id = :fresh REMOVE invitee_id, invitation_id, ignored",
+                ConditionExpression: "attribute_exists(face_id)",
+                ExpressionAttributeValues: { ":fresh": randomUUID() },
+            })
+        );
+        return true;
+    } catch (error) {
+        if (error instanceof ConditionalCheckFailedException) return false;
+        throw error;
+    }
 }
 
 // Apply an assignment to every face in a cluster. Not transactional: a crash


### PR DESCRIPTION
Adds a fourth tab to `/dashboard/photos/faces`: **By Person** — "show me all faces of the selected person", with a reject button on every face. This is the verification layer for #162's labeling: clustering (even at the raised threshold) occasionally attaches a lookalike's face to the wrong person, and this tab is how every face gets human-checked.

## How it works

- Pick any guest who has assigned faces (searchable select, shows face counts). Every face attributed to them renders as a crop grid, **least detection-confidence first** — blurry and marginal faces sort to the top, which is where the mistakes concentrate.
- Each crop has a red ✕ ("Not them"). Rejecting **detaches** the face: it gets a fresh singleton cluster and loses its invitee/invitation/ignored fields, so it
  - disappears from this person (and from guest-facing Find My Photos) instantly, and
  - reappears in the Unassigned tab — if it's actually a different guest, it can be labeled correctly from there rather than being lost.
- Optimistic UI with rollback on failure; the request-id guard pattern from the modal-race fix protects against slow responses landing after a person switch.

## API (both `requireAuth`)

| Route | Purpose |
|---|---|
| `GET /api/dashboard/faces/by-invitee/[id]` | All faces attributed to an invitee, with thumbnail crop data, sorted lowest-confidence first |
| `PATCH /api/dashboard/faces/[faceId]` `{detach: true}` | Sever one face into an unassigned singleton (`detachFace()` with an `attribute_exists` condition → 404 for unknown faces) |

## Why detach instead of delete

The face vector stays in the Rekognition collection and the row survives — the face is a real person, just not *this* person. Deleting would throw away the chance to assign it to the right guest, and would also remove it as a match anchor for future uploads.

## Testing

10 new tests: auth gates on both routes, non-numeric id 400, sort order, empty person, detach success/404/bad-body, `detachFace` update semantics (fresh uuid cluster + field removal, false-on-missing). Suite: 183 passed; `tsc --noEmit` + `eslint` clean.