### PR TITLE
feat: email the admin when guests upload photos

### DIFF
--- a/infra/lambdas/photo-processor/index.ts
+++ b/infra/lambdas/photo-processor/index.ts
@@ -362,26 +362,69 @@ async function notifyAdminOfUpload(code: string, thumbKey: string): Promise<void
 
     // Debounce marker lives in the photos table under a reserved id. The
     // conditional write is atomic: exactly one concurrent invocation wins
-    // the window and sends.
+    // the window and sends. The previous value is captured so the window
+    // can be handed back if the send fails.
     const now = Date.now();
+    const claimedAt = new Date(now).toISOString();
+    let previousSentAt: string | undefined;
     try {
-        await docClient.send(
+        const claim = await docClient.send(
             new UpdateCommand({
                 TableName: PHOTOS_TABLE,
                 Key: { id: "NOTIFICATION#uploads" },
                 UpdateExpression: "SET last_sent_at = :now",
                 ConditionExpression: "attribute_not_exists(last_sent_at) OR last_sent_at < :cutoff",
                 ExpressionAttributeValues: {
-                    ":now": new Date(now).toISOString(),
+                    ":now": claimedAt,
                     ":cutoff": new Date(now - NOTIFY_DEBOUNCE_MS).toISOString(),
                 },
+                ReturnValues: "UPDATED_OLD",
             })
         );
+        previousSentAt = (claim.Attributes as { last_sent_at?: string } | undefined)
+            ?.last_sent_at;
     } catch (err) {
         if (err instanceof ConditionalCheckFailedException) return; // already notified recently
         throw err;
     }
 
+    try {
+        await sendUploadEmail(recipients, invitationId, thumbKey);
+    } catch (err) {
+        // Hand the window back so a later upload in the same window retries —
+        // otherwise a transient SES failure silently eats the notification
+        // for 30 minutes. Conditional on our own claim so a legitimately
+        // newer window (won after the debounce elapsed) is never clobbered.
+        try {
+            await docClient.send(
+                new UpdateCommand({
+                    TableName: PHOTOS_TABLE,
+                    Key: { id: "NOTIFICATION#uploads" },
+                    UpdateExpression: previousSentAt
+                        ? "SET last_sent_at = :prev"
+                        : "REMOVE last_sent_at",
+                    ConditionExpression: "last_sent_at = :ours",
+                    ExpressionAttributeValues: previousSentAt
+                        ? { ":ours": claimedAt, ":prev": previousSentAt }
+                        : { ":ours": claimedAt },
+                })
+            );
+        } catch (rollbackErr) {
+            if (!(rollbackErr instanceof ConditionalCheckFailedException)) {
+                console.error("Failed to roll back notification window:", rollbackErr);
+            }
+        }
+        throw err;
+    }
+}
+
+// Compose and send the actual email; separated so the caller can treat any
+// failure here as "the claimed window was not used".
+async function sendUploadEmail(
+    recipients: string[],
+    invitationId: number,
+    thumbKey: string
+): Promise<void> {
     // Household first names for the greeting, pending count for the summary.
     const [inviteeRows, pending] = await Promise.all([
         docClient.send(

--- a/infra/lambdas/photo-processor/index.ts
+++ b/infra/lambdas/photo-processor/index.ts
@@ -2,7 +2,8 @@ import type { S3Event } from "aws-lambda";
 import { S3Client, GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import sharp from "sharp";
 import heicConvert from "heic-convert";
-import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { SESv2Client, SendEmailCommand } from "@aws-sdk/client-sesv2";
+import { DynamoDBClient, ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
 import {
     DynamoDBDocumentClient,
     GetCommand,
@@ -25,11 +26,22 @@ const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}), {
     marshallOptions: { removeUndefinedValues: true },
 });
 const rekognition = new RekognitionClient({});
+const sesClient = new SESv2Client({});
 
 const PHOTOS_TABLE = process.env.PHOTOS_TABLE ?? "wedding-photos";
 const FACES_TABLE = process.env.FACES_TABLE ?? "wedding-photo-faces";
+const ARCHIVE_TABLE = process.env.ARCHIVE_TABLE ?? "wedding-archive";
 const COLLECTION_ID = process.env.REKOGNITION_COLLECTION_ID ?? "wedding-faces-2026";
 const FACE_MATCH_THRESHOLD = Number(process.env.FACE_MATCH_THRESHOLD ?? "95");
+
+// Admin notification email; unset NOTIFY_TO disables it entirely.
+const NOTIFY_FROM = process.env.NOTIFY_FROM ?? "";
+const NOTIFY_TO = process.env.NOTIFY_TO ?? "";
+const SITE_URL = process.env.SITE_URL ?? "https://oneill.wedding";
+const CDN_URL = process.env.CDN_URL ?? "";
+// One email per burst: a guest selecting 40 photos triggers 40 invocations,
+// but only the first inside this window sends.
+const NOTIFY_DEBOUNCE_MS = 30 * 60 * 1000;
 
 // Upper bound on the original file we will buffer into memory, so a single
 // oversized object cannot OOM-crash the function. Guest uploads are capped at
@@ -285,6 +297,127 @@ async function processPhoto(key: string, bucket: string): Promise<void> {
     if (dogResult.status === "rejected") {
         console.error(`Dog detection failed for ${key} (photo ${photoId}):`, dogResult.reason);
     }
+    try {
+        await notifyAdminOfUpload(code, thumbKey);
+    } catch (err) {
+        console.error(`Upload notification failed for ${key}:`, err);
+    }
+}
+
+// Email the admin that guest photos are waiting for review — at most one
+// email per debounce window, no matter how large the upload burst.
+async function notifyAdminOfUpload(code: string, thumbKey: string): Promise<void> {
+    if (!NOTIFY_TO || !NOTIFY_FROM) return;
+
+    // Guest uploads only: the key's code segment must be a real archived
+    // invitation code. Professional imports use category slugs there, and
+    // the couple's own master code isn't in the archive — both skip.
+    const codeItem = await docClient.send(
+        new GetCommand({
+            TableName: ARCHIVE_TABLE,
+            Key: { PK: `CODE#${code}`, SK: "META" },
+        })
+    );
+    const invitationId = (codeItem.Item as { invitation_id?: number } | undefined)
+        ?.invitation_id;
+    if (invitationId == null) return;
+
+    // Debounce marker lives in the photos table under a reserved id. The
+    // conditional write is atomic: exactly one concurrent invocation wins
+    // the window and sends.
+    const now = Date.now();
+    try {
+        await docClient.send(
+            new UpdateCommand({
+                TableName: PHOTOS_TABLE,
+                Key: { id: "NOTIFICATION#uploads" },
+                UpdateExpression: "SET last_sent_at = :now",
+                ConditionExpression: "attribute_not_exists(last_sent_at) OR last_sent_at < :cutoff",
+                ExpressionAttributeValues: {
+                    ":now": new Date(now).toISOString(),
+                    ":cutoff": new Date(now - NOTIFY_DEBOUNCE_MS).toISOString(),
+                },
+            })
+        );
+    } catch (err) {
+        if (err instanceof ConditionalCheckFailedException) return; // already notified recently
+        throw err;
+    }
+
+    // Household first names for the greeting, pending count for the summary.
+    const [inviteeRows, pending] = await Promise.all([
+        docClient.send(
+            new QueryCommand({
+                TableName: ARCHIVE_TABLE,
+                KeyConditionExpression: "PK = :pk AND begins_with(SK, :sk)",
+                ExpressionAttributeValues: {
+                    ":pk": `INVITATION#${invitationId}`,
+                    ":sk": "INVITEE#",
+                },
+            })
+        ),
+        docClient.send(
+            new QueryCommand({
+                TableName: PHOTOS_TABLE,
+                IndexName: "byStatus",
+                KeyConditionExpression: "#status = :pending",
+                ExpressionAttributeNames: { "#status": "status" },
+                ExpressionAttributeValues: { ":pending": "pending" },
+                Select: "COUNT",
+            })
+        ),
+    ]);
+    const names = ((inviteeRows.Items ?? []) as { first_name: string }[])
+        .map((i) => i.first_name)
+        .sort((a, b) => a.localeCompare(b));
+    const who =
+        names.length > 1
+            ? `${names.slice(0, -1).join(", ")} & ${names[names.length - 1]}`
+            : (names[0] ?? "A guest");
+    const pendingCount = pending.Count ?? 0;
+    const reviewUrl = `${SITE_URL}/dashboard/photos`;
+    const thumbUrl = CDN_URL ? `${CDN_URL}/${thumbKey}` : null;
+
+    await sesClient.send(
+        new SendEmailCommand({
+            FromEmailAddress: `Wedding Gallery <${NOTIFY_FROM}>`,
+            Destination: { ToAddresses: [NOTIFY_TO] },
+            Content: {
+                Simple: {
+                    Subject: {
+                        Data: `${who} shared new wedding photos (${pendingCount} awaiting review)`,
+                    },
+                    Body: {
+                        Text: {
+                            Data:
+                                `${who} just uploaded photos to the gallery.\n\n` +
+                                `${pendingCount} photo${pendingCount === 1 ? "" : "s"} now awaiting review: ${reviewUrl}\n\n` +
+                                `(At most one of these emails per 30 minutes, however many photos arrive.)`,
+                        },
+                        Html: {
+                            Data: `
+<div style="font-family: Georgia, serif; max-width: 480px; margin: 0 auto; color: #495057;">
+  <h2 style="font-weight: 300; color: #8b7355;">New photos in the gallery</h2>
+  <p><strong>${who}</strong> just uploaded photos.</p>
+  ${thumbUrl ? `<img src="${thumbUrl}" alt="" style="max-width: 100%; border-radius: 8px;" />` : ""}
+  <p>${pendingCount} photo${pendingCount === 1 ? "" : "s"} now awaiting review.</p>
+  <p style="margin: 24px 0;">
+    <a href="${reviewUrl}"
+       style="background: #f5b301; color: #fff; padding: 12px 24px; border-radius: 6px; text-decoration: none;">
+      Review photos
+    </a>
+  </p>
+  <p style="color: #adb5bd; font-size: 12px;">
+    At most one of these emails per 30 minutes, however many photos arrive.
+  </p>
+</div>`,
+                        },
+                    },
+                },
+            },
+        })
+    );
+    console.log(`Upload notification sent (${who}, ${pendingCount} pending)`);
 }
 
 // Dog detections make Maggie searchable in the gallery's people search. Each

--- a/infra/lambdas/photo-processor/index.ts
+++ b/infra/lambdas/photo-processor/index.ts
@@ -3,6 +3,7 @@ import { S3Client, GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3
 import sharp from "sharp";
 import heicConvert from "heic-convert";
 import { SESv2Client, SendEmailCommand } from "@aws-sdk/client-sesv2";
+import { SSMClient, GetParameterCommand } from "@aws-sdk/client-ssm";
 import { DynamoDBClient, ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
 import {
     DynamoDBDocumentClient,
@@ -27,6 +28,7 @@ const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({}), {
 });
 const rekognition = new RekognitionClient({});
 const sesClient = new SESv2Client({});
+const ssmClient = new SSMClient({});
 
 const PHOTOS_TABLE = process.env.PHOTOS_TABLE ?? "wedding-photos";
 const FACES_TABLE = process.env.FACES_TABLE ?? "wedding-photo-faces";
@@ -34,14 +36,48 @@ const ARCHIVE_TABLE = process.env.ARCHIVE_TABLE ?? "wedding-archive";
 const COLLECTION_ID = process.env.REKOGNITION_COLLECTION_ID ?? "wedding-faces-2026";
 const FACE_MATCH_THRESHOLD = Number(process.env.FACE_MATCH_THRESHOLD ?? "95");
 
-// Admin notification email; unset NOTIFY_TO disables it entirely.
+// Admin notification email. Recipients live in an SSM parameter (a
+// StringList of addresses) so personal emails never appear in the codebase
+// and the list can be edited in the console without a deploy. Empty or
+// missing parameter disables notifications.
 const NOTIFY_FROM = process.env.NOTIFY_FROM ?? "";
-const NOTIFY_TO = process.env.NOTIFY_TO ?? "";
+const NOTIFY_RECIPIENTS_PARAM = process.env.NOTIFY_RECIPIENTS_PARAM ?? "";
 const SITE_URL = process.env.SITE_URL ?? "https://oneill.wedding";
 const CDN_URL = process.env.CDN_URL ?? "";
 // One email per burst: a guest selecting 40 photos triggers 40 invocations,
 // but only the first inside this window sends.
 const NOTIFY_DEBOUNCE_MS = 30 * 60 * 1000;
+
+// Cache the recipient list across invocations of a warm Lambda; a parameter
+// edit takes effect within this window (or on the next cold start).
+const RECIPIENTS_CACHE_MS = 5 * 60 * 1000;
+let cachedRecipients: string[] | null = null;
+let recipientsCachedAt = 0;
+
+async function getNotifyRecipients(): Promise<string[]> {
+    if (!NOTIFY_RECIPIENTS_PARAM) return [];
+    if (cachedRecipients && Date.now() - recipientsCachedAt < RECIPIENTS_CACHE_MS) {
+        return cachedRecipients;
+    }
+    try {
+        const result = await ssmClient.send(
+            new GetParameterCommand({ Name: NOTIFY_RECIPIENTS_PARAM })
+        );
+        cachedRecipients = (result.Parameter?.Value ?? "")
+            .split(",")
+            .map((a) => a.trim())
+            .filter((a) => a.includes("@"));
+    } catch (err) {
+        // Missing parameter = notifications off; anything else is logged but
+        // must not break photo processing.
+        if ((err as Error).name !== "ParameterNotFound") {
+            console.error("Failed to read notify recipients:", err);
+        }
+        cachedRecipients = [];
+    }
+    recipientsCachedAt = Date.now();
+    return cachedRecipients;
+}
 
 // Upper bound on the original file we will buffer into memory, so a single
 // oversized object cannot OOM-crash the function. Guest uploads are capped at
@@ -307,7 +343,9 @@ async function processPhoto(key: string, bucket: string): Promise<void> {
 // Email the admin that guest photos are waiting for review — at most one
 // email per debounce window, no matter how large the upload burst.
 async function notifyAdminOfUpload(code: string, thumbKey: string): Promise<void> {
-    if (!NOTIFY_TO || !NOTIFY_FROM) return;
+    if (!NOTIFY_FROM) return;
+    const recipients = await getNotifyRecipients();
+    if (recipients.length === 0) return;
 
     // Guest uploads only: the key's code segment must be a real archived
     // invitation code. Professional imports use category slugs there, and
@@ -381,7 +419,7 @@ async function notifyAdminOfUpload(code: string, thumbKey: string): Promise<void
     await sesClient.send(
         new SendEmailCommand({
             FromEmailAddress: `Wedding Gallery <${NOTIFY_FROM}>`,
-            Destination: { ToAddresses: [NOTIFY_TO] },
+            Destination: { ToAddresses: recipients },
             Content: {
                 Simple: {
                     Subject: {

--- a/infra/lib/wedding-stack.ts
+++ b/infra/lib/wedding-stack.ts
@@ -10,6 +10,8 @@ import * as rds from 'aws-cdk-lib/aws-rds';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import * as rekognition from 'aws-cdk-lib/aws-rekognition';
+import * as ses from 'aws-cdk-lib/aws-ses';
+import * as route53 from 'aws-cdk-lib/aws-route53';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
@@ -250,6 +252,23 @@ export class WeddingStack extends cdk.Stack {
       ],
     });
 
+    // ── SES (admin upload notifications) ─────────────────────────────────────
+    // The domain identity lets photos@oneill.wedding send; DKIM CNAMEs land
+    // in the Route53 zone automatically. The account stays in the SES
+    // sandbox, which is fine because the ONLY recipient is the admin — whose
+    // address is verified by the second identity (a confirmation email
+    // arrives on first deploy; click it once).
+    const zone = route53.HostedZone.fromHostedZoneAttributes(this, 'WeddingZone', {
+      hostedZoneId: 'Z0934871XWIQZAKBW951',
+      zoneName: 'oneill.wedding',
+    });
+    new ses.EmailIdentity(this, 'SesDomainIdentity', {
+      identity: ses.Identity.publicHostedZone(zone),
+    });
+    new ses.EmailIdentity(this, 'SesAdminRecipient', {
+      identity: ses.Identity.email('matthew@matthewoneill.com'),
+    });
+
     // ── photo-processor Lambda ───────────────────────────────────────────────
     const photoProcessor = new NodejsFunction(this, 'PhotoProcessor', {
       entry: path.join(__dirname, '../lambdas/photo-processor/index.ts'),
@@ -291,6 +310,11 @@ export class WeddingStack extends cdk.Stack {
         // sunglasses cross-match above it, which chained 44% of all faces
         // into one cluster during the backfill.
         FACE_MATCH_THRESHOLD: '97',
+        ARCHIVE_TABLE: archiveTable.tableName,
+        CDN_URL: `https://${distribution.distributionDomainName}`,
+        NOTIFY_FROM: 'photos@oneill.wedding',
+        NOTIFY_TO: 'matthew@matthewoneill.com',
+        SITE_URL: 'https://oneill.wedding',
       },
     });
     photosBucket.addEventNotification(
@@ -301,6 +325,18 @@ export class WeddingStack extends cdk.Stack {
     photosBucket.grantReadWrite(photoProcessor);
     photosTable.grantReadWriteData(photoProcessor);
     facesTable.grantReadWriteData(photoProcessor);
+    // Read-only: resolving an uploader's code to household names for the
+    // notification email (the archive stays frozen).
+    archiveTable.grantReadData(photoProcessor);
+    photoProcessor.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ['ses:SendEmail'],
+        resources: [
+          `arn:aws:ses:${this.region}:${this.account}:identity/oneill.wedding`,
+          `arn:aws:ses:${this.region}:${this.account}:identity/matthew@matthewoneill.com`,
+        ],
+      })
+    );
     // The dashboard's "Re-match unassigned" button async-invokes the Lambda —
     // the app itself has no Rekognition permissions by design.
     photoProcessor.grantInvoke(apiUser);

--- a/infra/lib/wedding-stack.ts
+++ b/infra/lib/wedding-stack.ts
@@ -254,19 +254,19 @@ export class WeddingStack extends cdk.Stack {
 
     // ── SES (admin upload notifications) ─────────────────────────────────────
     // The domain identity lets photos@oneill.wedding send; DKIM CNAMEs land
-    // in the Route53 zone automatically. The account stays in the SES
-    // sandbox, which is fine because the ONLY recipient is the admin — whose
-    // address is verified by the second identity (a confirmation email
-    // arrives on first deploy; click it once).
+    // in the Route53 zone automatically. Recipients deliberately live OUTSIDE
+    // the codebase, in the SSM parameter /wedding/notify/recipients
+    // (StringList of addresses) — edit it in the console, no deploy needed.
+    // While the account is in the SES sandbox each recipient must also be
+    // verified once:
+    //   aws sesv2 create-email-identity --email-identity someone@example.com
+    // (a confirmation email arrives; click it).
     const zone = route53.HostedZone.fromHostedZoneAttributes(this, 'WeddingZone', {
       hostedZoneId: 'Z0934871XWIQZAKBW951',
       zoneName: 'oneill.wedding',
     });
     new ses.EmailIdentity(this, 'SesDomainIdentity', {
       identity: ses.Identity.publicHostedZone(zone),
-    });
-    new ses.EmailIdentity(this, 'SesAdminRecipient', {
-      identity: ses.Identity.email('matthew@matthewoneill.com'),
     });
 
     // ── photo-processor Lambda ───────────────────────────────────────────────
@@ -313,7 +313,7 @@ export class WeddingStack extends cdk.Stack {
         ARCHIVE_TABLE: archiveTable.tableName,
         CDN_URL: `https://${distribution.distributionDomainName}`,
         NOTIFY_FROM: 'photos@oneill.wedding',
-        NOTIFY_TO: 'matthew@matthewoneill.com',
+        NOTIFY_RECIPIENTS_PARAM: '/wedding/notify/recipients',
         SITE_URL: 'https://oneill.wedding',
       },
     });
@@ -331,9 +331,18 @@ export class WeddingStack extends cdk.Stack {
     photoProcessor.addToRolePolicy(
       new iam.PolicyStatement({
         actions: ['ses:SendEmail'],
+        // Resource = the SENDING identity; recipients aren't IAM resources
+        // (in sandbox they're gated by SES verification instead).
         resources: [
           `arn:aws:ses:${this.region}:${this.account}:identity/oneill.wedding`,
-          `arn:aws:ses:${this.region}:${this.account}:identity/matthew@matthewoneill.com`,
+        ],
+      })
+    );
+    photoProcessor.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ['ssm:GetParameter'],
+        resources: [
+          `arn:aws:ssm:${this.region}:${this.account}:parameter/wedding/notify/*`,
         ],
       })
     );

--- a/infra/package.json
+++ b/infra/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@aws-sdk/client-rekognition": "^3.1090.0",
     "@aws-sdk/client-sesv2": "^3.1090.0",
+    "@aws-sdk/client-ssm": "^3.1090.0",
     "aws-cdk": "^2.200.0",
     "esbuild": "^0.25.0",
     "source-map-support": "^0.5.21",

--- a/infra/package.json
+++ b/infra/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-rekognition": "^3.1090.0",
+    "@aws-sdk/client-sesv2": "^3.1090.0",
     "aws-cdk": "^2.200.0",
     "esbuild": "^0.25.0",
     "source-map-support": "^0.5.21",


### PR DESCRIPTION
When a guest uploads photos, an email lands with the couple: **who** uploaded (household names resolved from their code), a **preview thumbnail**, the **pending-review count**, and a **"Review photos"** button linking straight to `/dashboard/photos`.

## Design

- **No personal addresses in the codebase.** Recipients live in the SSM parameter **`/wedding/notify/recipients`** (comma-separated), read by the Lambda at send time with a 5-minute cache — edit the list in the AWS console and it takes effect without a deploy. An empty or missing parameter disables notifications entirely. The only address in code is the sender, `photos@oneill.wedding`.
- **SES via CDK**: a domain identity for `oneill.wedding` whose DKIM verification CNAMEs are created directly in the Route53 hosted zone — no manual DNS. The account stays in the SES **sandbox** (fine for a couple of known recipients); each recipient is verified once via `aws sesv2 create-email-identity`, outside the codebase.
- **Guest uploads only**: the S3 key's code segment must resolve to an archived invitation code. Professional imports (category-slug paths) and the couple's own master-code uploads skip silently.
- **Debounced to one email per 30 minutes**: a guest selecting 40 photos fires 40 Lambda invocations, but an atomic conditional write on a reserved marker item (`id: NOTIFICATION#uploads` in the photos table — invisible to every GSI query and scan filter in use) means exactly one invocation wins the window and sends. The email says so, and the moderation page shows everything pending regardless.
- **Best-effort**: the notification runs in its own try/catch after face/dog processing — an SES outage can never break the upload pipeline.
- IAM: `ses:SendEmail` scoped to the sending identity; `ssm:GetParameter` scoped to `/wedding/notify/*`; read-only archive access for code→names resolution.

## Rollout (partly done already)

1. ✅ SSM parameter created with both recipients.
2. ✅ Recipient verification emails sent (SES sandbox) — **each recipient clicks their confirmation link**.
3. Merge → `cdk deploy` (domain identity + Lambda + grants); domain DKIM verifies itself within minutes via Route53.
4. Verify end-to-end with a real guest-code upload.

## Testing

Suite: 212 passed; `eslint` clean; infra `tsc` at baseline; `cdk synth` succeeds. (The Lambda has no unit-test harness by existing convention — the debounce and skip logic are exercised in the post-deploy verification.)