### PR TITLE
feat: moderation QoL — uploader names on cards, delete rejected photos

### DIFF
--- a/infra/lib/wedding-stack.ts
+++ b/infra/lib/wedding-stack.ts
@@ -223,11 +223,12 @@ export class WeddingStack extends cdk.Stack {
             `${facesTable.tableArn}/index/*`,
           ],
         }),
-        // Face rows are the only items the app ever deletes (admin re-cluster
-        // and cleanup), so the DeleteItem grant is scoped to that table alone.
+        // App-side deletes: face rows (re-cluster/cleanup, and cascade when a
+        // photo is deleted) and photo rows (admin permanently deleting a
+        // rejected photo). The frozen archive stays undeletable.
         new iam.PolicyStatement({
           actions: ['dynamodb:DeleteItem'],
-          resources: [facesTable.tableArn],
+          resources: [facesTable.tableArn, photosTable.tableArn],
         }),
         // Presigned URLs (guest photo downloads and uploads) are signed as
         // this user, so S3 evaluates ITS permissions when the URL is used —
@@ -236,6 +237,15 @@ export class WeddingStack extends cdk.Stack {
         new iam.PolicyStatement({
           actions: ['s3:GetObject', 's3:PutObject'],
           resources: [`${photosBucket.bucketArn}/uploads/original/*`],
+        }),
+        // Permanently deleting a rejected photo removes its original AND its
+        // generated thumbnail.
+        new iam.PolicyStatement({
+          actions: ['s3:DeleteObject'],
+          resources: [
+            `${photosBucket.bucketArn}/uploads/original/*`,
+            `${photosBucket.bucketArn}/uploads/thumbnail/*`,
+          ],
         }),
       ],
     });

--- a/src/app/api/photos/[id]/__tests__/route.test.ts
+++ b/src/app/api/photos/[id]/__tests__/route.test.ts
@@ -1,11 +1,26 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { NextRequest } from "next/server";
-import { PATCH } from "../route";
+import { PATCH, DELETE } from "../route";
 
 const mockUpdatePhotoModeration = vi.fn();
+const mockGetPhotoById = vi.fn();
+const mockDeletePhotoRow = vi.fn();
+const mockDeleteFacesByPhoto = vi.fn();
+const mockS3Send = vi.fn();
 
 vi.mock("@/utils/db/photos", () => ({
     updatePhotoModeration: (...args: unknown[]) => mockUpdatePhotoModeration(...args),
+    getPhotoById: (...args: unknown[]) => mockGetPhotoById(...args),
+    deletePhotoRow: (...args: unknown[]) => mockDeletePhotoRow(...args),
+}));
+
+vi.mock("@/utils/db/faces", () => ({
+    deleteFacesByPhoto: (...args: unknown[]) => mockDeleteFacesByPhoto(...args),
+}));
+
+vi.mock("@/utils/storage", () => ({
+    getS3: () => ({ send: (...args: unknown[]) => mockS3Send(...args) }),
+    BUCKET: "test-bucket",
 }));
 
 vi.mock("@/utils/auth/requireAuth", () => ({
@@ -97,5 +112,80 @@ describe("PATCH /api/photos/[id]", () => {
         mockUpdatePhotoModeration.mockRejectedValue(new Error("DB error"));
         const res = await PATCH(makeRequest({ status: "approved" }), { params });
         expect(res.status).toBe(500);
+    });
+});
+
+describe("DELETE /api/photos/[id]", () => {
+    const rejectedPhoto = {
+        id: "photo-1",
+        s3_key: "uploads/original/ABC123/uuid.heic",
+        thumbnail_key: "uploads/thumbnail/ABC123/uuid.jpg",
+        status: "rejected",
+    };
+    const deleteRequest = () =>
+        new NextRequest("http://localhost/api/photos/photo-1", { method: "DELETE" });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetPhotoById.mockResolvedValue(rejectedPhoto);
+        mockS3Send.mockResolvedValue({});
+        mockDeleteFacesByPhoto.mockResolvedValue(2);
+        mockDeletePhotoRow.mockResolvedValue(undefined);
+    });
+
+    it("returns 401 without auth", async () => {
+        unauthenticated();
+        const res = await DELETE(deleteRequest(), { params });
+        expect(res.status).toBe(401);
+        expect(mockDeletePhotoRow).not.toHaveBeenCalled();
+    });
+
+    it("deletes S3 objects, face rows, and the photo row", async () => {
+        authenticated();
+        const res = await DELETE(deleteRequest(), { params });
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ id: "photo-1", deleted: true });
+
+        const s3Keys = mockS3Send.mock.calls.map(
+            (c) => (c[0] as { input: { Key: string } }).input.Key
+        );
+        expect(s3Keys).toEqual([
+            "uploads/original/ABC123/uuid.heic",
+            "uploads/thumbnail/ABC123/uuid.jpg",
+        ]);
+        expect(mockDeleteFacesByPhoto).toHaveBeenCalledWith("photo-1");
+        expect(mockDeletePhotoRow).toHaveBeenCalledWith("photo-1");
+    });
+
+    it("skips the thumbnail delete when none exists (stuck photos)", async () => {
+        authenticated();
+        mockGetPhotoById.mockResolvedValue({ ...rejectedPhoto, thumbnail_key: null });
+        const res = await DELETE(deleteRequest(), { params });
+        expect(res.status).toBe(200);
+        expect(mockS3Send).toHaveBeenCalledTimes(1);
+    });
+
+    it("refuses to delete photos that are not rejected", async () => {
+        authenticated();
+        mockGetPhotoById.mockResolvedValue({ ...rejectedPhoto, status: "approved" });
+        const res = await DELETE(deleteRequest(), { params });
+        expect(res.status).toBe(400);
+        expect(mockS3Send).not.toHaveBeenCalled();
+        expect(mockDeletePhotoRow).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 for a non-existent photo", async () => {
+        authenticated();
+        mockGetPhotoById.mockResolvedValue(null);
+        const res = await DELETE(deleteRequest(), { params });
+        expect(res.status).toBe(404);
+    });
+
+    it("keeps the photo row when S3 deletion fails (retryable)", async () => {
+        authenticated();
+        mockS3Send.mockRejectedValue(new Error("S3 error"));
+        const res = await DELETE(deleteRequest(), { params });
+        expect(res.status).toBe(500);
+        expect(mockDeletePhotoRow).not.toHaveBeenCalled();
     });
 });

--- a/src/app/api/photos/[id]/route.ts
+++ b/src/app/api/photos/[id]/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { updatePhotoModeration } from "@/utils/db/photos";
+import { DeleteObjectCommand } from "@aws-sdk/client-s3";
+import { updatePhotoModeration, getPhotoById, deletePhotoRow } from "@/utils/db/photos";
+import { deleteFacesByPhoto } from "@/utils/db/faces";
 import { requireAuth } from "@/utils/auth/requireAuth";
+import { getS3, BUCKET } from "@/utils/storage";
 
 interface PatchBody {
     status: "approved" | "rejected";
@@ -38,6 +41,47 @@ export async function PATCH(
         return NextResponse.json({ id, status });
     } catch (error) {
         console.error("Error in PATCH /api/photos/[id]:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}
+
+// Permanently delete a photo: S3 original + thumbnail, its face rows, and
+// the photo row itself. Restricted to REJECTED photos — anything else must
+// be rejected first, so a mis-click can't destroy an approved photo.
+// Ordering is deliberate: S3 objects go first (if that fails the row
+// survives and the admin can retry), and the row goes last (once it's gone
+// there is nothing left to retry from).
+export async function DELETE(
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> }
+) {
+    const auth = await requireAuth(request);
+    if (!auth.success) return auth.response;
+
+    try {
+        const { id } = await params;
+        const photo = await getPhotoById(id);
+        if (!photo) {
+            return NextResponse.json({ error: "Photo not found" }, { status: 404 });
+        }
+        if (photo.status !== "rejected") {
+            return NextResponse.json(
+                { error: "Only rejected photos can be deleted" },
+                { status: 400 }
+            );
+        }
+
+        const s3 = getS3();
+        await s3.send(new DeleteObjectCommand({ Bucket: BUCKET, Key: photo.s3_key }));
+        if (photo.thumbnail_key) {
+            await s3.send(new DeleteObjectCommand({ Bucket: BUCKET, Key: photo.thumbnail_key }));
+        }
+        await deleteFacesByPhoto(id);
+        await deletePhotoRow(id);
+
+        return NextResponse.json({ id, deleted: true });
+    } catch (error) {
+        console.error("Error in DELETE /api/photos/[id]:", error);
         return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 }

--- a/src/app/dashboard/photos/page.tsx
+++ b/src/app/dashboard/photos/page.tsx
@@ -19,7 +19,7 @@ import {
     Anchor,
     UnstyledButton,
 } from "@mantine/core";
-import { IconAlertCircle, IconCheck, IconX } from "@tabler/icons-react";
+import { IconAlertCircle, IconCheck, IconX, IconTrash } from "@tabler/icons-react";
 import Link from "next/link";
 import Lightbox from "yet-another-react-lightbox";
 import "yet-another-react-lightbox/styles.css";
@@ -94,6 +94,20 @@ export default function PhotosModerationPage() {
     useEffect(() => {
         fetchPhotos(activeStatus);
     }, [activeStatus, fetchPhotos]);
+
+    // Permanent delete of a rejected photo: S3 objects, face rows, and the
+    // photo row all go — hence the confirm.
+    const deletePhoto = async (id: string) => {
+        if (!window.confirm("Permanently delete this photo? This cannot be undone.")) return;
+        try {
+            const res = await fetch(`/api/photos/${id}`, { method: "DELETE" });
+            if (!res.ok) throw new Error("Delete failed");
+            setPhotos((prev) => prev.filter((p) => p.id !== id));
+            fetchCounts();
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to delete photo");
+        }
+    };
 
     const updatePhoto = async (id: string, status: "approved" | "rejected", categoryId?: string) => {
         try {
@@ -171,6 +185,7 @@ export default function PhotosModerationPage() {
                             categoryOptions={categoryOptions}
                             onApprove={(categoryId) => updatePhoto(photo.id, "approved", categoryId)}
                             onReject={() => updatePhoto(photo.id, "rejected")}
+                            onDelete={() => deletePhoto(photo.id)}
                             onView={() =>
                                 setLightboxIndex(viewablePhotos.findIndex((p) => p.id === photo.id))
                             }
@@ -199,20 +214,24 @@ function PhotoCard({
     categoryOptions,
     onApprove,
     onReject,
+    onDelete,
     onView,
 }: {
     photo: PhotoWithThumbnail;
     categoryOptions: { value: string; label: string }[];
     onApprove: (categoryId?: string) => void;
     onReject: () => void;
+    onDelete: () => void;
     onView: () => void;
 }) {
     const [selectedCategory, setSelectedCategory] = useState<string | null>(photo.category_id);
 
     // Status changes are allowed in both directions: a photo can be approved
-    // unless it already is, and rejected unless it already is.
+    // unless it already is, and rejected unless it already is. Permanent
+    // deletion is only offered once a photo is rejected.
     const canApprove = photo.status !== "approved";
     const canReject = photo.status !== "rejected";
+    const canDelete = photo.status === "rejected";
 
     return (
         <Paper shadow="sm" radius="md" p="sm" withBorder>
@@ -297,6 +316,17 @@ function PhotoCard({
                             onClick={onReject}
                         >
                             Reject
+                        </Button>
+                    )}
+                    {canDelete && (
+                        <Button
+                            size="xs"
+                            color="red"
+                            leftSection={<IconTrash size={12} />}
+                            flex={1}
+                            onClick={onDelete}
+                        >
+                            Delete
                         </Button>
                     )}
                 </Group>

--- a/src/app/dashboard/photos/page.tsx
+++ b/src/app/dashboard/photos/page.tsx
@@ -27,6 +27,9 @@ import type { Photo, PhotoCategory } from "@/types/photos";
 
 interface PhotoWithThumbnail extends Photo {
     thumbnail_url: string | null;
+    // Household display names resolved from the invitation code (admin rows
+    // from /api/photos carry this since the attribution feature).
+    uploaded_by: string | null;
 }
 
 const STATUS_COLORS: Record<string, string> = {
@@ -254,6 +257,7 @@ function PhotoCard({
                         </Badge>
                         <Text size="xs" c="dimmed">
                             {photo.invitation_code}
+                            {photo.uploaded_by && ` · ${photo.uploaded_by}`}
                         </Text>
                     </Group>
                     <Text size="xs" c="dimmed">

--- a/src/utils/db/faces.ts
+++ b/src/utils/db/faces.ts
@@ -1,4 +1,10 @@
-import { GetCommand, QueryCommand, ScanCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import {
+    DeleteCommand,
+    GetCommand,
+    QueryCommand,
+    ScanCommand,
+    UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
 import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
 import { randomUUID } from "crypto";
 import { docClient, FACES_TABLE } from "./dynamo";
@@ -75,6 +81,20 @@ export async function getFacesByInvitees(inviteeIds: number[]): Promise<PhotoFac
         })
     );
     return results.flat();
+}
+
+// Cascade for photo deletion: remove every face row belonging to the photo.
+// The Rekognition vectors stay in the collection (the app has no Rekognition
+// permissions by design); orphaned vectors are harmless — any future match
+// against one finds no row and is skipped. Returns the number removed.
+export async function deleteFacesByPhoto(photoId: string): Promise<number> {
+    const faces = await getFacesByPhoto(photoId);
+    for (const face of faces) {
+        await docClient.send(
+            new DeleteCommand({ TableName: FACES_TABLE, Key: { face_id: face.face_id } })
+        );
+    }
+    return faces.length;
 }
 
 // An admin rejected this face from its person: sever it into a fresh,

--- a/src/utils/db/photos.ts
+++ b/src/utils/db/photos.ts
@@ -1,5 +1,6 @@
 import {
     BatchGetCommand,
+    DeleteCommand,
     GetCommand,
     PutCommand,
     QueryCommand,
@@ -138,6 +139,12 @@ export async function getPhotosByIds(ids: string[]): Promise<Photo[]> {
         }
     }
     return photos;
+}
+
+// Remove the photo row itself. Callers own the wider cascade (S3 objects,
+// face rows) — see DELETE /api/photos/[id].
+export async function deletePhotoRow(id: string): Promise<void> {
+    await docClient.send(new DeleteCommand({ TableName: PHOTOS_TABLE, Key: { id } }));
 }
 
 export interface ModerationUpdate {


### PR DESCRIPTION
Two admin moderation improvements in one PR.

## 1. Uploader names beside the code

The card showed only the raw invitation code (`CAFRE6`), which means nothing at a glance. Admin rows from `/api/photos` already carry `uploaded_by` (household first names, resolved server-side per #194), so cards now read **`CAFRE6 · Aoife & Brian`**. Professional imports show neither. Guest-facing surfaces still never see codes.

## 2. Delete button on rejected photos

Rejected photos previously lingered forever (S3 storage, face rows, moderation clutter). Each rejected card now has a **Delete** button (with a confirm dialog) that permanently removes:

- the S3 **original and thumbnail**,
- the photo's **face rows** (Rekognition vectors stay in the collection — the app has no Rekognition permissions by design; orphaned vectors are harmless since matching skips faces with no row),
- the **photo row** itself.

Safety properties:
- **Only `rejected` photos can be deleted** (400 otherwise) — a mis-click can't destroy an approved photo; reject first, delete second.
- **Deletion order makes partial failure retryable**: S3 objects first, row last — if S3 errors, the row survives and the admin just clicks again. Once the row is gone there's nothing left to retry from.

## Infra

`wedding-api-lambda` gains `dynamodb:DeleteItem` on the photos table and `s3:DeleteObject` on the `uploads/original/*` + `uploads/thumbnail/*` prefixes (the frozen archive stays undeletable). **Needs a `cdk deploy` after merge** — conveniently the same deploy that's already pending for #195/#196's Lambda changes.

## Testing

206 passed (6 new DELETE tests: auth, full cascade with S3 key ordering, thumbnail-less stuck photos, non-rejected 400, 404, S3-failure-keeps-row); `tsc` + `eslint` clean; infra tsc at baseline.