### PR TITLE
fix: make the bride and groom assignable to face clusters

### DIFF
--- a/src/app/api/gallery/my-photos/__tests__/route.test.ts
+++ b/src/app/api/gallery/my-photos/__tests__/route.test.ts
@@ -17,6 +17,10 @@ vi.mock("@/utils/db/archive", () => ({
     isMasterCode: (...args: unknown[]) => mockIsMasterCode(...args),
     getInvitationIdByCode: (...args: unknown[]) => mockGetInvitationIdByCode(...args),
     getInviteesWithIds: (...args: unknown[]) => mockGetInviteesWithIds(...args),
+    COUPLE_INVITEES: [
+        { id: -1, invitation_id: -1, name: "Matthew O'Neill", code: null },
+        { id: -2, invitation_id: -1, name: "Rebecca O'Neill", code: null },
+    ],
 }));
 vi.mock("@/utils/db/faces", () => ({
     getFacesByInvitees: (...args: unknown[]) => mockGetFacesByInvitees(...args),
@@ -128,12 +132,20 @@ describe("GET /api/gallery/my-photos", () => {
         expect(body.photos[0].thumbnail_url).toBe("https://cdn/uploads/thumbnail/x/p1.jpg");
     });
 
-    it("returns an empty result for the master code without touching the archive", async () => {
+    it("master code searches the couple's synthetic ids without touching the archive", async () => {
         mockIsMasterCode.mockReturnValue(true);
+        mockGetFacesByInvitees.mockResolvedValue([
+            { face_id: "f1", photo_id: "p1", invitee_id: -1 },
+        ]);
+        mockGetPhotosByIds.mockResolvedValue([photo({ id: "p1" })]);
+
         const body = await (await GET(req("?code=RM2026"))).json();
-        expect(body).toEqual({ photos: [], invitees: [], page: 1, limit: 200, total: 0 });
+
         expect(mockGetInvitationIdByCode).not.toHaveBeenCalled();
-        expect(mockGetFacesByInvitees).not.toHaveBeenCalled();
+        expect(mockGetInviteesWithIds).not.toHaveBeenCalled();
+        expect(mockGetFacesByInvitees).toHaveBeenCalledWith([-1, -2]);
+        expect(body.invitees).toEqual(["Matthew", "Rebecca"]);
+        expect(body.photos).toHaveLength(1);
     });
 
     it("admin without a code gets an empty 200, not a 401", async () => {

--- a/src/app/api/gallery/my-photos/route.ts
+++ b/src/app/api/gallery/my-photos/route.ts
@@ -1,5 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { isMasterCode, getInvitationIdByCode, getInviteesWithIds } from "@/utils/db/archive";
+import {
+    isMasterCode,
+    getInvitationIdByCode,
+    getInviteesWithIds,
+    COUPLE_INVITEES,
+} from "@/utils/db/archive";
 import { getFacesByInvitees } from "@/utils/db/faces";
 import { getPhotosByIds } from "@/utils/db/photos";
 import { listCategories } from "@/utils/db/categories";
@@ -34,13 +39,17 @@ export async function GET(request: NextRequest) {
             );
         }
 
-        // The master code (and an admin session without a guest code) has no
-        // archived household behind it — nothing to match, empty result.
-        if (invitationId === null) {
+        // The couple aren't archived invitees — the master code maps to their
+        // synthetic ids so their own faces are searchable too. An admin
+        // session without any code still has nobody to match.
+        const invitees = isMaster
+            ? COUPLE_INVITEES.map((c) => ({ id: c.id, first_name: c.name.split(" ")[0] }))
+            : invitationId !== null
+              ? await getInviteesWithIds(invitationId)
+              : null;
+        if (invitees === null) {
             return NextResponse.json({ photos: [], invitees: [], page, limit, total: 0 });
         }
-
-        const invitees = await getInviteesWithIds(invitationId);
         const faces = await getFacesByInvitees(invitees.map((i) => i.id));
         const photoIds = [...new Set(faces.map((f) => f.photo_id))];
 

--- a/src/app/gallery/my-photos/page.tsx
+++ b/src/app/gallery/my-photos/page.tsx
@@ -215,7 +215,7 @@ export default function MyPhotosPage() {
                             <Stack align="center" gap="xs">
                                 <Text c="dimmed">
                                     {isAdmin && (!invitationCode || invitationCode === masterCode)
-                                        ? "The couple's code has no guest household to match — enter a guest's code to preview their view."
+                                        ? "No faces are assigned to you two yet — label your clusters in the dashboard (Photos → Faces)."
                                         : "We haven't spotted you in any photos yet."}
                                 </Text>
                                 <Text c="dimmed" size="sm">

--- a/src/utils/db/__tests__/archive.test.ts
+++ b/src/utils/db/__tests__/archive.test.ts
@@ -7,7 +7,12 @@ vi.mock("../dynamo", () => ({
     ARCHIVE_TABLE: "wedding-archive",
 }));
 
-import { isMasterCode, isValidInvitationCode, getInviteesByCode } from "../archive";
+import {
+    isMasterCode,
+    isValidInvitationCode,
+    getInviteesByCode,
+    listAllInvitees,
+} from "../archive";
 
 const savedMaster = process.env.MASTER_INVITATION_CODE;
 
@@ -48,5 +53,33 @@ describe("master invitation code", () => {
     it("returns the couple's names for the master code", async () => {
         expect(await getInviteesByCode("LOCAL1")).toEqual(["Matthew", "Rebecca"]);
         expect(mockSend).not.toHaveBeenCalled();
+    });
+});
+
+describe("listAllInvitees", () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it("includes the couple as synthetic invitees alongside archived guests", async () => {
+        mockSend.mockResolvedValue({
+            Items: [
+                { entity: "code", code: "ABC123", invitation_id: 3 },
+                {
+                    entity: "invitee",
+                    id: 7,
+                    invitation_id: 3,
+                    first_name: "Aoife",
+                    last_name: "Byrne",
+                    coming: true,
+                },
+            ],
+        });
+
+        const invitees = await listAllInvitees();
+
+        expect(invitees).toEqual([
+            { id: 7, invitation_id: 3, name: "Aoife Byrne", code: "ABC123" },
+            { id: -1, invitation_id: -1, name: "Matthew O'Neill", code: null },
+            { id: -2, invitation_id: -1, name: "Rebecca O'Neill", code: null },
+        ]);
     });
 });

--- a/src/utils/db/archive.ts
+++ b/src/utils/db/archive.ts
@@ -182,8 +182,18 @@ export async function getArchiveSummary(): Promise<ArchiveSummary> {
     };
 }
 
-// Every archived invitee with their invitation's code, for the face-cluster
-// assignment picker. Alphabetical by full name.
+// The bride & groom aren't archived invitees (nobody sent them an invitation
+// to their own wedding), so they get reserved synthetic ids — negative, to
+// stay clear of the Postgres-era serial ids — making their face clusters
+// assignable like anyone else's. Their "code" is the master code env var,
+// never an archive row, hence code: null here.
+export const COUPLE_INVITEES: InviteeSummary[] = [
+    { id: -1, invitation_id: -1, name: "Matthew O'Neill", code: null },
+    { id: -2, invitation_id: -1, name: "Rebecca O'Neill", code: null },
+];
+
+// Every assignable person for the face-cluster picker: archived invitees
+// with their invitation's code, plus the couple. Alphabetical by full name.
 export async function listAllInvitees(): Promise<InviteeSummary[]> {
     const items = await scanArchive();
 
@@ -200,6 +210,7 @@ export async function listAllInvitees(): Promise<InviteeSummary[]> {
             name: `${i.first_name} ${i.last_name}`,
             code: codeByInvitation.get(i.invitation_id) ?? null,
         }))
+        .concat(COUPLE_INVITEES)
         .sort((a, b) => a.name.localeCompare(b.name));
 }
 

--- a/src/utils/db/archive.ts
+++ b/src/utils/db/archive.ts
@@ -118,7 +118,7 @@ export async function getInviteesWithIds(
 // exist. Returning names behind a valid code is fine — the code is the
 // guest's credential.
 export async function getInviteesByCode(code: string): Promise<string[] | null> {
-    if (isMasterCode(code)) return ["Matthew", "Rebecca"];
+    if (isMasterCode(code)) return COUPLE_INVITEES.map((c) => c.name.split(" ")[0]);
     const codeResult = await docClient.send(
         new GetCommand({
             TableName: ARCHIVE_TABLE,


### PR DESCRIPTION
The face-assignment picker was built from the archived invitee list — and the couple were never invitees, because nobody sent them an invitation to their own wedding. Net effect: the two *largest* clusters in the dataset (Matthew and Rebecca, ~620 faces between them) couldn't be labeled at all.

## Fix

- **`COUPLE_INVITEES`** in `archive.ts`: two synthetic invitee entries with reserved negative ids (safely clear of the Postgres-era serial ids that populate the archive), `invitation_id: -1`, and no code (their credential is the master-code env var, matching the existing `isMasterCode`/`getInviteesByCode` special-casing). `listAllInvitees()` appends them, so the cluster-assign picker, the PATCH validation, the By Person tab, and the `byInvitee` GSI writes all work for them with zero further changes — negative numbers are ordinary DynamoDB NUMBER keys.
- **Find My Photos works for the couple now**: `GET /api/gallery/my-photos` resolves the master code to the synthetic ids instead of short-circuiting to an empty result. Once their clusters are assigned, entering the master code (or just being logged in, which auto-fills it) shows every photo either of them appears in. An admin session with no code at all still gets the empty result.
- Guest page's master-code empty state now says to label clusters in the dashboard rather than claiming the code has no household.

## Testing

- Updated the master-code my-photos test: asserts the couple's ids are searched, the archive is never touched, and the header names come back as Matthew and Rebecca.
- New `listAllInvitees` test: synthetic entries appended to archived guests with correct ids/codes.
- Suite: 185 passed; `tsc --noEmit` + `eslint` clean.

After merging: assign the two big clusters to yourselves on `/dashboard/photos/faces`, then check `/gallery/my-photos` while logged in — it should fill with photos of you both.