### PR TITLE
fix: real downloads and pinch-to-zoom in the lightbox

### DIFF
--- a/src/app/api/photos/[id]/download-url/__tests__/route.test.ts
+++ b/src/app/api/photos/[id]/download-url/__tests__/route.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockIsValidInvitationCode = vi.fn();
+const mockGetPhotoById = vi.fn();
+const mockGetSignedUrl = vi.fn();
+
+vi.mock("@/utils/db/archive", () => ({
+    isValidInvitationCode: (...args: unknown[]) => mockIsValidInvitationCode(...args),
+}));
+vi.mock("@/utils/db/photos", () => ({
+    getPhotoById: (...args: unknown[]) => mockGetPhotoById(...args),
+}));
+vi.mock("@/utils/storage", () => ({
+    getS3: () => ({}),
+    BUCKET: "test-bucket",
+}));
+vi.mock("@aws-sdk/client-s3", () => ({
+    GetObjectCommand: class {
+        input: unknown;
+        constructor(input: unknown) {
+            this.input = input;
+        }
+    },
+}));
+vi.mock("@aws-sdk/s3-request-presigner", () => ({
+    getSignedUrl: (...args: unknown[]) => mockGetSignedUrl(...args),
+}));
+
+import { GET } from "../route";
+
+const params = { params: Promise.resolve({ id: "photo-1" }) };
+const req = (qs = "?code=ABC123") =>
+    new NextRequest(`http://localhost/api/photos/photo-1/download-url${qs}`);
+
+const approvedPhoto = (fileName: string) => ({
+    id: "photo-1",
+    s3_key: "uploads/original/ABC123/uuid.jpg",
+    file_name: fileName,
+    status: "approved",
+});
+
+// The disposition passed to the presigner, for a given stored file name.
+async function dispositionFor(fileName: string): Promise<string> {
+    mockGetPhotoById.mockResolvedValue(approvedPhoto(fileName));
+    const res = await GET(req(), params);
+    expect(res.status).toBe(302);
+    const command = mockGetSignedUrl.mock.calls[0][1] as {
+        input: { ResponseContentDisposition: string };
+    };
+    return command.input.ResponseContentDisposition;
+}
+
+describe("GET /api/photos/[id]/download-url", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockIsValidInvitationCode.mockResolvedValue(true);
+        mockGetSignedUrl.mockResolvedValue("https://signed.example/photo");
+    });
+
+    it("requires a code", async () => {
+        const res = await GET(req(""), params);
+        expect(res.status).toBe(400);
+    });
+
+    it("rejects an invalid code", async () => {
+        mockIsValidInvitationCode.mockResolvedValue(false);
+        const res = await GET(req(), params);
+        expect(res.status).toBe(403);
+    });
+
+    it("404s for a missing photo and 403s for unapproved ones", async () => {
+        mockGetPhotoById.mockResolvedValue(null);
+        expect((await GET(req(), params)).status).toBe(404);
+        mockGetPhotoById.mockResolvedValue({ ...approvedPhoto("a.jpg"), status: "pending" });
+        expect((await GET(req(), params)).status).toBe(403);
+    });
+
+    it("redirects to a presigned URL that forces a download", async () => {
+        const disposition = await dispositionFor("beach.jpg");
+        expect(disposition).toBe('attachment; filename="beach.jpg"; filename*=UTF-8\'\'beach.jpg');
+    });
+
+    it("strips header-injection characters from the ASCII filename", async () => {
+        const disposition = await dispositionFor('evil";\r\nX: y.jpg');
+        const asciiPart = disposition.match(/filename="([^"]*)"/)?.[1] ?? "";
+        expect(asciiPart).not.toMatch(/["\r\n;]/);
+        expect(asciiPart).toBe("evil____X_ y.jpg");
+    });
+
+    it("preserves non-ASCII names via RFC 5987 while keeping an ASCII fallback", async () => {
+        const disposition = await dispositionFor("café.jpg");
+        expect(disposition).toContain('filename="caf_.jpg"');
+        expect(disposition).toContain("filename*=UTF-8''caf%C3%A9.jpg");
+    });
+});

--- a/src/app/api/photos/[id]/download-url/route.ts
+++ b/src/app/api/photos/[id]/download-url/route.ts
@@ -32,14 +32,21 @@ export async function GET(
 
         // Without an attachment disposition the browser follows the redirect
         // and just DISPLAYS the image; this makes S3 serve it as a download
-        // with the original file name.
+        // with the original file name. The ASCII fallback also strips ", CR/LF
+        // and ; — file_name is guest-supplied, so this doubles as header-
+        // injection protection. filename* (RFC 5987) preserves accented or
+        // non-Latin names in modern browsers.
         const safeName = photo.file_name.replace(/[^\w.\- ]/g, "_");
+        const utf8Name = encodeURIComponent(photo.file_name).replace(
+            /['()*]/g,
+            (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase()
+        );
         const downloadUrl = await getSignedUrl(
             getS3(),
             new GetObjectCommand({
                 Bucket: BUCKET,
                 Key: photo.s3_key,
-                ResponseContentDisposition: `attachment; filename="${safeName}"`,
+                ResponseContentDisposition: `attachment; filename="${safeName}"; filename*=UTF-8''${utf8Name}`,
             }),
             { expiresIn: 900 }
         );

--- a/src/app/api/photos/[id]/download-url/route.ts
+++ b/src/app/api/photos/[id]/download-url/route.ts
@@ -30,9 +30,17 @@ export async function GET(
             return NextResponse.json({ error: "Photo not available" }, { status: 403 });
         }
 
+        // Without an attachment disposition the browser follows the redirect
+        // and just DISPLAYS the image; this makes S3 serve it as a download
+        // with the original file name.
+        const safeName = photo.file_name.replace(/[^\w.\- ]/g, "_");
         const downloadUrl = await getSignedUrl(
             getS3(),
-            new GetObjectCommand({ Bucket: BUCKET, Key: photo.s3_key }),
+            new GetObjectCommand({
+                Bucket: BUCKET,
+                Key: photo.s3_key,
+                ResponseContentDisposition: `attachment; filename="${safeName}"`,
+            }),
             { expiresIn: 900 }
         );
 

--- a/src/app/dashboard/photos/page.tsx
+++ b/src/app/dashboard/photos/page.tsx
@@ -22,6 +22,7 @@ import {
 import { IconAlertCircle, IconCheck, IconX, IconTrash } from "@tabler/icons-react";
 import Link from "next/link";
 import Lightbox from "yet-another-react-lightbox";
+import Zoom from "yet-another-react-lightbox/plugins/zoom";
 import "yet-another-react-lightbox/styles.css";
 import type { Photo, PhotoCategory } from "@/types/photos";
 
@@ -204,6 +205,8 @@ export default function PhotosModerationPage() {
                     height: p.height ?? undefined,
                     alt: p.file_name,
                 }))}
+                plugins={[Zoom]}
+                zoom={{ maxZoomPixelRatio: 2 }}
             />
         </Stack>
     );

--- a/src/app/gallery/my-photos/page.tsx
+++ b/src/app/gallery/my-photos/page.tsx
@@ -22,6 +22,7 @@ import "react-photo-album/rows.css";
 import Lightbox from "yet-another-react-lightbox";
 import Download from "yet-another-react-lightbox/plugins/download";
 import Captions from "yet-another-react-lightbox/plugins/captions";
+import Zoom from "yet-another-react-lightbox/plugins/zoom";
 import "yet-another-react-lightbox/styles.css";
 import "yet-another-react-lightbox/plugins/captions.css";
 import type { PublicPhoto } from "@/types/photos";
@@ -246,7 +247,8 @@ export default function MyPhotosPage() {
                 slides={lightboxSlides}
                 index={lightboxIndex}
                 on={{ view: ({ index }) => setLightboxIndex(index) }}
-                plugins={invitationCode ? [Captions, Download] : [Captions]}
+                plugins={invitationCode ? [Captions, Download, Zoom] : [Captions, Zoom]}
+                zoom={{ maxZoomPixelRatio: 2 }}
                 render={{
                     iconDownload: () => <IconDownload size={32} />,
                 }}

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -27,6 +27,7 @@ import "react-photo-album/rows.css";
 import Lightbox from "yet-another-react-lightbox";
 import Download from "yet-another-react-lightbox/plugins/download";
 import Captions from "yet-another-react-lightbox/plugins/captions";
+import Zoom from "yet-another-react-lightbox/plugins/zoom";
 import "yet-another-react-lightbox/styles.css";
 import "yet-another-react-lightbox/plugins/captions.css";
 import type { PublicPhoto, PhotoCategory } from "@/types/photos";
@@ -438,7 +439,8 @@ function Gallery() {
                 slides={lightboxSlides}
                 index={lightboxIndex}
                 on={{ view: ({ index }) => setLightboxIndex(index) }}
-                plugins={invitationCode ? [Captions, Download] : [Captions]}
+                plugins={invitationCode ? [Captions, Download, Zoom] : [Captions, Zoom]}
+                zoom={{ maxZoomPixelRatio: 2 }}
                 render={{
                     iconDownload: () => <IconDownload size={32} />,
                 }}


### PR DESCRIPTION
Two lightbox issues reported from phone use:

## Download opened the image instead of saving it

The download button hits `/api/photos/[id]/download-url`, which 302-redirects to a presigned S3 URL — and since S3 served the object with its default inline disposition, the browser just displayed the full-size image. The presign now sets **`ResponseContentDisposition: attachment`** with the photo's original file name (sanitized to header-safe characters), so S3 itself instructs the browser to save the file. Works for cross-origin redirects where the anchor `download` attribute is ignored — which is exactly this case.

## No pinch-to-zoom

Added yet-another-react-lightbox's **Zoom plugin** (pinch, double-tap, and scroll-wheel zoom) to all three lightboxes — gallery, Find My Photos, and the admin moderation view. `maxZoomPixelRatio: 2` lets phones zoom meaningfully into the 1200px thumbnails; beyond that the source pixels run out (full-size viewing is what the download button is for).

No conflict with open PR #199 — different lines (plugins/imports vs headers/tabs).

Suite: 206 passed; `tsc` + `eslint` clean. Amplify deploys on merge — no infra.