### PR TITLE
feat: re-match unassigned faces button on the dashboard

### DIFF
--- a/infra/lambdas/photo-processor/index.ts
+++ b/infra/lambdas/photo-processor/index.ts
@@ -7,6 +7,7 @@ import {
     GetCommand,
     PutCommand,
     QueryCommand,
+    ScanCommand,
     UpdateCommand,
 } from "@aws-sdk/lib-dynamodb";
 import {
@@ -47,8 +48,18 @@ const MAX_INPUT_PIXELS = 100_000_000;
 // exponential backoff before giving up.
 const MAX_UPDATE_ATTEMPTS = 5;
 
-export async function handler(event: S3Event): Promise<void> {
-    for (const record of event.Records) {
+// Direct-invoke payload from the dashboard's "Re-match unassigned" button
+// (the Next.js app has no Rekognition permissions, so it delegates here).
+interface RematchEvent {
+    action: "rematch_faces";
+}
+
+export async function handler(event: S3Event | RematchEvent): Promise<void> {
+    if ("action" in event && event.action === "rematch_faces") {
+        await rematchUnassignedFaces();
+        return;
+    }
+    for (const record of (event as S3Event).Records) {
         const key = decodeURIComponent(record.s3.object.key.replace(/\+/g, " "));
         try {
             await processPhoto(key, record.s3.bucket.name);
@@ -57,6 +68,111 @@ export async function handler(event: S3Event): Promise<void> {
             console.error(`Failed to process ${key}:`, err);
         }
     }
+}
+
+// Give every unassigned, unignored face another chance to be matched: as the
+// admin labels clusters, the collection fills with labeled anchors, so faces
+// that had no decisive match earlier may have one now. Only the still-
+// unlabeled rows are touched — assignments and ignores are never overwritten.
+async function rematchUnassignedFaces(): Promise<void> {
+    const faces: { face_id: string; invitee_id?: number; ignored?: boolean }[] = [];
+    let lastKey: Record<string, unknown> | undefined;
+    do {
+        const page = await docClient.send(
+            new ScanCommand({ TableName: FACES_TABLE, ExclusiveStartKey: lastKey })
+        );
+        faces.push(...((page.Items ?? []) as typeof faces));
+        lastKey = page.LastEvaluatedKey;
+    } while (lastKey);
+
+    const candidates = faces.filter(
+        (f) =>
+            f.invitee_id == null &&
+            !f.ignored &&
+            // Dog detections are DetectLabels output, not collection members —
+            // SearchFaces on their synthetic ids would fail.
+            !f.face_id.startsWith("dog-")
+    );
+    console.log(`Re-matching ${candidates.length} unassigned faces of ${faces.length} total`);
+
+    let assigned = 0;
+    let ignored = 0;
+    const CONCURRENCY = 3;
+    for (let i = 0; i < candidates.length; i += CONCURRENCY) {
+        await Promise.all(
+            candidates.slice(i, i + CONCURRENCY).map(async (face) => {
+                try {
+                    const match = await findLabeledMatch(face.face_id);
+                    if (!match) return;
+                    await docClient.send(
+                        new UpdateCommand({
+                            TableName: FACES_TABLE,
+                            Key: { face_id: face.face_id },
+                            UpdateExpression: match.ignored
+                                ? "SET cluster_id = :cluster, ignored = :ignored"
+                                : "SET cluster_id = :cluster, invitee_id = :invitee, invitation_id = :invitation",
+                            ExpressionAttributeValues: match.ignored
+                                ? { ":cluster": match.cluster_id, ":ignored": true }
+                                : {
+                                      ":cluster": match.cluster_id,
+                                      ":invitee": match.invitee_id,
+                                      ":invitation": match.invitation_id,
+                                  },
+                        })
+                    );
+                    if (match.ignored) ignored++;
+                    else assigned++;
+                } catch (err) {
+                    console.error(`Re-match failed for face ${face.face_id}:`, err);
+                }
+            })
+        );
+    }
+    console.log(`Re-match done: ${assigned} auto-assigned, ${ignored} auto-ignored`);
+}
+
+// Like findClusterForFace, but only decisive outcomes count: the best match
+// that is itself labeled (assigned to a person, or ignored). Matching another
+// unlabeled face wouldn't move the admin's queue forward.
+async function findLabeledMatch(faceId: string): Promise<{
+    cluster_id: string;
+    invitee_id?: number;
+    invitation_id?: number;
+    ignored?: boolean;
+} | null> {
+    const search = await rekognition.send(
+        new SearchFacesCommand({
+            CollectionId: COLLECTION_ID,
+            FaceId: faceId,
+            FaceMatchThreshold: FACE_MATCH_THRESHOLD,
+            MaxFaces: 10,
+        })
+    );
+    for (const match of search.FaceMatches ?? []) {
+        const matchedId = match.Face?.FaceId;
+        if (!matchedId) continue;
+        const row = await docClient.send(
+            new GetCommand({ TableName: FACES_TABLE, Key: { face_id: matchedId } })
+        );
+        const item = row.Item as
+            | {
+                  cluster_id?: string;
+                  invitee_id?: number;
+                  invitation_id?: number;
+                  ignored?: boolean;
+              }
+            | undefined;
+        if (!item?.cluster_id) continue;
+        if (item.invitee_id != null || item.ignored) {
+            return {
+                cluster_id: item.cluster_id,
+                invitee_id: item.invitee_id,
+                invitation_id: item.invitation_id,
+                ignored: item.ignored,
+            };
+        }
+    }
+    return null;
 }
 
 async function processPhoto(key: string, bucket: string): Promise<void> {

--- a/infra/lambdas/photo-processor/index.ts
+++ b/infra/lambdas/photo-processor/index.ts
@@ -79,7 +79,14 @@ async function rematchUnassignedFaces(): Promise<void> {
     let lastKey: Record<string, unknown> | undefined;
     do {
         const page = await docClient.send(
-            new ScanCommand({ TableName: FACES_TABLE, ExclusiveStartKey: lastKey })
+            new ScanCommand({
+                TableName: FACES_TABLE,
+                // Only the fields the filter needs — no point hauling
+                // bounding boxes for thousands of already-decided rows.
+                ProjectionExpression: "face_id, invitee_id, #ig",
+                ExpressionAttributeNames: { "#ig": "ignored" },
+                ExclusiveStartKey: lastKey,
+            })
         );
         faces.push(...((page.Items ?? []) as typeof faces));
         lastKey = page.LastEvaluatedKey;
@@ -131,15 +138,21 @@ async function rematchUnassignedFaces(): Promise<void> {
     console.log(`Re-match done: ${assigned} auto-assigned, ${ignored} auto-ignored`);
 }
 
-// Like findClusterForFace, but only decisive outcomes count: the best match
-// that is itself labeled (assigned to a person, or ignored). Matching another
-// unlabeled face wouldn't move the admin's queue forward.
-async function findLabeledMatch(faceId: string): Promise<{
+interface FaceAssignment {
     cluster_id: string;
     invitee_id?: number;
     invitation_id?: number;
     ignored?: boolean;
-} | null> {
+}
+
+// Search the collection for faces similar to the given one and return the
+// first match (in similarity order) whose faces-table row satisfies the
+// predicate. Shared by upload-time assignment and the re-match pass so their
+// search tuning can't drift apart.
+async function findMatchingRow(
+    faceId: string,
+    accept: (item: FaceAssignment) => boolean
+): Promise<FaceAssignment | null> {
     const search = await rekognition.send(
         new SearchFacesCommand({
             CollectionId: COLLECTION_ID,
@@ -154,25 +167,24 @@ async function findLabeledMatch(faceId: string): Promise<{
         const row = await docClient.send(
             new GetCommand({ TableName: FACES_TABLE, Key: { face_id: matchedId } })
         );
-        const item = row.Item as
-            | {
-                  cluster_id?: string;
-                  invitee_id?: number;
-                  invitation_id?: number;
-                  ignored?: boolean;
-              }
-            | undefined;
+        const item = row.Item as (Partial<FaceAssignment> & { cluster_id?: string }) | undefined;
         if (!item?.cluster_id) continue;
-        if (item.invitee_id != null || item.ignored) {
-            return {
-                cluster_id: item.cluster_id,
-                invitee_id: item.invitee_id,
-                invitation_id: item.invitation_id,
-                ignored: item.ignored,
-            };
-        }
+        const candidate: FaceAssignment = {
+            cluster_id: item.cluster_id,
+            invitee_id: item.invitee_id,
+            invitation_id: item.invitation_id,
+            ignored: item.ignored,
+        };
+        if (accept(candidate)) return candidate;
     }
     return null;
+}
+
+// Only decisive outcomes count for re-matching: the best match that is
+// itself labeled (assigned to a person, or ignored). Matching another
+// unlabeled face wouldn't move the admin's queue forward.
+function findLabeledMatch(faceId: string): Promise<FaceAssignment | null> {
+    return findMatchingRow(faceId, (item) => item.invitee_id != null || !!item.ignored);
 }
 
 async function processPhoto(key: string, bucket: string): Promise<void> {
@@ -301,48 +313,10 @@ async function indexAndAssignFaces(
     );
 }
 
-// Search the collection for faces similar to the given one and return the
-// cluster (and any invitee assignment) of the best already-clustered match.
-async function findClusterForFace(faceId: string): Promise<{
-    cluster_id: string;
-    invitee_id?: number;
-    invitation_id?: number;
-    ignored?: boolean;
-} | null> {
-    const search = await rekognition.send(
-        new SearchFacesCommand({
-            CollectionId: COLLECTION_ID,
-            FaceId: faceId,
-            FaceMatchThreshold: FACE_MATCH_THRESHOLD,
-            MaxFaces: 10,
-        })
-    );
-
-    // Matches arrive sorted by similarity; take the first with a cluster.
-    for (const match of search.FaceMatches ?? []) {
-        const matchedId = match.Face?.FaceId;
-        if (!matchedId) continue;
-        const row = await docClient.send(
-            new GetCommand({ TableName: FACES_TABLE, Key: { face_id: matchedId } })
-        );
-        const item = row.Item as
-            | {
-                  cluster_id?: string;
-                  invitee_id?: number;
-                  invitation_id?: number;
-                  ignored?: boolean;
-              }
-            | undefined;
-        if (item?.cluster_id) {
-            return {
-                cluster_id: item.cluster_id,
-                invitee_id: item.invitee_id,
-                invitation_id: item.invitation_id,
-                ignored: item.ignored,
-            };
-        }
-    }
-    return null;
+// Upload-time assignment: any already-clustered match will do — an unlabeled
+// cluster is still the right home for a new face of the same person.
+function findClusterForFace(faceId: string): Promise<FaceAssignment | null> {
+    return findMatchingRow(faceId, () => true);
 }
 
 // Look up the photo id via the byS3Key GSI and backfill the thumbnail fields.

--- a/infra/lib/wedding-stack.ts
+++ b/infra/lib/wedding-stack.ts
@@ -248,7 +248,10 @@ export class WeddingStack extends cdk.Stack {
       runtime: lambda.Runtime.NODEJS_22_X,
       architecture: lambda.Architecture.ARM_64,
       // 2 min covered thumbnailing; the re-match mode walks every unassigned
-      // face (SearchFaces each), which needs headroom at ~2k faces.
+      // face (SearchFaces each), which needs headroom at ~2k faces. The
+      // longer cap also applies to S3-triggered runs — accepted: a hung
+      // invocation holds a slot longer, but post-wedding upload volume is a
+      // trickle and the account's default concurrency dwarfs it.
       timeout: cdk.Duration.minutes(10),
       // 512 MB OOMed on large JPEGs during the professional photo import
       // (decoded pixel buffers dwarf the file size — an 11 MB JPEG was enough).

--- a/infra/lib/wedding-stack.ts
+++ b/infra/lib/wedding-stack.ts
@@ -188,8 +188,9 @@ export class WeddingStack extends cdk.Stack {
     // The Next.js SSR runtime authenticates as the pre-existing
     // `wedding-api-lambda` IAM user (Amplify bakes its keys into the bundle),
     // so grant it table access via an attached managed policy.
+    const apiUser = iam.User.fromUserName(this, 'ApiUser', 'wedding-api-lambda');
     new iam.ManagedPolicy(this, 'DynamoAccessPolicy', {
-      users: [iam.User.fromUserName(this, 'ApiUser', 'wedding-api-lambda')],
+      users: [apiUser],
       statements: [
         // The archive is the frozen wedding dataset — nothing in the app
         // writes to it, so keep the grant read-only.
@@ -240,9 +241,15 @@ export class WeddingStack extends cdk.Stack {
     const photoProcessor = new NodejsFunction(this, 'PhotoProcessor', {
       entry: path.join(__dirname, '../lambdas/photo-processor/index.ts'),
       handler: 'handler',
+      // Fixed name so the dashboard's re-match trigger can invoke it without
+      // env-var plumbing. NOTE: naming a previously auto-named function makes
+      // CloudFormation REPLACE it (brief harmless window during deploy).
+      functionName: 'wedding-photo-processor',
       runtime: lambda.Runtime.NODEJS_22_X,
       architecture: lambda.Architecture.ARM_64,
-      timeout: cdk.Duration.minutes(2),
+      // 2 min covered thumbnailing; the re-match mode walks every unassigned
+      // face (SearchFaces each), which needs headroom at ~2k faces.
+      timeout: cdk.Duration.minutes(10),
       // 512 MB OOMed on large JPEGs during the professional photo import
       // (decoded pixel buffers dwarf the file size — an 11 MB JPEG was enough).
       // Guest uploads go up to 20 MB, so give sharp real headroom.
@@ -276,6 +283,9 @@ export class WeddingStack extends cdk.Stack {
     photosBucket.grantReadWrite(photoProcessor);
     photosTable.grantReadWriteData(photoProcessor);
     facesTable.grantReadWriteData(photoProcessor);
+    // The dashboard's "Re-match unassigned" button async-invokes the Lambda —
+    // the app itself has no Rekognition permissions by design.
+    photoProcessor.grantInvoke(apiUser);
 
     // ── Cognito User Pool ─────────────────────────────────────────────────────
     const userPool = new cognito.UserPool(this, 'AdminUserPool', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@aws-sdk/client-cloudwatch-logs": "^3.1065.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.1058.0",
         "@aws-sdk/client-dynamodb": "^3.1083.0",
+        "@aws-sdk/client-lambda": "^3.1090.0",
         "@aws-sdk/client-s3": "^3.1058.0",
         "@aws-sdk/lib-dynamodb": "^3.1083.0",
         "@aws-sdk/s3-request-presigner": "^3.1058.0",
@@ -228,6 +229,25 @@
         "@smithy/fetch-http-handler": "^5.6.4",
         "@smithy/node-http-handler": "^4.9.4",
         "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda": {
+      "version": "3.1090.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1090.0.tgz",
+      "integrity": "sha512-Gu4bEgTr+f859KLdPkjINhzBCxwQctSmoJ3I5XlVdFGt565w6UCI5tw4sEbC+qltq1RMoORTTRjrbL5jExANaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-node": "^3.972.70",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@aws-sdk/client-cloudwatch-logs": "^3.1065.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.1058.0",
     "@aws-sdk/client-dynamodb": "^3.1083.0",
+    "@aws-sdk/client-lambda": "^3.1090.0",
     "@aws-sdk/client-s3": "^3.1058.0",
     "@aws-sdk/lib-dynamodb": "^3.1083.0",
     "@aws-sdk/s3-request-presigner": "^3.1058.0",

--- a/src/app/api/dashboard/faces/rematch/__tests__/route.test.ts
+++ b/src/app/api/dashboard/faces/rematch/__tests__/route.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockRequireAuth = vi.fn();
+const mockLambdaSend = vi.fn();
+
+vi.mock("@/utils/auth/requireAuth", () => ({
+    requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
+}));
+vi.mock("@aws-sdk/client-lambda", () => ({
+    LambdaClient: class {
+        send = (...args: unknown[]) => mockLambdaSend(...args);
+    },
+    InvokeCommand: class {
+        input: unknown;
+        constructor(input: unknown) {
+            this.input = input;
+        }
+    },
+}));
+
+import { POST } from "../route";
+
+const req = () =>
+    new NextRequest("http://localhost/api/dashboard/faces/rematch", { method: "POST" });
+
+describe("POST /api/dashboard/faces/rematch", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockRequireAuth.mockResolvedValue({ success: true, payload: {} });
+        mockLambdaSend.mockResolvedValue({});
+    });
+
+    it("requires auth", async () => {
+        mockRequireAuth.mockResolvedValue({
+            success: false,
+            response: new Response(null, { status: 401 }),
+        });
+        const res = await POST(req());
+        expect(res.status).toBe(401);
+        expect(mockLambdaSend).not.toHaveBeenCalled();
+    });
+
+    it("async-invokes the photo-processor with the rematch action", async () => {
+        const res = await POST(req());
+        expect(res.status).toBe(202);
+        expect(await res.json()).toEqual({ started: true });
+
+        const cmd = mockLambdaSend.mock.calls[0][0] as {
+            input: { FunctionName: string; InvocationType: string; Payload: string };
+        };
+        expect(cmd.input.FunctionName).toBe("wedding-photo-processor");
+        expect(cmd.input.InvocationType).toBe("Event");
+        expect(JSON.parse(cmd.input.Payload)).toEqual({ action: "rematch_faces" });
+    });
+
+    it("returns 500 when the invocation fails", async () => {
+        mockLambdaSend.mockRejectedValue(new Error("boom"));
+        const res = await POST(req());
+        expect(res.status).toBe(500);
+    });
+});

--- a/src/app/api/dashboard/faces/rematch/route.ts
+++ b/src/app/api/dashboard/faces/rematch/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { LambdaClient, InvokeCommand } from "@aws-sdk/client-lambda";
+import { requireAuth } from "@/utils/auth/requireAuth";
+
+// The app has no Rekognition permissions by design, so re-matching runs in
+// the photo-processor Lambda; this route just fires the async invocation.
+const endpoint = process.env["AWS_ENDPOINT_URL"];
+const lambdaClient = new LambdaClient({
+    region: process.env["AWS_REGION"] ?? "eu-west-1",
+    ...(endpoint && { endpoint }),
+    ...(process.env["LAMBDA_AWS_KEY_ID"] && process.env["LAMBDA_AWS_SECRET"] && {
+        credentials: {
+            accessKeyId: process.env["LAMBDA_AWS_KEY_ID"],
+            secretAccessKey: process.env["LAMBDA_AWS_SECRET"],
+        },
+    }),
+});
+
+// The CDK stack pins this name; env override exists for local setups.
+const PHOTO_PROCESSOR_FUNCTION =
+    process.env["PHOTO_PROCESSOR_FUNCTION"] || "wedding-photo-processor";
+
+// Fire-and-forget: give every unassigned, unignored face another SearchFaces
+// pass against the (now better-labeled) collection.
+export async function POST(request: NextRequest) {
+    const auth = await requireAuth(request);
+    if (!auth.success) return auth.response;
+
+    try {
+        await lambdaClient.send(
+            new InvokeCommand({
+                FunctionName: PHOTO_PROCESSOR_FUNCTION,
+                InvocationType: "Event",
+                Payload: JSON.stringify({ action: "rematch_faces" }),
+            })
+        );
+        return NextResponse.json({ started: true }, { status: 202 });
+    } catch (error) {
+        console.error("Error in POST /api/dashboard/faces/rematch:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/src/app/dashboard/photos/faces/page.tsx
+++ b/src/app/dashboard/photos/faces/page.tsx
@@ -141,13 +141,21 @@ export default function FacesPage() {
     // Fire the Lambda's re-match pass: every unassigned face gets another
     // SearchFaces look now that more of the collection is labeled. It runs in
     // the background — refresh the cluster list after a while to see results.
+    const rematchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    useEffect(() => {
+        // The refresh timer outlives fetches by design; don't let it fire
+        // into an unmounted page.
+        return () => {
+            if (rematchTimer.current) clearTimeout(rematchTimer.current);
+        };
+    }, []);
     const startRematch = async () => {
         setRematchState("starting");
         try {
             const res = await fetch("/api/dashboard/faces/rematch", { method: "POST" });
             if (!res.ok) throw new Error("Failed to start re-matching");
             setRematchState("running");
-            setTimeout(() => {
+            rematchTimer.current = setTimeout(() => {
                 fetchClusters();
                 setRematchState("idle");
             }, 30000);

--- a/src/app/dashboard/photos/faces/page.tsx
+++ b/src/app/dashboard/photos/faces/page.tsx
@@ -49,6 +49,7 @@ export default function FacesPage() {
     const [error, setError] = useState<string | null>(null);
     const [detail, setDetail] = useState<ClusterDetailResponse | null>(null);
     const [detailLoading, setDetailLoading] = useState(false);
+    const [rematchState, setRematchState] = useState<"idle" | "starting" | "running">("idle");
     // Monotonic id per detail fetch: closing the modal (or opening another
     // cluster) bumps it, so a stale response can neither reopen a dismissed
     // modal nor overwrite a newer cluster's data.
@@ -137,6 +138,25 @@ export default function FacesPage() {
         setDetailLoading(false);
     };
 
+    // Fire the Lambda's re-match pass: every unassigned face gets another
+    // SearchFaces look now that more of the collection is labeled. It runs in
+    // the background — refresh the cluster list after a while to see results.
+    const startRematch = async () => {
+        setRematchState("starting");
+        try {
+            const res = await fetch("/api/dashboard/faces/rematch", { method: "POST" });
+            if (!res.ok) throw new Error("Failed to start re-matching");
+            setRematchState("running");
+            setTimeout(() => {
+                fetchClusters();
+                setRematchState("idle");
+            }, 30000);
+        } catch (err) {
+            setRematchState("idle");
+            setError(err instanceof Error ? err.message : "Failed to start re-matching");
+        }
+    };
+
     const assigned = clusters.filter((c) => c.invitee_id != null).length;
     const ignored = clusters.filter((c) => c.ignored).length;
     const visible = clusters.filter((c) => clusterTab(c) === activeTab);
@@ -177,10 +197,32 @@ export default function FacesPage() {
                 <Title order={2} style={{ fontWeight: 300, color: "#495057", fontFamily: "serif" }}>
                     Faces
                 </Title>
-                <Anchor component={Link} href="/dashboard/photos" size="sm" c="dimmed">
-                    ← Photo moderation
-                </Anchor>
+                <Group gap="md">
+                    <Tooltip label="Try to auto-assign every unassigned face using the people you've already labeled">
+                        <Button
+                            variant="light"
+                            color="yellow"
+                            size="xs"
+                            loading={rematchState === "starting"}
+                            disabled={rematchState === "running"}
+                            onClick={startRematch}
+                        >
+                            {rematchState === "running" ? "Re-matching…" : "Re-match unassigned"}
+                        </Button>
+                    </Tooltip>
+                    <Anchor component={Link} href="/dashboard/photos" size="sm" c="dimmed">
+                        ← Photo moderation
+                    </Anchor>
+                </Group>
             </Group>
+
+            {rematchState === "running" && (
+                <Alert color="yellow" variant="light">
+                    Re-matching runs in the background — this page will refresh itself in about
+                    half a minute. Faces that now match a labeled person move to Assigned
+                    automatically.
+                </Alert>
+            )}
 
             <Text c="dimmed" size="sm">
                 {assigned} of {clusters.length - ignored} people identified · {ignored} ignored


### PR DESCRIPTION
Adds a **"Re-match unassigned"** button to the Faces page header. The workflow it serves: after you label the big clusters, the Rekognition collection is full of labeled anchor faces that didn't exist when clustering first ran — so many of the leftover unassigned fragments can now be matched automatically instead of hand-assigned card by card.

## What the button does

Fires a background pass over **every unassigned, unignored face**: each gets a fresh `SearchFaces` against the collection, and if its best match above the threshold is itself labeled, the face adopts that match's cluster and person (or its ignored flag — matching an ignored non-guest propagates the ignore). Decisive outcomes only: matching another *unlabeled* face changes nothing, and already-assigned or ignored rows are never touched. Dog detection rows are skipped (they're `DetectLabels` output, not collection members). Faces that now match a labeled person move straight to the Assigned tab.

## How it's wired

The Next.js app deliberately has zero Rekognition permissions, so the button doesn't do the work itself:

- **photo-processor Lambda** gains a direct-invoke mode (`{action: "rematch_faces"}`) alongside its S3-event path — it already holds the Rekognition + faces-table permissions.
- **`POST /api/dashboard/faces/rematch`** (`requireAuth`) async-invokes it (`InvocationType: Event`) and returns 202 immediately.
- **CDK**: the function gets the fixed name `wedding-photo-processor` so the route can invoke it without env plumbing (**note: CloudFormation replaces the function on deploy** — a brief, harmless window since it's stateless); timeout 2→10 min for the full-scan pass; `lambda:InvokeFunction` granted to `wedding-api-lambda` scoped to this function.
- **UI**: header button with tooltip, an in-progress alert, and an automatic cluster-list refresh ~30s after firing. Idempotent — clicking again after completion just finds fewer candidates.

Cost per click: one `SearchFaces` per unassigned face (~$0.001 each), so under $1 even on the first, largest run.

## Testing

3 new route tests (auth gate, invoke payload/function/async type, failure 500). Suite: 195 passed; `tsc --noEmit` + `eslint` clean; infra tsc unchanged from baseline. End-to-end behavior verified after deploy via CloudWatch logs (`Re-match done: N auto-assigned, M auto-ignored`).

## Deploy

Needs `cdk deploy` after merge (function rename + timeout + invoke grant). Merge-order note: #190 and #192 touch neighbouring code (Lambda file / faces page) — whichever merges last may need a trivial rebase, which I'll handle.