### PR TITLE
fix: decode guest HEIC uploads in the photo-processor

### DIFF
--- a/infra/lambdas/photo-processor/heic-convert.d.ts
+++ b/infra/lambdas/photo-processor/heic-convert.d.ts
@@ -1,0 +1,8 @@
+declare module "heic-convert" {
+    interface HeicConvertOptions {
+        buffer: Buffer | Uint8Array;
+        format: "JPEG" | "PNG";
+        quality?: number; // 0–1, JPEG only
+    }
+    export default function convert(options: HeicConvertOptions): Promise<ArrayBuffer>;
+}

--- a/infra/lambdas/photo-processor/index.ts
+++ b/infra/lambdas/photo-processor/index.ts
@@ -214,7 +214,11 @@ async function processPhoto(key: string, bucket: string): Promise<void> {
     const ext = fileName.slice(fileName.lastIndexOf(".")).toLowerCase();
     let takenAt: string | null = null;
     if (ext === ".heic" || ext === ".heif") {
-        takenAt = extractDateTimeOriginal(buffer);
+        // Scan only the head of the file: HEIC metadata (the meta box, incl.
+        // EXIF) precedes the mdat media data, so this finds the capture date
+        // without regexing megabytes of HEVC bitstream — cheaper and far less
+        // surface for the unanchored date pattern to false-positive in.
+        takenAt = extractDateTimeOriginal(buffer.subarray(0, 256 * 1024));
         buffer = Buffer.from(
             new Uint8Array(await heicConvert({ buffer, format: "JPEG", quality: 0.9 }))
         );

--- a/infra/lambdas/photo-processor/index.ts
+++ b/infra/lambdas/photo-processor/index.ts
@@ -1,6 +1,7 @@
 import type { S3Event } from "aws-lambda";
 import { S3Client, GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import sharp from "sharp";
+import heicConvert from "heic-convert";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
     DynamoDBDocumentClient,
@@ -202,11 +203,26 @@ async function processPhoto(key: string, bucket: string): Promise<void> {
             `Object ${key} is ${obj.ContentLength} bytes, exceeds ${MAX_IMAGE_BYTES} limit`
         );
     }
-    const buffer = await streamToBuffer(obj.Body as Readable, MAX_IMAGE_BYTES);
+    let buffer = await streamToBuffer(obj.Body as Readable, MAX_IMAGE_BYTES);
+
+    // sharp's prebuilt libvips has no HEVC decoder (patent licensing), so
+    // iPhone-default HEIC/HEIF uploads must be decoded in WASM first.
+    // heic-convert applies the file's rotation/mirror transforms during
+    // decode but drops metadata, so the EXIF capture date is pulled from the
+    // ORIGINAL bytes — extractDateTimeOriginal only pattern-scans, and the
+    // EXIF block inside a HEIC container scans the same as a raw EXIF buffer.
+    const ext = fileName.slice(fileName.lastIndexOf(".")).toLowerCase();
+    let takenAt: string | null = null;
+    if (ext === ".heic" || ext === ".heif") {
+        takenAt = extractDateTimeOriginal(buffer);
+        buffer = Buffer.from(
+            new Uint8Array(await heicConvert({ buffer, format: "JPEG", quality: 0.9 }))
+        );
+    }
 
     const image = sharp(buffer, { limitInputPixels: MAX_INPUT_PIXELS }).rotate(); // auto-rotate using EXIF orientation
     const metadata = await image.metadata();
-    const takenAt = metadata.exif ? extractDateTimeOriginal(metadata.exif) : null;
+    if (!takenAt) takenAt = metadata.exif ? extractDateTimeOriginal(metadata.exif) : null;
 
     const { data, info } = await image
         .withMetadata(false) // strip EXIF from thumbnail

--- a/infra/lib/wedding-stack.ts
+++ b/infra/lib/wedding-stack.ts
@@ -258,7 +258,9 @@ export class WeddingStack extends cdk.Stack {
       // Guest uploads go up to 20 MB, so give sharp real headroom.
       memorySize: 1536,
       bundling: {
-        nodeModules: ['sharp'],
+        // heic-convert stays a real node_module (not esbuild-inlined) so its
+        // WASM decoder loads the way its loader expects.
+        nodeModules: ['sharp', 'heic-convert'],
         // sharp ships per-platform binaries; force npm to stage the Lambda's
         // platform (linux/arm64) rather than the machine running `cdk deploy`.
         environment: {

--- a/infra/package.json
+++ b/infra/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "aws-cdk-lib": "^2.200.0",
     "constructs": "^10.0.0",
+    "heic-convert": "^2.1.0",
     "sharp": "^0.34.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Production bug: guest HEIC uploads — the iPhone default format — stuck in processing forever while JPEGs worked. CloudWatch shows the cause on every attempt: `heif: Support for this compression format has not been built in`. sharp's prebuilt libvips deliberately excludes the HEVC decoder (patent licensing), so the Lambda threw at decode, the per-record catch logged it, and `thumbnail_key` stayed null.

## Fix

- **HEIC/HEIF originals are decoded to JPEG with `heic-convert`** (pure WASM libheif — no native compilation, no custom libvips build, no Lambda layer) before entering the existing sharp pipeline. Rotation/mirror transforms are applied during decode; everything downstream (thumbnailing, face indexing, dog detection) is unchanged.
- **The EXIF capture date survives**: conversion drops metadata, but `extractDateTimeOriginal` only pattern-scans bytes, and the EXIF block inside a HEIC container scans identically to a raw EXIF buffer — so it now runs against the *original* bytes for HEICs.
- `heic-convert` ships as a real node_module in the bundle (like sharp) so its WASM loader resolves normally rather than fighting esbuild inlining.

Memory note: WASM decode of a 12–48MP HEIC adds transient heap on top of sharp's; the 1536 MB function has headroom, and a failure degrades gracefully as before (photo stays pending, never breaks the batch).

## Rollout

1. Merge → `cdk deploy` (Lambda code + bundling change only).
2. Re-trigger the currently stuck photo (one as of now, from code CAFRE6) with a self-copy so S3 re-fires the event:
   `aws s3api copy-object --bucket oneill-wedding-photos --copy-source "oneill-wedding-photos/uploads/original/CAFRE6/f9a58636-8035-491e-94c4-ffecd1161cf2.heic" --key "uploads/original/CAFRE6/f9a58636-8035-491e-94c4-ffecd1161cf2.heic" --metadata-directive REPLACE`
3. Verify: photo gets a thumbnail + face rows, appears in moderation.

## Testing

App suite 199 passed, `eslint` clean, infra `tsc` at baseline, `cdk synth` succeeds. Real HEIC decode is verified post-deploy via the stuck photo (step 2) — LocalStack can't exercise the Lambda's Rekognition path and the WASM decode is environment-independent.