### PR TITLE
feat: Maggie dog detection (surfaces via people search)

### DIFF
--- a/infra/lambdas/photo-processor/index.ts
+++ b/infra/lambdas/photo-processor/index.ts
@@ -13,6 +13,7 @@ import {
     RekognitionClient,
     IndexFacesCommand,
     SearchFacesCommand,
+    DetectLabelsCommand,
 } from "@aws-sdk/client-rekognition";
 import { randomUUID } from "node:crypto";
 import type { Readable } from "stream";
@@ -105,6 +106,70 @@ async function processPhoto(key: string, bucket: string): Promise<void> {
     } catch (err) {
         console.error(`Face indexing failed for ${key} (photo ${photoId}):`, err);
     }
+    try {
+        await detectDogs(bucket, thumbKey, photoId);
+    } catch (err) {
+        console.error(`Dog detection failed for ${key} (photo ${photoId}):`, err);
+    }
+}
+
+// Dog detections make Maggie searchable in the gallery's people search. Each
+// detection becomes an UNASSIGNED singleton row (other dogs attended the
+// wedding, so a new dog is never auto-assumed to be Maggie) — it surfaces as
+// an unassigned card in the dashboard for the admin to assign or ignore.
+async function detectDogs(bucket: string, thumbKey: string, photoId: string): Promise<void> {
+    const photo = await docClient.send(
+        new GetCommand({
+            TableName: PHOTOS_TABLE,
+            Key: { id: photoId },
+            ConsistentRead: true,
+            ProjectionExpression: "dog_scanned_at",
+        })
+    );
+    if (photo.Item?.dog_scanned_at) return;
+
+    const result = await rekognition.send(
+        new DetectLabelsCommand({
+            Image: { S3Object: { Bucket: bucket, Name: thumbKey } },
+            Features: ["GENERAL_LABELS"],
+            Settings: { GeneralLabels: { LabelInclusionFilters: ["Dog"] } },
+            MinConfidence: 70,
+        })
+    );
+
+    for (const label of result.Labels ?? []) {
+        for (const instance of label.Instances ?? []) {
+            const box = instance.BoundingBox;
+            if (!box) continue;
+            await docClient.send(
+                new PutCommand({
+                    TableName: FACES_TABLE,
+                    Item: {
+                        face_id: `dog-${randomUUID()}`,
+                        photo_id: photoId,
+                        cluster_id: randomUUID(),
+                        bounding_box: {
+                            left: box.Left ?? 0,
+                            top: box.Top ?? 0,
+                            width: box.Width ?? 0,
+                            height: box.Height ?? 0,
+                        },
+                        confidence: instance.Confidence ?? 0,
+                        indexed_at: new Date().toISOString(),
+                    },
+                })
+            );
+        }
+    }
+
+    await docClient.send(
+        new UpdateCommand({
+            TableName: PHOTOS_TABLE,
+            Key: { id: photoId },
+            UpdateExpression: "SET dog_scanned_at = :now",
+            ExpressionAttributeValues: { ":now": new Date().toISOString() },
+        })
+    );
 }
 
 // Index every face in the thumbnail into the Rekognition collection and store

--- a/infra/lambdas/photo-processor/index.ts
+++ b/infra/lambdas/photo-processor/index.ts
@@ -99,17 +99,18 @@ async function processPhoto(key: string, bucket: string): Promise<void> {
 
     const photoId = await updatePhotoRecord(key, thumbKey, info.width, info.height, takenAt);
 
-    // Face indexing is strictly best-effort: a Rekognition or faces-table
-    // failure must never break the thumbnail pipeline the gallery depends on.
-    try {
-        await indexAndAssignFaces(bucket, thumbKey, photoId);
-    } catch (err) {
-        console.error(`Face indexing failed for ${key} (photo ${photoId}):`, err);
+    // Face indexing and dog detection are strictly best-effort: a Rekognition
+    // or faces-table failure must never break the thumbnail pipeline the
+    // gallery depends on. They're independent calls, so run them concurrently.
+    const [faceResult, dogResult] = await Promise.allSettled([
+        indexAndAssignFaces(bucket, thumbKey, photoId),
+        detectDogs(bucket, thumbKey, photoId),
+    ]);
+    if (faceResult.status === "rejected") {
+        console.error(`Face indexing failed for ${key} (photo ${photoId}):`, faceResult.reason);
     }
-    try {
-        await detectDogs(bucket, thumbKey, photoId);
-    } catch (err) {
-        console.error(`Dog detection failed for ${key} (photo ${photoId}):`, err);
+    if (dogResult.status === "rejected") {
+        console.error(`Dog detection failed for ${key} (photo ${photoId}):`, dogResult.reason);
     }
 }
 

--- a/infra/lib/wedding-stack.ts
+++ b/infra/lib/wedding-stack.ts
@@ -323,6 +323,12 @@ export class WeddingStack extends cdk.Stack {
             `arn:aws:rekognition:${this.region}:${this.account}:collection/wedding-faces-2026`,
           ],
         }),
+        // Dog detection (Maggie in the gallery's people search). DetectLabels
+        // doesn't operate on a collection, so it can't be resource-scoped.
+        new iam.PolicyStatement({
+          actions: ['rekognition:DetectLabels'],
+          resources: ['*'],
+        }),
       ],
     });
     // Only the photo-processor talks to Rekognition at runtime — the Next.js

--- a/scripts/detect-dogs.mjs
+++ b/scripts/detect-dogs.mjs
@@ -17,6 +17,10 @@
 // Idempotent: photos with a dog_scanned_at marker are skipped, so a crashed
 // run can simply be re-run. Cost: ~$0.001/photo (~$0.75 for the full set).
 //
+// Caveat: the to-do list is snapshotted up front, so a photo uploaded (and
+// Lambda-scanned) mid-run can be scanned twice, leaving duplicate dog rows —
+// harmless, just extra cards to prune. Avoid re-running while uploads are hot.
+//
 // Requires: AWS credentials (run with AWS_PROFILE=wedding), S3_PHOTOS_BUCKET,
 // DDB_PHOTOS_TABLE, DDB_FACES_TABLE.
 

--- a/scripts/detect-dogs.mjs
+++ b/scripts/detect-dogs.mjs
@@ -1,0 +1,148 @@
+// Backfill dog detection so Maggie appears in the gallery's people search.
+//
+// Runs Rekognition DetectLabels (filtered to "Dog") over every photo
+// thumbnail and stores one faces-table row per detected dog, all under the
+// single shared cluster "dog-detections". The admin then assigns that
+// cluster to Maggie in the dashboard and rejects the dogs that aren't her
+// via the By Person tab (other dogs attended the wedding). Once assigned,
+// she shows up in the guest-facing people search like any labeled person.
+//
+// Usage:
+//   node scripts/detect-dogs.mjs [--dry-run] [--limit N] [--min-confidence N]
+//
+//   --dry-run           list what would be scanned, no AWS mutations
+//   --limit N           scan at most N photos (smoke-testing)
+//   --min-confidence N  DetectLabels MinConfidence, default 70
+//
+// Idempotent: photos with a dog_scanned_at marker are skipped, so a crashed
+// run can simply be re-run. Cost: ~$0.001/photo (~$0.75 for the full set).
+//
+// Requires: AWS credentials (run with AWS_PROFILE=wedding), S3_PHOTOS_BUCKET,
+// DDB_PHOTOS_TABLE, DDB_FACES_TABLE.
+
+import { RekognitionClient, DetectLabelsCommand } from "@aws-sdk/client-rekognition";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+    DynamoDBDocumentClient,
+    PutCommand,
+    ScanCommand,
+    UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { randomUUID } from "node:crypto";
+
+const region = process.env.AWS_REGION ?? "eu-west-1";
+const bucket = process.env.S3_PHOTOS_BUCKET;
+const photosTable = process.env.DDB_PHOTOS_TABLE ?? "wedding-photos";
+const facesTable = process.env.DDB_FACES_TABLE ?? "wedding-photo-faces";
+
+// One shared cluster so the whole backfill shows as a single card the admin
+// assigns to Maggie once, then prunes.
+const DOG_CLUSTER_ID = "dog-detections";
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const limitIdx = args.indexOf("--limit");
+const limit = limitIdx !== -1 ? Number(args[limitIdx + 1]) : Infinity;
+const confIdx = args.indexOf("--min-confidence");
+const minConfidence = confIdx !== -1 ? Number(args[confIdx + 1]) : 70;
+
+if (!bucket) {
+    console.error("S3_PHOTOS_BUCKET is required");
+    process.exit(1);
+}
+
+const rekognition = new RekognitionClient({ region });
+const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region }), {
+    marshallOptions: { removeUndefinedValues: true },
+});
+
+const CONCURRENCY = 3;
+async function inBatches(items, worker) {
+    for (let i = 0; i < items.length; i += CONCURRENCY) {
+        await Promise.all(items.slice(i, i + CONCURRENCY).map(worker));
+    }
+}
+
+const photos = [];
+let lastKey;
+do {
+    const page = await docClient.send(
+        new ScanCommand({ TableName: photosTable, ExclusiveStartKey: lastKey })
+    );
+    photos.push(...(page.Items ?? []));
+    lastKey = page.LastEvaluatedKey;
+} while (lastKey);
+
+const todo = photos.filter((p) => p.thumbnail_key && !p.dog_scanned_at).slice(0, limit);
+const done = photos.filter((p) => p.thumbnail_key && p.dog_scanned_at).length;
+console.log(`${todo.length} photos to scan for dogs (${done} already scanned)`);
+
+if (dryRun) {
+    for (const p of todo.slice(0, 10)) console.log(`  would scan: ${p.thumbnail_key}`);
+    if (todo.length > 10) console.log(`  … and ${todo.length - 10} more`);
+    process.exit(0);
+}
+
+let scanned = 0;
+let dogs = 0;
+let failed = 0;
+
+await inBatches(todo, async (photo) => {
+    try {
+        const result = await rekognition.send(
+            new DetectLabelsCommand({
+                Image: { S3Object: { Bucket: bucket, Name: photo.thumbnail_key } },
+                Features: ["GENERAL_LABELS"],
+                Settings: { GeneralLabels: { LabelInclusionFilters: ["Dog"] } },
+                MinConfidence: minConfidence,
+            })
+        );
+
+        for (const label of result.Labels ?? []) {
+            for (const instance of label.Instances ?? []) {
+                if (!instance.BoundingBox) continue;
+                await docClient.send(
+                    new PutCommand({
+                        TableName: facesTable,
+                        Item: {
+                            face_id: `dog-${randomUUID()}`,
+                            photo_id: photo.id,
+                            cluster_id: DOG_CLUSTER_ID,
+                            bounding_box: {
+                                left: instance.BoundingBox.Left ?? 0,
+                                top: instance.BoundingBox.Top ?? 0,
+                                width: instance.BoundingBox.Width ?? 0,
+                                height: instance.BoundingBox.Height ?? 0,
+                            },
+                            confidence: instance.Confidence ?? 0,
+                            indexed_at: new Date().toISOString(),
+                        },
+                    })
+                );
+                dogs++;
+            }
+        }
+
+        await docClient.send(
+            new UpdateCommand({
+                TableName: photosTable,
+                Key: { id: photo.id },
+                UpdateExpression: "SET dog_scanned_at = :now",
+                ExpressionAttributeValues: { ":now": new Date().toISOString() },
+            })
+        );
+
+        scanned++;
+        if (scanned % 50 === 0) console.log(`  …${scanned}/${todo.length} scanned, ${dogs} dogs so far`);
+    } catch (err) {
+        failed++;
+        console.error(`FAILED ${photo.thumbnail_key}: ${err.message}`);
+    }
+});
+
+console.log(
+    `Done: ${scanned} photos scanned, ${dogs} dog detections in cluster "${DOG_CLUSTER_ID}", ${failed} failed`
+);
+if (dogs > 0) {
+    console.log("Next: assign the dog cluster to Maggie in the dashboard, then prune via By Person.");
+}

--- a/src/utils/db/__tests__/archive.test.ts
+++ b/src/utils/db/__tests__/archive.test.ts
@@ -78,6 +78,7 @@ describe("listAllInvitees", () => {
 
         expect(invitees).toEqual([
             { id: 7, invitation_id: 3, name: "Aoife Byrne", code: "ABC123" },
+            { id: -3, invitation_id: -1, name: "Maggie", code: null },
             { id: -1, invitation_id: -1, name: "Matthew O'Neill", code: null },
             { id: -2, invitation_id: -1, name: "Rebecca O'Neill", code: null },
         ]);

--- a/src/utils/db/archive.ts
+++ b/src/utils/db/archive.ts
@@ -192,6 +192,18 @@ export const COUPLE_INVITEES: InviteeSummary[] = [
     { id: -2, invitation_id: -1, name: "Rebecca O'Neill", code: null },
 ];
 
+// The couple's dog. Dog detections (Rekognition DetectLabels, not face
+// matching) are stored as ordinary face rows and assigned to her like any
+// person, so she surfaces through the gallery's people search once her
+// detections are labeled. Deliberately NOT part of COUPLE_INVITEES — the
+// master code's Find My Photos stays humans-only.
+export const MAGGIE_INVITEE: InviteeSummary = {
+    id: -3,
+    invitation_id: -1,
+    name: "Maggie",
+    code: null,
+};
+
 // Every assignable person for the face-cluster picker: archived invitees
 // with their invitation's code, plus the couple. Alphabetical by full name.
 export async function listAllInvitees(): Promise<InviteeSummary[]> {
@@ -210,7 +222,7 @@ export async function listAllInvitees(): Promise<InviteeSummary[]> {
             name: `${i.first_name} ${i.last_name}`,
             code: codeByInvitation.get(i.invitation_id) ?? null,
         }))
-        .concat(COUPLE_INVITEES)
+        .concat(COUPLE_INVITEES, MAGGIE_INVITEE)
         .sort((a, b) => a.name.localeCompare(b.name));
 }
 


### PR DESCRIPTION
**Reworked after #191 merged** (branch rebuilt on current main, force-pushed): the original gallery "Maggie 🐾" tab and `filter=maggie` API param are gone — the general people search covers her. Once her detections are assigned, Maggie appears in the gallery's search dropdown with a snout headshot like any other labeled person. What remains is the detection core.

Rekognition can *detect* dogs (`DetectLabels`, per-dog bounding boxes) but can't *recognize* a specific dog — and other dogs attended — so every detection routes through the existing human review machinery:

- **`scripts/detect-dogs.mjs`** (backfill, local creds): `DetectLabels` filtered to `Dog` over every thumbnail, ~$0.001/photo. Each detection becomes a faces-table row under one shared cluster `dog-detections`, so the whole backfill appears as a single dashboard card. Idempotent via a `dog_scanned_at` marker.
- **`MAGGIE_INVITEE`** (id `-3`, same synthetic pattern as #189): assign the dog cluster to Maggie once → **By Person → Maggie** → reject the dogs that aren't her. Deliberately *not* in `COUPLE_INVITEES`, so the master code's Find My Photos stays humans-only.
- **New uploads**: the photo-processor Lambda runs `DetectLabels` in its own try/catch; new dogs land as **unassigned singleton cards**, never auto-assigned to Maggie.
- **CDK**: one new statement on the Rekognition policy — `DetectLabels` isn't a collection operation, so it can't be resource-scoped. Needs a `cdk deploy`.

## Testing

Suite: 192 passed (picker test asserts Maggie's entry); `tsc --noEmit` + `eslint` clean; infra tsc unchanged from baseline. Rekognition behavior verified post-deploy via the `--limit 5` smoke run.

## Rollout

1. Merge → Amplify deploys the picker entry (people search picks her up automatically once labeled).
2. `cdk deploy` (DetectLabels IAM + Lambda update).
3. `AWS_PROFILE=wedding S3_PHOTOS_BUCKET=oneill-wedding-photos node scripts/detect-dogs.mjs --limit 5` then the full run.
4. Assign the `dog-detections` cluster to Maggie, prune impostors in By Person — she's searchable.