### PR TITLE
feat: mobile-friendly gallery layout

### DIFF
--- a/src/app/gallery/my-photos/page.tsx
+++ b/src/app/gallery/my-photos/page.tsx
@@ -9,7 +9,7 @@ import {
     Box,
     Button,
     Alert,
-    Group,
+    Flex,
     Loader,
     Center,
     Paper,
@@ -160,8 +160,14 @@ export default function MyPhotosPage() {
         <main id="main-content">
             <Container size="xl" py="xl">
                 <Stack gap="lg">
-                    <Group justify="space-between" align="flex-end">
-                        <Box>
+                    {/* Stacked and centred on phones, side-by-side on wider screens. */}
+                    <Flex
+                        direction={{ base: "column", sm: "row" }}
+                        align={{ base: "center", sm: "flex-end" }}
+                        justify="space-between"
+                        gap="md"
+                    >
+                        <Box ta={{ base: "center", sm: "left" }}>
                             <Title
                                 order={1}
                                 style={{
@@ -182,7 +188,7 @@ export default function MyPhotosPage() {
                         <Button component={Link} href="/gallery" variant="light" color="yellow">
                             Full Gallery
                         </Button>
-                    </Group>
+                    </Flex>
 
                     {error && (
                         <Alert icon={<IconAlertCircle size={16} />} color="red" variant="light">

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -401,12 +401,9 @@ function Gallery() {
                     <Tabs
                         value={activeCategory ?? "all"}
                         onChange={(v) => setActiveCategory(v === "all" ? null : v)}
+                        classNames={{ list: "no-scrollbar" }}
                         styles={{
-                            list: {
-                                flexWrap: "nowrap",
-                                overflowX: "auto",
-                                scrollbarWidth: "none",
-                            },
+                            list: { flexWrap: "nowrap", overflowX: "auto" },
                             tab: { whiteSpace: "nowrap", flexShrink: 0 },
                         }}
                     >

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -12,6 +12,7 @@ import {
     Button,
     Alert,
     Group,
+    Flex,
     Loader,
     Center,
     Paper,
@@ -275,8 +276,14 @@ function Gallery() {
         <main id="main-content">
             <Container size="xl" py="xl">
                 <Stack gap="lg">
-                    <Group justify="space-between" align="flex-end">
-                        <Box>
+                    {/* Stacked and centred on phones, side-by-side on wider screens. */}
+                    <Flex
+                        direction={{ base: "column", sm: "row" }}
+                        align={{ base: "center", sm: "flex-end" }}
+                        justify="space-between"
+                        gap="md"
+                    >
+                        <Box ta={{ base: "center", sm: "left" }}>
                             <Title
                                 order={1}
                                 style={{
@@ -295,7 +302,7 @@ function Gallery() {
                         {/* Both pages are code-gated — dead ends for a
                             codeless visitor staring at the gate. */}
                         {hasAccess && (
-                            <Group gap="sm">
+                            <Group gap="sm" justify="center">
                                 <Button
                                     component={Link}
                                     href="/gallery/my-photos"
@@ -309,7 +316,7 @@ function Gallery() {
                                 </Button>
                             </Group>
                         )}
-                    </Group>
+                    </Flex>
 
                     {error && (
                         <Alert icon={<IconAlertCircle size={16} />} color="red" variant="light">
@@ -382,13 +389,27 @@ function Gallery() {
                             }}
                             searchable
                             clearable
-                            maw={340}
+                            w="100%"
+                            maw={{ base: "100%", sm: 340 }}
                             value={personFilter}
                             onChange={setPersonFilter}
                         />
                     )}
 
-                    <Tabs value={activeCategory ?? "all"} onChange={(v) => setActiveCategory(v === "all" ? null : v)}>
+                    {/* One swipeable row on phones instead of wrapping into a
+                        ragged grid; desktop fits in a single row anyway. */}
+                    <Tabs
+                        value={activeCategory ?? "all"}
+                        onChange={(v) => setActiveCategory(v === "all" ? null : v)}
+                        styles={{
+                            list: {
+                                flexWrap: "nowrap",
+                                overflowX: "auto",
+                                scrollbarWidth: "none",
+                            },
+                            tab: { whiteSpace: "nowrap", flexShrink: 0 },
+                        }}
+                    >
                         <Tabs.List>
                             <Tabs.Tab value="all">All Photos</Tabs.Tab>
                             {categories.map((c) => (

--- a/src/app/gallery/upload/page.tsx
+++ b/src/app/gallery/upload/page.tsx
@@ -11,6 +11,7 @@ import {
     Stack,
     Box,
     Group,
+    Flex,
     Progress,
     Alert,
     Paper,
@@ -255,7 +256,7 @@ export default function UploadPage() {
         <main id="main-content">
             <Container size="sm" py="xl">
                 <Stack gap="xl">
-                    <Box>
+                    <Box ta={{ base: "center", sm: "left" }}>
                         <Title
                             order={1}
                             style={{
@@ -306,14 +307,21 @@ export default function UploadPage() {
                                         failed to upload — you can retry below.
                                     </Alert>
                                 )}
-                                <Group gap="sm">
+                                {/* Full-width stacked on phones (thumb-sized
+                                    targets), inline and centred otherwise. */}
+                                <Flex
+                                    direction={{ base: "column", xs: "row" }}
+                                    gap="sm"
+                                    justify="center"
+                                    w="100%"
+                                >
                                     <Button color="yellow" onClick={resetForMoreUploads}>
                                         Upload more photos
                                     </Button>
                                     <Button component={Link} href="/gallery" variant="light" color="yellow">
                                         View the gallery
                                     </Button>
-                                </Group>
+                                </Flex>
                             </Stack>
                         </Paper>
                     ) : !codeValidated ? (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,6 +77,17 @@ h1, h2, h3, h4, h5, h6 {
     background: var(--gold);
 }
 
+/* Swipeable rows (e.g. the gallery category tabs) scroll without showing a
+   bar. scrollbar-width covers Firefox; the pseudo-element rule covers
+   WebKit/Safari, which otherwise paints the gold scrollbar above. */
+.no-scrollbar {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+}
+.no-scrollbar::-webkit-scrollbar {
+    display: none;
+}
+
 /* Text selection color */
 ::selection {
     background-color: #8b7355;


### PR DESCRIPTION
Mobile polish pass over the guest-facing gallery pages (see conversation screenshots for the before state).

- **Headers centre on phones**: the Wedding Gallery / Photos of You / Share Your Photos headers (and their CTA buttons) stack and centre below the `sm` breakpoint, returning to the side-by-side left/right layout on wider screens. Done with responsive `Flex`/`ta` props — no CSS files, no duplicated markup.
- **Category tabs become one swipeable row** on phones (`nowrap` + horizontal overflow with hidden scrollbar) instead of wrapping into a ragged three-row grid — the standard mobile tab pattern. Desktop is visually unchanged since all tabs fit one row anyway.
- **People search** fills the width on phones instead of a floating 340px box.
- **Upload thank-you buttons** stack full-width on phones (thumb-sized targets, centred with the rest of the card), inline from `xs` up.

**Note:** this rewrites the same header block as open PR #198 (hide CTAs without a code) and therefore **includes that change** — merging this PR makes #198 redundant (close it), or merge #198 first and I'll rebase this one.

Suite: 206 passed; `tsc` + `eslint` clean. Amplify deploys on merge — no infra.