### PR TITLE
feat: people search in the gallery with face-crop headshots

### DIFF
--- a/src/app/api/gallery/people/__tests__/route.test.ts
+++ b/src/app/api/gallery/people/__tests__/route.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+
+const mockRequireAuth = vi.fn();
+const mockIsValidInvitationCode = vi.fn();
+const mockListAllInvitees = vi.fn();
+const mockListAllFaces = vi.fn();
+const mockGetPhotosByIds = vi.fn();
+
+vi.mock("@/utils/auth/requireAuth", () => ({
+    requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+}));
+vi.mock("@/utils/db/archive", () => ({
+    isValidInvitationCode: (...args: unknown[]) => mockIsValidInvitationCode(...args),
+    listAllInvitees: (...args: unknown[]) => mockListAllInvitees(...args),
+}));
+vi.mock("@/utils/db/faces", () => ({
+    listAllFaces: (...args: unknown[]) => mockListAllFaces(...args),
+}));
+vi.mock("@/utils/db/photos", () => ({
+    getPhotosByIds: (...args: unknown[]) => mockGetPhotosByIds(...args),
+}));
+vi.mock("@/utils/storage", () => ({
+    cdnUrl: (k: string) => `https://cdn/${k}`,
+}));
+
+const face = (over: Record<string, unknown>) => ({
+    face_id: "f",
+    photo_id: "p1",
+    cluster_id: "c1",
+    bounding_box: { left: 0.1, top: 0.1, width: 0.2, height: 0.2 },
+    confidence: 90,
+    indexed_at: "2026-07-18T00:00:00Z",
+    ...over,
+});
+
+const req = (qs = "") => new NextRequest(`http://localhost/api/gallery/people${qs}`);
+
+describe("GET /api/gallery/people", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockRequireAuth.mockResolvedValue({
+            success: false,
+            response: new Response(null, { status: 401 }),
+        });
+        mockIsValidInvitationCode.mockResolvedValue(true);
+        mockListAllInvitees.mockResolvedValue([
+            { id: 7, invitation_id: 3, name: "Aoife Byrne", code: "ABC123" },
+            { id: -3, invitation_id: -1, name: "Maggie", code: null },
+        ]);
+        mockGetPhotosByIds.mockResolvedValue([
+            { id: "p1", thumbnail_key: "t/p1.jpg", width: 1200, height: 800 },
+        ]);
+    });
+
+    it("rejects requests without a valid code", async () => {
+        mockIsValidInvitationCode.mockResolvedValue(false);
+        const res = await GET(req("?code=ZZZZZZ"));
+        expect(res.status).toBe(401);
+        expect(mockListAllFaces).not.toHaveBeenCalled();
+    });
+
+    it("admin session passes without a code", async () => {
+        mockRequireAuth.mockResolvedValue({ success: true, payload: {} });
+        mockListAllFaces.mockResolvedValue([]);
+        const res = await GET(req());
+        expect(res.status).toBe(200);
+        expect(mockIsValidInvitationCode).not.toHaveBeenCalled();
+    });
+
+    it("returns assigned people with their best face and photo counts, sorted by name", async () => {
+        mockListAllFaces.mockResolvedValue([
+            face({ face_id: "f1", invitee_id: -3, confidence: 80 }),
+            face({ face_id: "f2", invitee_id: 7, confidence: 85, photo_id: "p1" }),
+            face({ face_id: "f3", invitee_id: 7, confidence: 99, photo_id: "p2" }),
+            face({ face_id: "f4", invitee_id: 7, confidence: 60, photo_id: "p2" }),
+        ]);
+        mockGetPhotosByIds.mockResolvedValue([
+            { id: "p1", thumbnail_key: "t/p1.jpg", width: 1200, height: 800 },
+            { id: "p2", thumbnail_key: "t/p2.jpg", width: 900, height: 600 },
+        ]);
+
+        const body = await (await GET(req("?code=ABC123"))).json();
+
+        expect(body.people.map((p: { name: string }) => p.name)).toEqual([
+            "Aoife Byrne",
+            "Maggie",
+        ]);
+        const aoife = body.people[0];
+        expect(aoife.face.face_id).toBe("f3"); // highest confidence wins
+        expect(aoife.face.thumbnail_url).toBe("https://cdn/t/p2.jpg");
+        expect(aoife.photo_count).toBe(2); // p1 + p2, f4 deduped into p2
+    });
+
+    it("excludes unassigned and ignored faces", async () => {
+        mockListAllFaces.mockResolvedValue([
+            face({ face_id: "f1" }), // no invitee
+            face({ face_id: "f2", invitee_id: 7, ignored: true }),
+        ]);
+        const body = await (await GET(req("?code=ABC123"))).json();
+        expect(body.people).toEqual([]);
+    });
+});

--- a/src/app/api/gallery/people/__tests__/route.test.ts
+++ b/src/app/api/gallery/people/__tests__/route.test.ts
@@ -6,7 +6,7 @@ const mockRequireAuth = vi.fn();
 const mockIsValidInvitationCode = vi.fn();
 const mockListAllInvitees = vi.fn();
 const mockListAllFaces = vi.fn();
-const mockGetPhotosByIds = vi.fn();
+const mockListPhotosByStatus = vi.fn();
 
 vi.mock("@/utils/auth/requireAuth", () => ({
     requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
@@ -19,7 +19,7 @@ vi.mock("@/utils/db/faces", () => ({
     listAllFaces: (...args: unknown[]) => mockListAllFaces(...args),
 }));
 vi.mock("@/utils/db/photos", () => ({
-    getPhotosByIds: (...args: unknown[]) => mockGetPhotosByIds(...args),
+    listPhotosByStatus: (...args: unknown[]) => mockListPhotosByStatus(...args),
 }));
 vi.mock("@/utils/storage", () => ({
     cdnUrl: (k: string) => `https://cdn/${k}`,
@@ -49,8 +49,8 @@ describe("GET /api/gallery/people", () => {
             { id: 7, invitation_id: 3, name: "Aoife Byrne", code: "ABC123" },
             { id: -3, invitation_id: -1, name: "Maggie", code: null },
         ]);
-        mockGetPhotosByIds.mockResolvedValue([
-            { id: "p1", thumbnail_key: "t/p1.jpg", width: 1200, height: 800 },
+        mockListPhotosByStatus.mockResolvedValue([
+            { id: "p1", thumbnail_key: "t/p1.jpg", width: 1200, height: 800, status: "approved" },
         ]);
     });
 
@@ -76,9 +76,9 @@ describe("GET /api/gallery/people", () => {
             face({ face_id: "f3", invitee_id: 7, confidence: 99, photo_id: "p2" }),
             face({ face_id: "f4", invitee_id: 7, confidence: 60, photo_id: "p2" }),
         ]);
-        mockGetPhotosByIds.mockResolvedValue([
-            { id: "p1", thumbnail_key: "t/p1.jpg", width: 1200, height: 800 },
-            { id: "p2", thumbnail_key: "t/p2.jpg", width: 900, height: 600 },
+        mockListPhotosByStatus.mockResolvedValue([
+            { id: "p1", thumbnail_key: "t/p1.jpg", width: 1200, height: 800, status: "approved" },
+            { id: "p2", thumbnail_key: "t/p2.jpg", width: 900, height: 600, status: "approved" },
         ]);
 
         const body = await (await GET(req("?code=ABC123"))).json();
@@ -100,5 +100,28 @@ describe("GET /api/gallery/people", () => {
         ]);
         const body = await (await GET(req("?code=ABC123"))).json();
         expect(body.people).toEqual([]);
+    });
+
+    it("only counts approved photos, and drops people with none", async () => {
+        mockListAllFaces.mockResolvedValue([
+            // Aoife: one approved, one pending photo → count 1, best face
+            // must come from the approved one even though pending scores higher
+            face({ face_id: "f1", invitee_id: 7, confidence: 99, photo_id: "p-pending" }),
+            face({ face_id: "f2", invitee_id: 7, confidence: 80, photo_id: "p1" }),
+            // Maggie: only a pending photo → not searchable at all
+            face({ face_id: "f3", invitee_id: -3, confidence: 95, photo_id: "p-pending" }),
+        ]);
+        // listPhotosByStatus("approved") only ever returns approved rows.
+        mockListPhotosByStatus.mockResolvedValue([
+            { id: "p1", thumbnail_key: "t/p1.jpg", width: 1200, height: 800, status: "approved" },
+        ]);
+
+        const body = await (await GET(req("?code=ABC123"))).json();
+
+        expect(mockListPhotosByStatus).toHaveBeenCalledWith("approved");
+        expect(body.people).toHaveLength(1);
+        expect(body.people[0].name).toBe("Aoife Byrne");
+        expect(body.people[0].photo_count).toBe(1);
+        expect(body.people[0].face.face_id).toBe("f2");
     });
 });

--- a/src/app/api/gallery/people/route.ts
+++ b/src/app/api/gallery/people/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { isValidInvitationCode, listAllInvitees } from "@/utils/db/archive";
 import { listAllFaces } from "@/utils/db/faces";
-import { getPhotosByIds } from "@/utils/db/photos";
+import { listPhotosByStatus } from "@/utils/db/photos";
 import { requireAuth } from "@/utils/auth/requireAuth";
 import { cdnUrl } from "@/utils/storage";
 import type { GalleryPerson } from "@/types/faces";
@@ -27,14 +27,22 @@ export async function GET(request: NextRequest) {
             }
         }
 
-        const [faces, invitees] = await Promise.all([listAllFaces(), listAllInvitees()]);
+        const [faces, invitees, approvedPhotos] = await Promise.all([
+            listAllFaces(),
+            listAllInvitees(),
+            listPhotosByStatus("approved"),
+        ]);
         const nameById = new Map(invitees.map((i) => [i.id, i.name]));
+        const photoById = new Map(approvedPhotos.map((p) => [p.id, p]));
 
-        // Best (highest-confidence) face and distinct photo count per person.
+        // Best (highest-confidence) face and distinct photo count per person —
+        // approved photos only, so the advertised count matches what selecting
+        // the person in the gallery (which serves approved photos) shows.
         const bestFace = new Map<number, PhotoFace>();
         const photoIds = new Map<number, Set<string>>();
         for (const face of faces) {
             if (face.invitee_id == null || face.ignored) continue;
+            if (!photoById.has(face.photo_id)) continue; // pending/rejected
             const current = bestFace.get(face.invitee_id);
             if (!current || face.confidence > current.confidence) {
                 bestFace.set(face.invitee_id, face);
@@ -43,11 +51,6 @@ export async function GET(request: NextRequest) {
             ids.add(face.photo_id);
             photoIds.set(face.invitee_id, ids);
         }
-
-        const photos = await getPhotosByIds([
-            ...new Set([...bestFace.values()].map((f) => f.photo_id)),
-        ]);
-        const photoById = new Map(photos.map((p) => [p.id, p]));
 
         const people: GalleryPerson[] = [...bestFace.entries()]
             .map(([inviteeId, face]) => {

--- a/src/app/api/gallery/people/route.ts
+++ b/src/app/api/gallery/people/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isValidInvitationCode, listAllInvitees } from "@/utils/db/archive";
+import { listAllFaces } from "@/utils/db/faces";
+import { getPhotosByIds } from "@/utils/db/photos";
+import { requireAuth } from "@/utils/auth/requireAuth";
+import { cdnUrl } from "@/utils/storage";
+import type { GalleryPerson } from "@/types/faces";
+import type { PhotoFace } from "@/types/faces";
+
+// The searchable people list for the gallery: everyone with at least one
+// assigned face, with their highest-confidence face as the headshot. Same
+// code gate as the rest of the gallery — this is guest-visible by design
+// (guests search for each other), but only behind a valid invitation code.
+export async function GET(request: NextRequest) {
+    try {
+        const auth = await requireAuth(request);
+        if (!auth.success) {
+            const code = new URL(request.url).searchParams
+                .get("code")
+                ?.trim()
+                .toUpperCase();
+            if (!code || !(await isValidInvitationCode(code))) {
+                return NextResponse.json(
+                    { error: "A valid invitation code is required" },
+                    { status: 401 }
+                );
+            }
+        }
+
+        const [faces, invitees] = await Promise.all([listAllFaces(), listAllInvitees()]);
+        const nameById = new Map(invitees.map((i) => [i.id, i.name]));
+
+        // Best (highest-confidence) face and distinct photo count per person.
+        const bestFace = new Map<number, PhotoFace>();
+        const photoIds = new Map<number, Set<string>>();
+        for (const face of faces) {
+            if (face.invitee_id == null || face.ignored) continue;
+            const current = bestFace.get(face.invitee_id);
+            if (!current || face.confidence > current.confidence) {
+                bestFace.set(face.invitee_id, face);
+            }
+            const ids = photoIds.get(face.invitee_id) ?? new Set<string>();
+            ids.add(face.photo_id);
+            photoIds.set(face.invitee_id, ids);
+        }
+
+        const photos = await getPhotosByIds([
+            ...new Set([...bestFace.values()].map((f) => f.photo_id)),
+        ]);
+        const photoById = new Map(photos.map((p) => [p.id, p]));
+
+        const people: GalleryPerson[] = [...bestFace.entries()]
+            .map(([inviteeId, face]) => {
+                const photo = photoById.get(face.photo_id);
+                return {
+                    invitee_id: inviteeId,
+                    name: nameById.get(inviteeId) ?? "Guest",
+                    photo_count: photoIds.get(inviteeId)?.size ?? 0,
+                    face: {
+                        face_id: face.face_id,
+                        photo_id: face.photo_id,
+                        thumbnail_url: photo?.thumbnail_key ? cdnUrl(photo.thumbnail_key) : null,
+                        thumbnail_width: photo?.width ?? null,
+                        thumbnail_height: photo?.height ?? null,
+                        bounding_box: face.bounding_box,
+                        confidence: face.confidence,
+                    },
+                };
+            })
+            .sort((a, b) => a.name.localeCompare(b.name));
+
+        return NextResponse.json({ people });
+    } catch (error) {
+        console.error("Error in GET /api/gallery/people:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/app/api/photos/__tests__/route.test.ts
+++ b/src/app/api/photos/__tests__/route.test.ts
@@ -133,11 +133,15 @@ describe("GET /api/photos", () => {
         expect(data.total).toBe(1);
     });
 
-    it("rejects a non-numeric person param", async () => {
+    it("rejects non-numeric person params, including coercible ones", async () => {
         mockListPhotosByStatus.mockResolvedValue([mockPhoto]);
-        const req = new NextRequest("http://localhost/api/photos?code=ABC123&person=abc");
-        const res = await GET(req);
-        expect(res.status).toBe(400);
+        for (const bad of ["abc", "", " 7", "0x7", "7.5"]) {
+            const req = new NextRequest(
+                `http://localhost/api/photos?code=ABC123&person=${encodeURIComponent(bad)}`
+            );
+            const res = await GET(req);
+            expect(res.status, `person=${JSON.stringify(bad)}`).toBe(400);
+        }
         expect(mockGetFacesByInvitees).not.toHaveBeenCalled();
     });
 

--- a/src/app/api/photos/__tests__/route.test.ts
+++ b/src/app/api/photos/__tests__/route.test.ts
@@ -15,6 +15,11 @@ vi.mock("@/utils/db/archive", () => ({
     isValidInvitationCode: (...args: unknown[]) => mockIsValidInvitationCode(...args),
 }));
 
+const mockGetFacesByInvitees = vi.fn();
+vi.mock("@/utils/db/faces", () => ({
+    getFacesByInvitees: (...args: unknown[]) => mockGetFacesByInvitees(...args),
+}));
+
 vi.mock("@/utils/db/categories", () => ({
     listCategories: (...args: unknown[]) => mockListCategories(...args),
 }));
@@ -103,6 +108,44 @@ describe("GET /api/photos", () => {
         expect(data.photos[0].thumbnail_url).toBe("https://cdn/uploads/thumbnail/ABC123/uuid.jpg");
         // Verify only approved was queried
         expect(mockListPhotosByStatus).toHaveBeenCalledWith("approved");
+    });
+
+    it("person param restricts to that person's photos and composes with category", async () => {
+        mockListPhotosByStatus.mockResolvedValue([
+            { ...mockPhoto, id: "photo-1", category_id: "cat-ceremony" },
+            { ...mockPhoto, id: "photo-2", category_id: "cat-ceremony" },
+            { ...mockPhoto, id: "photo-3", category_id: null },
+        ]);
+        mockGetFacesByInvitees.mockResolvedValue([
+            { face_id: "f1", photo_id: "photo-2", invitee_id: 7 },
+            { face_id: "f2", photo_id: "photo-3", invitee_id: 7 },
+        ]);
+
+        const req = new NextRequest(
+            "http://localhost/api/photos?code=ABC123&person=7&category=ceremony"
+        );
+        const data = await (await GET(req)).json();
+
+        expect(mockGetFacesByInvitees).toHaveBeenCalledWith([7]);
+        // photo-2 is both ceremony AND person 7; photo-3 is person 7 but not
+        // ceremony; photo-1 is ceremony but not person 7.
+        expect(data.photos.map((p: { id: string }) => p.id)).toEqual(["photo-2"]);
+        expect(data.total).toBe(1);
+    });
+
+    it("rejects a non-numeric person param", async () => {
+        mockListPhotosByStatus.mockResolvedValue([mockPhoto]);
+        const req = new NextRequest("http://localhost/api/photos?code=ABC123&person=abc");
+        const res = await GET(req);
+        expect(res.status).toBe(400);
+        expect(mockGetFacesByInvitees).not.toHaveBeenCalled();
+    });
+
+    it("does not query faces without a person param", async () => {
+        mockListPhotosByStatus.mockResolvedValue([mockPhoto]);
+        const req = new NextRequest("http://localhost/api/photos?code=ABC123");
+        await GET(req);
+        expect(mockGetFacesByInvitees).not.toHaveBeenCalled();
     });
 
     it("does not expose sensitive fields to public callers", async () => {

--- a/src/app/api/photos/route.ts
+++ b/src/app/api/photos/route.ts
@@ -65,10 +65,12 @@ export async function GET(request: NextRequest) {
         // protects the photos protects who's in them.
         const personParam = searchParams.get("person");
         if (personParam !== null) {
-            const personId = Number(personParam);
-            if (!Number.isInteger(personId)) {
+            // Strict digit check: Number() would coerce "", whitespace, and
+            // hex strings into integers that silently query the wrong id.
+            if (!/^-?\d+$/.test(personParam)) {
                 return NextResponse.json({ error: "Invalid person id" }, { status: 400 });
             }
+            const personId = Number(personParam);
             const personFaces = await getFacesByInvitees([personId]);
             const personPhotoIds = new Set(personFaces.map((f) => f.photo_id));
             matching = matching.filter((p) => personPhotoIds.has(p.id));

--- a/src/app/api/photos/route.ts
+++ b/src/app/api/photos/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { listPhotosByStatus } from "@/utils/db/photos";
 import { listCategories } from "@/utils/db/categories";
 import { isValidInvitationCode } from "@/utils/db/archive";
+import { getFacesByInvitees } from "@/utils/db/faces";
 import { requireAuth } from "@/utils/auth/requireAuth";
 import { cdnUrl } from "@/utils/storage";
 import type { Photo, PublicPhoto } from "@/types/photos";
@@ -51,12 +52,27 @@ export async function GET(request: NextRequest) {
         ]);
         const slugById = new Map(categories.map((c) => [c.id, c.slug]));
 
-        const matching: PhotoRow[] = allPhotos
+        let matching: PhotoRow[] = allPhotos
             .map((p) => ({
                 ...p,
                 category_slug: p.category_id ? (slugById.get(p.category_id) ?? null) : null,
             }))
             .filter((p) => !categorySlug || p.category_slug === categorySlug);
+
+        // People search: restrict to photos the selected person appears in
+        // (per the labeled face detections). Composes with the category
+        // filter above. Guest-visible by design — the same code gate that
+        // protects the photos protects who's in them.
+        const personParam = searchParams.get("person");
+        if (personParam !== null) {
+            const personId = Number(personParam);
+            if (!Number.isInteger(personId)) {
+                return NextResponse.json({ error: "Invalid person id" }, { status: 400 });
+            }
+            const personFaces = await getFacesByInvitees([personId]);
+            const personPhotoIds = new Set(personFaces.map((f) => f.photo_id));
+            matching = matching.filter((p) => personPhotoIds.has(p.id));
+        }
 
         const total = matching.length;
         const rows = matching.slice(offset, offset + limit);

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -16,9 +16,12 @@ import {
     Center,
     Paper,
     TextInput,
+    Select,
 } from "@mantine/core";
-import { IconAlertCircle, IconDownload, IconTrash } from "@tabler/icons-react";
+import { IconAlertCircle, IconDownload, IconTrash, IconSearch } from "@tabler/icons-react";
 import { useSession } from "@/hooks/useSession";
+import { FaceCrop } from "@/components/FaceCrop";
+import type { GalleryPerson } from "@/types/faces";
 import { RowsPhotoAlbum } from "react-photo-album";
 import "react-photo-album/rows.css";
 import Lightbox from "yet-another-react-lightbox";
@@ -64,6 +67,8 @@ function Gallery() {
     const [page, setPage] = useState(1);
     const [hasMore, setHasMore] = useState(true);
     const [rejecting, setRejecting] = useState(false);
+    const [people, setPeople] = useState<GalleryPerson[]>([]);
+    const [personFilter, setPersonFilter] = useState<string | null>(null);
     const sentinelRef = useRef<HTMLDivElement | null>(null);
     const { status: sessionStatus, masterCode } = useSession();
     const isAdmin = sessionStatus === "authenticated";
@@ -164,12 +169,13 @@ function Gallery() {
     };
 
     const fetchPhotos = useCallback(
-        async (category: string | null, pg: number) => {
+        async (category: string | null, pg: number, person: string | null) => {
             setLoading(true);
             setError(null);
             try {
                 const params = new URLSearchParams({ page: String(pg), limit: String(LIMIT) });
                 if (category) params.set("category", category);
+                if (person) params.set("person", person);
                 if (invitationCode) params.set("code", invitationCode);
                 const res = await fetch(`/api/photos?${params}`);
                 if (res.status === 401) {
@@ -208,14 +214,25 @@ function Gallery() {
             .catch(() => {});
     }, []);
 
+    // The searchable people list (labeled faces). Needs gallery access, so
+    // it waits for the same code/session resolution the photos do.
+    useEffect(() => {
+        if (!codeChecked || (!invitationCode && sessionStatus !== "authenticated")) return;
+        const params = invitationCode ? `?code=${invitationCode}` : "";
+        fetch(`/api/gallery/people${params}`)
+            .then((r) => (r.ok ? r.json() : { people: [] }))
+            .then((d) => setPeople(d.people ?? []))
+            .catch(() => {});
+    }, [codeChecked, invitationCode, sessionStatus]);
+
     useEffect(() => {
         // Don't fetch until code resolution has run, and never fetch without
         // access — the API would just 401.
         if (!codeChecked || (!invitationCode && sessionStatus !== "authenticated")) return;
         setPage(1);
         setPhotos([]);
-        fetchPhotos(activeCategory, 1);
-    }, [activeCategory, fetchPhotos, codeChecked, invitationCode, sessionStatus]);
+        fetchPhotos(activeCategory, 1, personFilter);
+    }, [activeCategory, personFilter, fetchPhotos, codeChecked, invitationCode, sessionStatus]);
 
     // Infinite scroll: load the next page when the sentinel scrolls into view.
     // The effect re-runs on every relevant state change so the observer always
@@ -228,14 +245,14 @@ function Gallery() {
                 if (entries[0].isIntersecting) {
                     const next = page + 1;
                     setPage(next);
-                    fetchPhotos(activeCategory, next);
+                    fetchPhotos(activeCategory, next, personFilter);
                 }
             },
             { rootMargin: "400px" }
         );
         observer.observe(el);
         return () => observer.disconnect();
-    }, [hasMore, loading, page, activeCategory, fetchPhotos]);
+    }, [hasMore, loading, page, activeCategory, personFilter, fetchPhotos]);
 
     const lightboxSlides = photos.map((p) => ({
         src: p.src,
@@ -318,6 +335,49 @@ function Gallery() {
                         </Center>
                     ) : (
                         <>
+                    {people.length > 0 && (
+                        <Select
+                            placeholder="Search for someone…"
+                            leftSection={<IconSearch size={16} />}
+                            data={people.map((p) => ({
+                                value: String(p.invitee_id),
+                                label: p.name,
+                            }))}
+                            renderOption={({ option }) => {
+                                const person = people.find(
+                                    (p) => String(p.invitee_id) === option.value
+                                );
+                                return (
+                                    <Group gap="sm" wrap="nowrap">
+                                        {person && (
+                                            <FaceCrop
+                                                src={person.face.thumbnail_url}
+                                                box={person.face.bounding_box}
+                                                imgWidth={person.face.thumbnail_width}
+                                                imgHeight={person.face.thumbnail_height}
+                                                size={36}
+                                            />
+                                        )}
+                                        <div>
+                                            <Text size="sm">{option.label}</Text>
+                                            {person && (
+                                                <Text size="xs" c="dimmed">
+                                                    {person.photo_count} photo
+                                                    {person.photo_count === 1 ? "" : "s"}
+                                                </Text>
+                                            )}
+                                        </div>
+                                    </Group>
+                                );
+                            }}
+                            searchable
+                            clearable
+                            maw={340}
+                            value={personFilter}
+                            onChange={setPersonFilter}
+                        />
+                    )}
+
                     <Tabs value={activeCategory ?? "all"} onChange={(v) => setActiveCategory(v === "all" ? null : v)}>
                         <Tabs.List>
                             <Tabs.Tab value="all">All Photos</Tabs.Tab>
@@ -335,7 +395,11 @@ function Gallery() {
                         </Center>
                     ) : photos.length === 0 ? (
                         <Center py="xl">
-                            <Text c="dimmed">No photos yet — be the first to share!</Text>
+                            <Text c="dimmed">
+                                {personFilter
+                                    ? "No photos of them here — try All Photos or another section."
+                                    : "No photos yet — be the first to share!"}
+                            </Text>
                         </Center>
                     ) : (
                         <RowsPhotoAlbum

--- a/src/types/faces.ts
+++ b/src/types/faces.ts
@@ -59,6 +59,16 @@ export interface ClustersResponse {
     };
 }
 
+// A searchable person in the public gallery: anyone (or the dog) with at
+// least one assigned face. The face is their highest-confidence detection,
+// CSS-cropped as a headshot in the search dropdown.
+export interface GalleryPerson {
+    invitee_id: number;
+    name: string;
+    photo_count: number;
+    face: FaceView;
+}
+
 export interface ClusterDetailResponse {
     cluster_id: string;
     invitee_id: number | null;


### PR DESCRIPTION
Adds a people search to the guest gallery: a searchable select above the category tabs where any guest can look up any labeled person — each option shows a face-crop headshot (the person's highest-confidence detection) with their name and photo count. The selected person **composes with the category tabs**, so "Aoife + The Ceremony" shows exactly her ceremony photos.

Supersedes the Maggie filter-tab approach in #190 (parked): once Maggie's dog detections are assigned to her, she appears in this search like everyone else — no special-case tab needed.

## API

- **`GET /api/gallery/people`** — same code gate as `/api/photos` (valid guest/master code or admin session, else 401). Returns everyone with at least one assigned, non-ignored face: `{invitee_id, name, photo_count, face}` where `face` is the highest-confidence detection with the crop data (`thumbnail_url`, dimensions, bounding box) the client needs to render a headshot. Guest-visible by design — guests searching for each other is the feature — but only ever behind a valid invitation code, and it exposes nothing beyond what the labeled photos already show.
- **`person=<id>` on `/api/photos`** — intersects the photo list with the person's face rows (via the sparse `byInvitee` GSI) *after* the category filter, so both narrow together. 400 on non-numeric ids; the faces table isn't touched when the param is absent.

## UI

Searchable, clearable Mantine Select (`renderOption` with the existing `FaceCrop` component at 36px + name + photo count). The person filter threads through initial fetch, pagination, and the infinite-scroll sentinel, and gets its own empty state ("No photos of them here — try All Photos or another section"). The select only renders once at least one person has been labeled, so the gallery is unchanged until labeling produces something to search.

## Testing

7 new tests: people route (401/admin-pass, highest-confidence face selection, distinct-photo counting, unassigned+ignored exclusion), photos route (person∩category composition, non-numeric 400, no-faces-query-without-param). Suite: 191 passed; `tsc --noEmit` + `eslint` clean.

## Note on #190

Parked as agreed. After this merges, #190 should be reworked to drop its gallery tab + `filter=maggie` API param and keep only the detection backfill, Lambda `DetectLabels` step, CDK IAM statement, and `MAGGIE_INVITEE` picker entry — I'll rebase it accordingly.