### PR TITLE
fix: point homepage copy at the personalised links

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,7 +36,7 @@ const greatVibes = Great_Vibes({
 export const metadata: Metadata = {
     metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL || "https://oneill.wedding"),
     title: "Rebecca & Matthew's Wedding",
-    description: "Thanks for celebrating with us. Check back soon to see the photos.",
+    description: "Thanks for celebrating with us. Click the link we sent you to see the photos.",
     keywords: ["wedding", "Rebecca", "Matthew", "celebration"],
     icons: {
         icon: "/favicon.ico",
@@ -45,7 +45,7 @@ export const metadata: Metadata = {
     },
     openGraph: {
         title: "Rebecca & Matthew's Wedding",
-        description: "Thanks for celebrating with us. Check back soon to see the photos.",
+        description: "Thanks for celebrating with us. Click the link we sent you to see the photos.",
         type: "website",
         images: [
             {
@@ -59,7 +59,7 @@ export const metadata: Metadata = {
     twitter: {
         card: "summary_large_image",
         title: "Rebecca & Matthew's Wedding",
-        description: "Thanks for celebrating with us. Check back soon to see the photos.",
+        description: "Thanks for celebrating with us. Click the link we sent you to see the photos.",
         images: ["/rebecca-matthew-wedding-photo-2.jpeg"],
     },
     other: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,7 +65,7 @@ export default function HomePage() {
                                 lineHeight: 1.6,
                             }}
                         >
-                            Check back soon to see the photos
+                            Click the link we sent you to see the photos
                         </Text>
                     </Stack>
                 </Container>


### PR DESCRIPTION
The homepage still said "Check back soon to see the photos" — stale now the gallery is live. Both the visible homepage line and the three metadata descriptions (page, OpenGraph, Twitter — what link previews show when the site is shared) now read **"Click the link we sent you to see the photos"**, steering guests to their personalised code-carrying links.

Text-only change across two files. Suite: 212 passed; `tsc` + `eslint` clean. Amplify deploys on merge.