### PR TITLE
fix: group the assigned faces tab by person

### DIFF
--- a/src/app/dashboard/photos/faces/page.tsx
+++ b/src/app/dashboard/photos/faces/page.tsx
@@ -200,12 +200,12 @@ export default function FacesPage() {
         ignored,
     };
 
-    // Clear every cluster assigned to a person (sequential — each patch is
-    // an idempotent fan-out server-side, and person cluster counts are small).
+    // Clear every cluster assigned to a person — in parallel, since each
+    // patch is an independent, idempotent fan-out server-side.
     const clearPerson = async (group: AssignedGroup) => {
-        for (const clusterId of group.cluster_ids) {
-            await patchCluster(clusterId, { invitee_id: null });
-        }
+        await Promise.all(
+            group.cluster_ids.map((clusterId) => patchCluster(clusterId, { invitee_id: null }))
+        );
     };
 
     // Person-level detail: every face across all their clusters, via the
@@ -221,7 +221,9 @@ export default function FacesPage() {
             setDetail({
                 cluster_id: "",
                 invitee_id: group.invitee_id,
-                invitee_name: group.invitee_name,
+                // Fallback keeps the modal title person-specific even for a
+                // nameless invitee, matching the card badge.
+                invitee_name: group.invitee_name ?? `Guest #${group.invitee_id}`,
                 ignored: false,
                 faces: json.faces ?? [],
             });
@@ -250,7 +252,8 @@ export default function FacesPage() {
             </Group>
 
             <Text c="dimmed" size="sm">
-                {assigned} of {clusters.length - ignored} people identified · {ignored} ignored
+                {assignedGroups.length} people identified · {counts.unassigned} unassigned
+                face{counts.unassigned === 1 ? "" : "s"} · {ignored} ignored
                 {unclusteredFaces > 0 &&
                     ` · ${unclusteredFaces} faces not yet clustered (run the clustering script)`}
             </Text>

--- a/src/app/dashboard/photos/faces/page.tsx
+++ b/src/app/dashboard/photos/faces/page.tsx
@@ -160,10 +160,77 @@ export default function FacesPage() {
                 label: `${v.name} (${v.count} face${v.count === 1 ? "" : "s"})`,
             }));
     }, [clusters]);
+    // The clustering threshold errs toward splitting a person into several
+    // clusters, so the Assigned tab groups by person: one card each, with
+    // every underlying cluster's faces pooled.
+    interface AssignedGroup {
+        invitee_id: number;
+        invitee_name: string | null;
+        face_count: number;
+        cluster_ids: string[];
+        rep_face: ClusterSummary["rep_face"];
+    }
+    const assignedGroups = useMemo<AssignedGroup[]>(() => {
+        const byInvitee = new Map<number, AssignedGroup>();
+        for (const c of clusters) {
+            if (c.invitee_id == null || c.ignored) continue;
+            const group = byInvitee.get(c.invitee_id);
+            if (!group) {
+                byInvitee.set(c.invitee_id, {
+                    invitee_id: c.invitee_id,
+                    invitee_name: c.invitee_name,
+                    face_count: c.face_count,
+                    cluster_ids: [c.cluster_id],
+                    rep_face: c.rep_face,
+                });
+            } else {
+                group.face_count += c.face_count;
+                group.cluster_ids.push(c.cluster_id);
+                if (c.rep_face.confidence > group.rep_face.confidence) {
+                    group.rep_face = c.rep_face;
+                }
+            }
+        }
+        return [...byInvitee.values()].sort((a, b) => b.face_count - a.face_count);
+    }, [clusters]);
+
     const counts: Record<Exclude<FilterTab, "by-person">, number> = {
         unassigned: clusters.length - assigned - ignored,
-        assigned,
+        assigned: assignedGroups.length,
         ignored,
+    };
+
+    // Clear every cluster assigned to a person (sequential — each patch is
+    // an idempotent fan-out server-side, and person cluster counts are small).
+    const clearPerson = async (group: AssignedGroup) => {
+        for (const clusterId of group.cluster_ids) {
+            await patchCluster(clusterId, { invitee_id: null });
+        }
+    };
+
+    // Person-level detail: every face across all their clusters, via the
+    // by-invitee route, rendered in the same modal as cluster detail.
+    const openPersonDetail = async (group: AssignedGroup) => {
+        const requestId = ++detailRequestId.current;
+        setDetailLoading(true);
+        try {
+            const res = await fetch(`/api/dashboard/faces/by-invitee/${group.invitee_id}`);
+            if (!res.ok) throw new Error("Failed to load this person's faces");
+            const json = await res.json();
+            if (detailRequestId.current !== requestId) return;
+            setDetail({
+                cluster_id: "",
+                invitee_id: group.invitee_id,
+                invitee_name: group.invitee_name,
+                ignored: false,
+                faces: json.faces ?? [],
+            });
+        } catch (err) {
+            if (detailRequestId.current !== requestId) return;
+            setError(err instanceof Error ? err.message : "Failed to load this person's faces");
+        } finally {
+            if (detailRequestId.current === requestId) setDetailLoading(false);
+        }
     };
 
     const inviteeOptions = invitees.map((i) => ({
@@ -220,7 +287,7 @@ export default function FacesPage() {
                 <Center py="xl">
                     <Loader color="yellow" />
                 </Center>
-            ) : visible.length === 0 ? (
+            ) : (activeTab === "assigned" ? assignedGroups.length : visible.length) === 0 ? (
                 <Center py="xl">
                     <Text c="dimmed">
                         {activeTab === "unassigned" && clusters.length > 0
@@ -228,6 +295,41 @@ export default function FacesPage() {
                             : `No ${activeTab} faces`}
                     </Text>
                 </Center>
+            ) : activeTab === "assigned" ? (
+                <SimpleGrid cols={{ base: 2, sm: 3, md: 4, lg: 5 }} spacing="md">
+                    {assignedGroups.map((group) => (
+                        <Paper key={group.invitee_id} p="sm" withBorder>
+                            <Stack gap="xs" align="center">
+                                <UnstyledButton
+                                    onClick={() => openPersonDetail(group)}
+                                    title="See every face assigned to them"
+                                >
+                                    <FaceCrop
+                                        src={group.rep_face.thumbnail_url}
+                                        box={group.rep_face.bounding_box}
+                                        imgWidth={group.rep_face.thumbnail_width}
+                                        imgHeight={group.rep_face.thumbnail_height}
+                                        size={120}
+                                    />
+                                </UnstyledButton>
+                                <Badge variant="light" color="gray">
+                                    {group.face_count} photo{group.face_count === 1 ? "" : "s"}
+                                </Badge>
+                                <Badge color="green" variant="light">
+                                    {group.invitee_name ?? `Guest #${group.invitee_id}`}
+                                </Badge>
+                                <Button
+                                    variant="subtle"
+                                    color="gray"
+                                    size="compact-xs"
+                                    onClick={() => clearPerson(group)}
+                                >
+                                    Clear
+                                </Button>
+                            </Stack>
+                        </Paper>
+                    ))}
+                </SimpleGrid>
             ) : (
                 <SimpleGrid cols={{ base: 2, sm: 3, md: 4, lg: 5 }} spacing="md">
                     {visible.map((cluster) => (


### PR DESCRIPTION
The Assigned tab on `/dashboard/photos/faces` showed **one card per cluster**, and the threshold-98 clustering deliberately splits a person into several clusters rather than risk merging two people — so a well-photographed guest appeared as fifteen separate one-photo cards (see the Evan Tighe wall). This groups the tab by person.

## Changes

- **One card per person**, sorted by photo count descending: the face count is pooled across all their clusters, and the headshot is the highest-confidence rep face among them.
- **Clicking the face** opens the modal with *every* face assigned to that person (via the existing `by-invitee` route from #188), instead of one arbitrary cluster's slice.
- **Clear** releases all of the person's clusters back to Unassigned in one click (sequential PATCHes over the person's cluster ids — each is an idempotent fan-out server-side).
- The Assigned tab's semantics now match its display: progress and counts reflect **people**, not cluster fragments.

Unassigned and Ignored tabs are unchanged — cluster granularity is correct there, since each unassigned cluster genuinely needs its own "Who is this?" decision.

Client-side only: the grouping is a `useMemo` over the cluster list the page already fetches; no API changes.

## Testing

Suite: 184 passed; `tsc --noEmit` + `eslint` clean. (The page follows the repo's existing convention of no component tests for the dashboard pages.)