### PR TITLE
fix: re-matching honors admin face rejections

### DIFF
--- a/infra/lambdas/photo-processor/index.ts
+++ b/infra/lambdas/photo-processor/index.ts
@@ -120,20 +120,27 @@ async function rematchUnassignedFaces(): Promise<void> {
                         face.rejected_invitee_ids ?? []
                     );
                     if (!match) return;
+                    // assigned_by/assigned_at make each re-match round
+                    // enumerable after the fact — an automated round must
+                    // always be precisely undoable (learned the hard way).
                     await docClient.send(
                         new UpdateCommand({
                             TableName: FACES_TABLE,
                             Key: { face_id: face.face_id },
                             UpdateExpression: match.ignored
-                                ? "SET cluster_id = :cluster, ignored = :ignored"
-                                : "SET cluster_id = :cluster, invitee_id = :invitee, invitation_id = :invitation",
-                            ExpressionAttributeValues: match.ignored
-                                ? { ":cluster": match.cluster_id, ":ignored": true }
-                                : {
-                                      ":cluster": match.cluster_id,
-                                      ":invitee": match.invitee_id,
-                                      ":invitation": match.invitation_id,
-                                  },
+                                ? "SET cluster_id = :cluster, ignored = :ignored, assigned_by = :by, assigned_at = :at"
+                                : "SET cluster_id = :cluster, invitee_id = :invitee, invitation_id = :invitation, assigned_by = :by, assigned_at = :at",
+                            ExpressionAttributeValues: {
+                                ":cluster": match.cluster_id,
+                                ":by": "rematch",
+                                ":at": new Date().toISOString(),
+                                ...(match.ignored
+                                    ? { ":ignored": true }
+                                    : {
+                                          ":invitee": match.invitee_id,
+                                          ":invitation": match.invitation_id,
+                                      }),
+                            },
                         })
                     );
                     if (match.ignored) ignored++;

--- a/infra/lambdas/photo-processor/index.ts
+++ b/infra/lambdas/photo-processor/index.ts
@@ -76,7 +76,12 @@ export async function handler(event: S3Event | RematchEvent): Promise<void> {
 // that had no decisive match earlier may have one now. Only the still-
 // unlabeled rows are touched — assignments and ignores are never overwritten.
 async function rematchUnassignedFaces(): Promise<void> {
-    const faces: { face_id: string; invitee_id?: number; ignored?: boolean }[] = [];
+    const faces: {
+        face_id: string;
+        invitee_id?: number;
+        ignored?: boolean;
+        rejected_invitee_ids?: number[];
+    }[] = [];
     let lastKey: Record<string, unknown> | undefined;
     do {
         const page = await docClient.send(
@@ -84,7 +89,7 @@ async function rematchUnassignedFaces(): Promise<void> {
                 TableName: FACES_TABLE,
                 // Only the fields the filter needs — no point hauling
                 // bounding boxes for thousands of already-decided rows.
-                ProjectionExpression: "face_id, invitee_id, #ig",
+                ProjectionExpression: "face_id, invitee_id, #ig, rejected_invitee_ids",
                 ExpressionAttributeNames: { "#ig": "ignored" },
                 ExclusiveStartKey: lastKey,
             })
@@ -110,7 +115,10 @@ async function rematchUnassignedFaces(): Promise<void> {
         await Promise.all(
             candidates.slice(i, i + CONCURRENCY).map(async (face) => {
                 try {
-                    const match = await findLabeledMatch(face.face_id);
+                    const match = await findLabeledMatch(
+                        face.face_id,
+                        face.rejected_invitee_ids ?? []
+                    );
                     if (!match) return;
                     await docClient.send(
                         new UpdateCommand({
@@ -183,9 +191,19 @@ async function findMatchingRow(
 
 // Only decisive outcomes count for re-matching: the best match that is
 // itself labeled (assigned to a person, or ignored). Matching another
-// unlabeled face wouldn't move the admin's queue forward.
-function findLabeledMatch(faceId: string): Promise<FaceAssignment | null> {
-    return findMatchingRow(faceId, (item) => item.invitee_id != null || !!item.ignored);
+// unlabeled face wouldn't move the admin's queue forward — and a match to
+// anyone the admin explicitly rejected this face from is skipped entirely,
+// so re-matching never undoes a human "that's not them" correction.
+function findLabeledMatch(
+    faceId: string,
+    rejectedInviteeIds: number[]
+): Promise<FaceAssignment | null> {
+    return findMatchingRow(
+        faceId,
+        (item) =>
+            (item.invitee_id != null && !rejectedInviteeIds.includes(item.invitee_id)) ||
+            (item.invitee_id == null && !!item.ignored)
+    );
 }
 
 async function processPhoto(key: string, bucket: string): Promise<void> {

--- a/infra/lib/wedding-stack.ts
+++ b/infra/lib/wedding-stack.ts
@@ -163,6 +163,9 @@ export class WeddingStack extends cdk.Stack {
       tableName: 'wedding-photo-faces',
       partitionKey: { name: 'face_id', type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      // The table holds weeks of manual labeling work — recoverable if an
+      // automated pass (or an admin slip) ever mangles it.
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
       removalPolicy: cdk.RemovalPolicy.RETAIN,
     });
     // photo-processor idempotency ("is this photo already indexed?") and cleanup.

--- a/src/types/faces.ts
+++ b/src/types/faces.ts
@@ -16,6 +16,10 @@ export interface PhotoFace {
     invitee_id?: number;
     invitation_id?: number;
     ignored?: boolean;
+    // People an admin has explicitly said this face is NOT (via the By
+    // Person reject button). Automated re-matching must never re-attach the
+    // face to anyone on this list.
+    rejected_invitee_ids?: number[];
     bounding_box: FaceBoundingBox;
     confidence: number;
     indexed_at: string;

--- a/src/types/faces.ts
+++ b/src/types/faces.ts
@@ -20,6 +20,11 @@ export interface PhotoFace {
     // Person reject button). Automated re-matching must never re-attach the
     // face to anyone on this list.
     rejected_invitee_ids?: number[];
+    // Provenance of the current assignment: set to "rematch" (with a
+    // timestamp) by automated re-match rounds so any round can be enumerated
+    // and undone; absent for human assignments.
+    assigned_by?: "rematch";
+    assigned_at?: string;
     bounding_box: FaceBoundingBox;
     confidence: number;
     indexed_at: string;

--- a/src/utils/db/__tests__/faces.test.ts
+++ b/src/utils/db/__tests__/faces.test.ts
@@ -99,24 +99,36 @@ describe("updateClusterAssignment", () => {
 describe("detachFace", () => {
     beforeEach(() => vi.clearAllMocks());
 
-    it("moves the face to a fresh cluster and strips assignment fields", async () => {
-        mockSend.mockResolvedValue({});
+    it("records the rejected person and strips assignment fields", async () => {
+        mockSend
+            .mockResolvedValueOnce({ Item: { invitee_id: 7 } }) // current row
+            .mockResolvedValueOnce({}); // update
 
         expect(await detachFace("f1")).toBe(true);
-        const update = sentCommand(0);
+        const update = sentCommand(1);
         expect(update.Key).toEqual({ face_id: "f1" });
         expect(update.UpdateExpression).toBe(
-            "SET cluster_id = :fresh REMOVE invitee_id, invitation_id, ignored"
+            "SET cluster_id = :fresh, rejected_invitee_ids = list_append(if_not_exists(rejected_invitee_ids, :empty), :rejected) REMOVE invitee_id, invitation_id, ignored"
         );
+        expect(update.ExpressionAttributeValues?.[":rejected"]).toEqual([7]);
         // A real (random) uuid, not a fixed sentinel.
         expect(update.ExpressionAttributeValues?.[":fresh"]).toMatch(/^[0-9a-f-]{36}$/);
     });
 
-    it("returns false when the face does not exist", async () => {
-        const { ConditionalCheckFailedException } = await import("@aws-sdk/client-dynamodb");
-        mockSend.mockRejectedValue(
-            new ConditionalCheckFailedException({ message: "nope", $metadata: {} })
+    it("detaches an unassigned face without recording a rejection", async () => {
+        mockSend.mockResolvedValueOnce({ Item: {} }).mockResolvedValueOnce({});
+
+        expect(await detachFace("f1")).toBe(true);
+        const update = sentCommand(1);
+        expect(update.UpdateExpression).toBe(
+            "SET cluster_id = :fresh REMOVE invitee_id, invitation_id, ignored"
         );
+        expect(update.ExpressionAttributeValues).not.toHaveProperty(":rejected");
+    });
+
+    it("returns false when the face does not exist", async () => {
+        mockSend.mockResolvedValueOnce({ Item: undefined });
         expect(await detachFace("missing")).toBe(false);
+        expect(mockSend).toHaveBeenCalledTimes(1); // no update attempted
     });
 });

--- a/src/utils/db/faces.ts
+++ b/src/utils/db/faces.ts
@@ -1,4 +1,4 @@
-import { QueryCommand, ScanCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { GetCommand, QueryCommand, ScanCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
 import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
 import { randomUUID } from "crypto";
 import { docClient, FACES_TABLE } from "./dynamo";
@@ -80,18 +80,37 @@ export async function getFacesByInvitees(inviteeIds: number[]): Promise<PhotoFac
 // An admin rejected this face from its person: sever it into a fresh,
 // unassigned singleton cluster. It disappears from the person (and from
 // guest results) immediately, but reappears in the Unassigned tab — if it's
-// really a different guest, it can be labeled correctly from there. Returns
-// false when no such face exists.
+// really a different guest, it can be labeled correctly from there. The
+// rejected person is recorded on the row so automated re-matching can never
+// re-attach the face to them (to Rekognition it still LOOKS like that
+// person — that's why it was mis-clustered — so without this memory the
+// re-matcher would fight the admin's corrections). Returns false when no
+// such face exists.
 export async function detachFace(faceId: string): Promise<boolean> {
+    const current = await docClient.send(
+        new GetCommand({
+            TableName: FACES_TABLE,
+            Key: { face_id: faceId },
+            ProjectionExpression: "invitee_id",
+        })
+    );
+    if (!current.Item) return false;
+    const rejectedFrom = (current.Item as { invitee_id?: number }).invitee_id;
+
     try {
         await docClient.send(
             new UpdateCommand({
                 TableName: FACES_TABLE,
                 Key: { face_id: faceId },
                 UpdateExpression:
-                    "SET cluster_id = :fresh REMOVE invitee_id, invitation_id, ignored",
+                    rejectedFrom != null
+                        ? "SET cluster_id = :fresh, rejected_invitee_ids = list_append(if_not_exists(rejected_invitee_ids, :empty), :rejected) REMOVE invitee_id, invitation_id, ignored"
+                        : "SET cluster_id = :fresh REMOVE invitee_id, invitation_id, ignored",
                 ConditionExpression: "attribute_exists(face_id)",
-                ExpressionAttributeValues: { ":fresh": randomUUID() },
+                ExpressionAttributeValues:
+                    rejectedFrom != null
+                        ? { ":fresh": randomUUID(), ":empty": [], ":rejected": [rejectedFrom] }
+                        : { ":fresh": randomUUID() },
             })
         );
         return true;


### PR DESCRIPTION
Found in production use: rejecting a face from a person via the By Person tab, then clicking **Re-match unassigned**, re-attached the face to the very person it was rejected from — undoing the admin's correction. Root cause: `detachFace` threw the face back into the unassigned pool with **no memory of the rejection**, and to Rekognition the face still *looks* like that person (that's exactly why it was mis-clustered in the first place), so the re-matcher confidently reapplied the same mistake. Human corrections and the automation were fighting each other.

## Fix 1: rejections are persistent

- **`detachFace` records who the face was rejected from** — `rejected_invitee_ids` on the face row (`list_append`, so a face can accumulate rejections from multiple people over time). Detaching an already-unassigned face records nothing.
- **The Lambda re-match pass skips any candidate match assigned to someone on the face's rejection list.** It can still legitimately match the face to a *different* person (the actual goal of rejecting into Unassigned), or inherit an ignore. The rejection filter lives in `findLabeledMatch`'s predicate on the shared `findMatchingRow` helper.
- Upload-time auto-assign is untouched — brand-new faces have no rejection history by definition.

## Fix 2: automated rounds are now undoable

The first re-match round couldn't be reverted: no row marker, no PITR on the faces table, logs recorded only counts. Both gaps closed:

- **Re-match stamps `assigned_by: "rematch"` + `assigned_at`** on every row it writes, so any future round is precisely enumerable (and revertible with a one-line filter). Human assignments carry no stamp.
- **Point-in-time recovery enabled on `wedding-photo-faces`** — the table holds weeks of manual labeling; it deserves the same backstop the photos table already has.

## Recovering the current state

The already-resurrected faces predate the stamping, so they need one manual pass: By Person → reject them again. With this fix deployed those rejections stick forever.

## Deploy note

Needs a `cdk deploy` after merge (Lambda code + PITR flag; no IAM changes).

## Testing

200 tests passing (detachFace: rejection recorded with previous assignee, no record for unassigned detach, read-then-update 404 path); `tsc --noEmit` + `eslint` clean; infra tsc at baseline.