### PR TITLE
fix: hide gallery CTAs until a code or session grants access

### DIFF
--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -292,19 +292,23 @@ function Gallery() {
                                 Share your memories from our special day
                             </Text>
                         </Box>
-                        <Group gap="sm">
-                            <Button
-                                component={Link}
-                                href="/gallery/my-photos"
-                                variant="light"
-                                color="yellow"
-                            >
-                                Find My Photos
-                            </Button>
-                            <Button component={Link} href="/gallery/upload" variant="light" color="yellow">
-                                Upload Photos
-                            </Button>
-                        </Group>
+                        {/* Both pages are code-gated — dead ends for a
+                            codeless visitor staring at the gate. */}
+                        {hasAccess && (
+                            <Group gap="sm">
+                                <Button
+                                    component={Link}
+                                    href="/gallery/my-photos"
+                                    variant="light"
+                                    color="yellow"
+                                >
+                                    Find My Photos
+                                </Button>
+                                <Button component={Link} href="/gallery/upload" variant="light" color="yellow">
+                                    Upload Photos
+                                </Button>
+                            </Group>
+                        )}
                     </Group>
 
                     {error && (


### PR DESCRIPTION
On the gallery's code-entry gate, the **Find My Photos** and **Upload Photos** buttons were still shown (see screenshot in the conversation) — both lead to code-gated pages, so for a codeless visitor they're dead ends that just bounce them to another gate. They now render only once `hasAccess` is true (a stored/entered code or an admin session), i.e. exactly when the gallery content itself renders.

One-condition UI change reusing the page's existing `hasAccess` flag. Suite: 206 passed; `tsc` + `eslint` clean. Deploys via Amplify on merge.