### PR TITLE
feat: attribute guest uploads to their household in the lightbox

### DIFF
--- a/src/app/api/gallery/my-photos/__tests__/route.test.ts
+++ b/src/app/api/gallery/my-photos/__tests__/route.test.ts
@@ -13,10 +13,12 @@ const mockListCategories = vi.fn();
 vi.mock("@/utils/auth/requireAuth", () => ({
     requireAuth: (...args: unknown[]) => mockRequireAuth(...args),
 }));
+const mockListUploaderNames = vi.fn();
 vi.mock("@/utils/db/archive", () => ({
     isMasterCode: (...args: unknown[]) => mockIsMasterCode(...args),
     getInvitationIdByCode: (...args: unknown[]) => mockGetInvitationIdByCode(...args),
     getInviteesWithIds: (...args: unknown[]) => mockGetInviteesWithIds(...args),
+    listUploaderNames: (...args: unknown[]) => mockListUploaderNames(...args),
     COUPLE_INVITEES: [
         { id: -1, invitation_id: -1, name: "Matthew O'Neill", code: null },
         { id: -2, invitation_id: -1, name: "Rebecca O'Neill", code: null },
@@ -69,6 +71,7 @@ describe("GET /api/gallery/my-photos", () => {
             { id: 8, first_name: "Brian" },
         ]);
         mockListCategories.mockResolvedValue([]);
+        mockListUploaderNames.mockResolvedValue(new Map([["ABC123", "Aoife & Brian"]]));
     });
 
     it("rejects requests without a code", async () => {
@@ -118,7 +121,7 @@ describe("GET /api/gallery/my-photos", () => {
         expect(body.total).toBe(1);
     });
 
-    it("only exposes PublicPhoto fields", async () => {
+    it("only exposes PublicPhoto fields, including household attribution", async () => {
         mockGetFacesByInvitees.mockResolvedValue([
             { face_id: "f1", photo_id: "p1", invitee_id: 7 },
         ]);
@@ -130,6 +133,7 @@ describe("GET /api/gallery/my-photos", () => {
         expect(keys).not.toContain("invitation_code");
         expect(keys).not.toContain("approved_by");
         expect(body.photos[0].thumbnail_url).toBe("https://cdn/uploads/thumbnail/x/p1.jpg");
+        expect(body.photos[0].uploaded_by).toBe("Aoife & Brian");
     });
 
     it("master code searches the couple's synthetic ids without touching the archive", async () => {

--- a/src/app/api/gallery/my-photos/route.ts
+++ b/src/app/api/gallery/my-photos/route.ts
@@ -3,6 +3,7 @@ import {
     isMasterCode,
     getInvitationIdByCode,
     getInviteesWithIds,
+    listUploaderNames,
     COUPLE_INVITEES,
 } from "@/utils/db/archive";
 import { getFacesByInvitees } from "@/utils/db/faces";
@@ -67,7 +68,13 @@ export async function GET(request: NextRequest) {
                 (b.taken_at ?? b.uploaded_at).localeCompare(a.taken_at ?? a.uploaded_at)
             );
 
-        const photos: PublicPhoto[] = approved.slice(offset, offset + limit).map((p) => ({
+        const rows = approved.slice(offset, offset + limit);
+        // Attribution for guest uploads; professional imports carry no code.
+        const uploaders = rows.some((p) => p.invitation_code)
+            ? await listUploaderNames()
+            : new Map<string, string>();
+
+        const photos: PublicPhoto[] = rows.map((p) => ({
             id: p.id,
             thumbnail_url: p.thumbnail_key ? cdnUrl(p.thumbnail_key) : null,
             width: p.width,
@@ -77,6 +84,9 @@ export async function GET(request: NextRequest) {
             category_id: p.category_id,
             category_slug: p.category_id ? (slugById.get(p.category_id) ?? null) : null,
             uploaded_at: p.uploaded_at,
+            uploaded_by: p.invitation_code
+                ? (uploaders.get(p.invitation_code) ?? null)
+                : null,
         }));
 
         return NextResponse.json({

--- a/src/app/api/photos/__tests__/route.test.ts
+++ b/src/app/api/photos/__tests__/route.test.ts
@@ -11,8 +11,10 @@ vi.mock("@/utils/db/photos", () => ({
     listPhotosByStatus: (...args: unknown[]) => mockListPhotosByStatus(...args),
 }));
 
+const mockListUploaderNames = vi.fn();
 vi.mock("@/utils/db/archive", () => ({
     isValidInvitationCode: (...args: unknown[]) => mockIsValidInvitationCode(...args),
+    listUploaderNames: (...args: unknown[]) => mockListUploaderNames(...args),
 }));
 
 const mockGetFacesByInvitees = vi.fn();
@@ -69,6 +71,7 @@ describe("GET /api/photos", () => {
         // Default to an unauthenticated (public) caller with a valid code —
         // the gallery is code-access only.
         mockIsValidInvitationCode.mockResolvedValue(true);
+        mockListUploaderNames.mockResolvedValue(new Map([["ABC123", "Aoife & Brian"]]));
         mockRequireAuth.mockResolvedValue({
             success: false,
             response: new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }),
@@ -150,6 +153,33 @@ describe("GET /api/photos", () => {
         const req = new NextRequest("http://localhost/api/photos?code=ABC123");
         await GET(req);
         expect(mockGetFacesByInvitees).not.toHaveBeenCalled();
+    });
+
+    it("attributes guest uploads to their household by name", async () => {
+        mockListPhotosByStatus.mockResolvedValue([
+            { ...mockPhoto, id: "guest-upload", invitation_code: "ABC123" },
+            { ...mockPhoto, id: "professional", invitation_code: undefined },
+        ]);
+        const req = new NextRequest("http://localhost/api/photos?code=ABC123");
+        const data = await (await GET(req)).json();
+
+        const byId = Object.fromEntries(
+            data.photos.map((p: { id: string; uploaded_by: string | null }) => [
+                p.id,
+                p.uploaded_by,
+            ])
+        );
+        expect(byId["guest-upload"]).toBe("Aoife & Brian");
+        expect(byId["professional"]).toBeNull();
+    });
+
+    it("skips the archive scan when the page has no guest uploads", async () => {
+        mockListPhotosByStatus.mockResolvedValue([
+            { ...mockPhoto, invitation_code: undefined },
+        ]);
+        const req = new NextRequest("http://localhost/api/photos?code=ABC123");
+        await GET(req);
+        expect(mockListUploaderNames).not.toHaveBeenCalled();
     });
 
     it("does not expose sensitive fields to public callers", async () => {

--- a/src/app/api/photos/route.ts
+++ b/src/app/api/photos/route.ts
@@ -82,6 +82,9 @@ export async function GET(request: NextRequest) {
         // Attribution for guest uploads (rows carrying an invitation code) —
         // professional imports have no code and stay unattributed. Only hit
         // the archive when this page actually contains guest uploads.
+        // Deliberately NOT gated on isAdmin: the couple browse the gallery
+        // logged in, and its lightbox reads uploaded_by from the admin rows —
+        // skipping the (tiny) scan would strip their captions.
         const uploaders = rows.some((p) => p.invitation_code)
             ? await listUploaderNames()
             : new Map<string, string>();

--- a/src/app/api/photos/route.ts
+++ b/src/app/api/photos/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { listPhotosByStatus } from "@/utils/db/photos";
 import { listCategories } from "@/utils/db/categories";
-import { isValidInvitationCode } from "@/utils/db/archive";
+import { isValidInvitationCode, listUploaderNames } from "@/utils/db/archive";
 import { getFacesByInvitees } from "@/utils/db/faces";
 import { requireAuth } from "@/utils/auth/requireAuth";
 import { cdnUrl } from "@/utils/storage";
@@ -79,10 +79,20 @@ export async function GET(request: NextRequest) {
         const total = matching.length;
         const rows = matching.slice(offset, offset + limit);
 
+        // Attribution for guest uploads (rows carrying an invitation code) —
+        // professional imports have no code and stay unattributed. Only hit
+        // the archive when this page actually contains guest uploads.
+        const uploaders = rows.some((p) => p.invitation_code)
+            ? await listUploaderNames()
+            : new Map<string, string>();
+
         const photos = rows.map((p) => {
             const thumbnail_url = p.thumbnail_key ? cdnUrl(p.thumbnail_key) : null;
+            const uploaded_by = p.invitation_code
+                ? (uploaders.get(p.invitation_code) ?? null)
+                : null;
             if (isAdmin) {
-                return { ...p, thumbnail_url };
+                return { ...p, thumbnail_url, uploaded_by };
             }
             // Public allowlist — never expose invitation_code, s3_key,
             // approved_by, or other internal fields to gallery visitors.
@@ -96,6 +106,7 @@ export async function GET(request: NextRequest) {
                 category_id: p.category_id,
                 category_slug: p.category_slug,
                 uploaded_at: p.uploaded_at,
+                uploaded_by,
             };
             return publicPhoto;
         });

--- a/src/app/gallery/my-photos/page.tsx
+++ b/src/app/gallery/my-photos/page.tsx
@@ -21,7 +21,9 @@ import { RowsPhotoAlbum } from "react-photo-album";
 import "react-photo-album/rows.css";
 import Lightbox from "yet-another-react-lightbox";
 import Download from "yet-another-react-lightbox/plugins/download";
+import Captions from "yet-another-react-lightbox/plugins/captions";
 import "yet-another-react-lightbox/styles.css";
+import "yet-another-react-lightbox/plugins/captions.css";
 import type { PublicPhoto } from "@/types/photos";
 import Link from "next/link";
 
@@ -32,6 +34,7 @@ interface GalleryPhoto {
     alt: string;
     id: string;
     key: string;
+    uploadedBy: string | null;
 }
 
 const FALLBACK_ASPECT = { width: 4, height: 3 };
@@ -124,6 +127,7 @@ export default function MyPhotosPage() {
                     alt: p.file_name,
                     id: p.id,
                     key: p.id,
+                    uploadedBy: p.uploaded_by ?? null,
                 }))
             );
             setLoaded(true);
@@ -144,6 +148,8 @@ export default function MyPhotosPage() {
         width: p.width,
         height: p.height,
         alt: p.alt,
+        // Attribution caption for guest uploads; professional photos have none.
+        ...(p.uploadedBy && { description: `Shared by ${p.uploadedBy}` }),
         download: {
             url: `/api/photos/${p.id}/download-url?code=${invitationCode}`,
             filename: p.alt,
@@ -240,7 +246,7 @@ export default function MyPhotosPage() {
                 slides={lightboxSlides}
                 index={lightboxIndex}
                 on={{ view: ({ index }) => setLightboxIndex(index) }}
-                plugins={invitationCode ? [Download] : []}
+                plugins={invitationCode ? [Captions, Download] : [Captions]}
                 render={{
                     iconDownload: () => <IconDownload size={32} />,
                 }}

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -26,7 +26,9 @@ import { RowsPhotoAlbum } from "react-photo-album";
 import "react-photo-album/rows.css";
 import Lightbox from "yet-another-react-lightbox";
 import Download from "yet-another-react-lightbox/plugins/download";
+import Captions from "yet-another-react-lightbox/plugins/captions";
 import "yet-another-react-lightbox/styles.css";
+import "yet-another-react-lightbox/plugins/captions.css";
 import type { PublicPhoto, PhotoCategory } from "@/types/photos";
 import Link from "next/link";
 
@@ -37,6 +39,7 @@ interface GalleryPhoto {
     alt: string;
     id: string;
     key: string;
+    uploadedBy: string | null;
 }
 
 const FALLBACK_ASPECT = { width: 4, height: 3 };
@@ -195,6 +198,7 @@ function Gallery() {
                     alt: p.file_name,
                     id: p.id,
                     key: p.id,
+                    uploadedBy: p.uploaded_by ?? null,
                 }));
                 setPhotos((prev) => (pg === 1 ? mapped : [...prev, ...mapped]));
                 setHasMore(mapped.length === LIMIT);
@@ -259,6 +263,8 @@ function Gallery() {
         width: p.width,
         height: p.height,
         alt: p.alt,
+        // Attribution caption for guest uploads; professional photos have none.
+        ...(p.uploadedBy && { description: `Shared by ${p.uploadedBy}` }),
         download: {
             url: `/api/photos/${p.id}/download-url?code=${invitationCode}`,
             filename: p.alt,
@@ -428,7 +434,7 @@ function Gallery() {
                 slides={lightboxSlides}
                 index={lightboxIndex}
                 on={{ view: ({ index }) => setLightboxIndex(index) }}
-                plugins={invitationCode ? [Download] : []}
+                plugins={invitationCode ? [Captions, Download] : [Captions]}
                 render={{
                     iconDownload: () => <IconDownload size={32} />,
                 }}

--- a/src/types/photos.ts
+++ b/src/types/photos.ts
@@ -26,6 +26,9 @@ export interface PublicPhoto {
     category_id: string | null;
     category_slug: string | null;
     uploaded_at: string;
+    // Household display names for guest uploads ("Aoife & Brian"); null for
+    // professionally imported photos. The code itself is never exposed.
+    uploaded_by: string | null;
 }
 
 export interface PhotoCategory {

--- a/src/utils/db/__tests__/archive.test.ts
+++ b/src/utils/db/__tests__/archive.test.ts
@@ -12,6 +12,7 @@ import {
     isValidInvitationCode,
     getInviteesByCode,
     listAllInvitees,
+    listUploaderNames,
 } from "../archive";
 
 const savedMaster = process.env.MASTER_INVITATION_CODE;
@@ -53,6 +54,48 @@ describe("master invitation code", () => {
     it("returns the couple's names for the master code", async () => {
         expect(await getInviteesByCode("LOCAL1")).toEqual(["Matthew", "Rebecca"]);
         expect(mockSend).not.toHaveBeenCalled();
+    });
+});
+
+describe("listUploaderNames", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        process.env.MASTER_INVITATION_CODE = "LOCAL1";
+    });
+    afterEach(() => {
+        if (savedMaster === undefined) delete process.env.MASTER_INVITATION_CODE;
+        else process.env.MASTER_INVITATION_CODE = savedMaster;
+    });
+
+    it("maps codes to household first names, never exposing the code in values", async () => {
+        mockSend.mockResolvedValue({
+            Items: [
+                { entity: "code", code: "ABC123", invitation_id: 3 },
+                { entity: "code", code: "SOLO01", invitation_id: 4 },
+                { entity: "code", code: "EMPTY0", invitation_id: 5 }, // no invitees
+                { entity: "invitee", id: 7, invitation_id: 3, first_name: "Brian", last_name: "Byrne" },
+                { entity: "invitee", id: 8, invitation_id: 3, first_name: "Aoife", last_name: "Byrne" },
+                { entity: "invitee", id: 9, invitation_id: 4, first_name: "Cara", last_name: "Kelly" },
+            ],
+        });
+
+        const uploaders = await listUploaderNames();
+
+        expect(uploaders.get("ABC123")).toBe("Aoife & Brian");
+        expect(uploaders.get("SOLO01")).toBe("Cara");
+        expect(uploaders.has("EMPTY0")).toBe(false);
+        expect(uploaders.get("LOCAL1")).toBe("Matthew & Rebecca");
+        // Display values are names only — a code appearing in a value would
+        // leak the site's access credential into public payloads.
+        for (const name of uploaders.values()) {
+            expect(name).not.toMatch(/^[A-Z0-9]{6}$/);
+        }
+    });
+
+    it("omits the master entry when the env var is unset", async () => {
+        delete process.env.MASTER_INVITATION_CODE;
+        mockSend.mockResolvedValue({ Items: [] });
+        expect((await listUploaderNames()).size).toBe(0);
     });
 });
 

--- a/src/utils/db/archive.ts
+++ b/src/utils/db/archive.ts
@@ -204,6 +204,43 @@ export const MAGGIE_INVITEE: InviteeSummary = {
     code: null,
 };
 
+// "Aoife" / "Aoife & Brian" / "Aoife, Brian & Cara"
+function joinFirstNames(names: string[]): string {
+    if (names.length <= 1) return names[0] ?? "";
+    return `${names.slice(0, -1).join(", ")} & ${names[names.length - 1]}`;
+}
+
+// Upload attribution: display names for the household behind each invitation
+// code ("Aoife & Brian"), plus the master code mapped to the couple. Guest
+// uploads carry their code on the photo row; photos without a code (the
+// professional imports) simply aren't in this map. One archive scan.
+export async function listUploaderNames(): Promise<Map<string, string>> {
+    const items = await scanArchive();
+
+    const firstNamesByInvitation = new Map<number, string[]>();
+    for (const item of items) {
+        if (item.entity !== "invitee") continue;
+        const names = firstNamesByInvitation.get(item.invitation_id) ?? [];
+        names.push(item.first_name);
+        firstNamesByInvitation.set(item.invitation_id, names);
+    }
+
+    const uploaders = new Map<string, string>();
+    for (const item of items) {
+        if (item.entity !== "code") continue;
+        const names = (firstNamesByInvitation.get(item.invitation_id) ?? []).sort((a, b) =>
+            a.localeCompare(b)
+        );
+        if (names.length > 0) uploaders.set(item.code, joinFirstNames(names));
+    }
+
+    const master = process.env.MASTER_INVITATION_CODE;
+    if (master) {
+        uploaders.set(master, joinFirstNames(COUPLE_INVITEES.map((c) => c.name.split(" ")[0])));
+    }
+    return uploaders;
+}
+
 // Every assignable person for the face-cluster picker: archived invitees
 // with their invitation's code, plus the couple. Alphabetical by full name.
 export async function listAllInvitees(): Promise<InviteeSummary[]> {


### PR DESCRIPTION
Guest-uploaded photos now show who shared them: opening one in the lightbox (gallery or Find My Photos) displays a **"Shared by Aoife & Brian"** caption at the bottom via the lightbox's Captions plugin. Professionally imported photos have no uploader and show nothing — no caption bar at all.

## Security: the invitation code is never displayed

The code is the site's access credential, so attribution is strictly name-based:

- Photos store the uploading *code*; the API resolves it to the household's **first names server-side** (`listUploaderNames()`, one archive scan) and exposes only `uploaded_by: "Aoife & Brian"` on `PublicPhoto`. The public allowlist still excludes `invitation_code`, as asserted by the existing tests.
- A new unit test additionally guards that no attribution value is ever code-shaped — belt and braces against a future regression wiring the map wrong.
- The master code maps to "Matthew & Rebecca" (names derived from `COUPLE_INVITEES`, the single source of truth).

## Notes

- Since codes are per-invitation, attribution is the household ("Shared by Aoife & Brian") rather than the individual — the system genuinely can't know which of them pressed upload.
- Both `/api/photos` and `/api/gallery/my-photos` enrich their responses, but only run the archive scan when the returned page actually contains guest uploads — a page of purely professional photos costs nothing extra.
- Admin moderation views are unchanged (admins already see full rows).

## Testing

5 new/updated tests: guest-upload attribution + professional-null on `/api/photos`, archive-scan skipped when no guest uploads in page, attribution present in the my-photos allowlist test, `listUploaderNames` formatting/master-code/no-code-shaped-values/empty-env cases. Suite: 196 passed; `tsc --noEmit` + `eslint` clean.