### PR TITLE
fix: SES grant covers recipient identities, pinned by sender

### DIFF
--- a/infra/lib/wedding-stack.ts
+++ b/infra/lib/wedding-stack.ts
@@ -331,11 +331,17 @@ export class WeddingStack extends cdk.Stack {
     photoProcessor.addToRolePolicy(
       new iam.PolicyStatement({
         actions: ['ses:SendEmail'],
-        // Resource = the SENDING identity; recipients aren't IAM resources
-        // (in sandbox they're gated by SES verification instead).
-        resources: [
-          `arn:aws:ses:${this.region}:${this.account}:identity/oneill.wedding`,
-        ],
+        // SendEmail authorizes against EVERY identity involved — the sender
+        // AND, while in the sandbox, each verified recipient — and the
+        // recipients are dynamic (SSM parameter), so the resource must be a
+        // wildcard. The FromAddress condition keeps the grant pinned to the
+        // gallery sender: this role can email anyone verified, but only AS
+        // photos@oneill.wedding. (Proved by e2e: the identity-scoped grant
+        // 403'd on the recipient's identity ARN.)
+        resources: [`arn:aws:ses:${this.region}:${this.account}:identity/*`],
+        conditions: {
+          StringEquals: { 'ses:FromAddress': 'photos@oneill.wedding' },
+        },
       })
     );
     photoProcessor.addToRolePolicy(


### PR DESCRIPTION
The #202 e2e test failed with `AccessDeniedException ... ses:SendEmail on resource ...identity/matthew@oneill.to`: SES authorizes `SendEmail` against **every identity involved** — the sender AND, while in the sandbox, each verified **recipient** — not just the sending identity as the original grant assumed. Since recipients are dynamic (the SSM parameter), they can't be enumerated at deploy time.

The grant is now `identity/*` **conditioned on `ses:FromAddress = photos@oneill.wedding`** — the role can email any verified recipient, but only ever *as* the gallery sender, which preserves the meaningful part of the scoping.

Silver lining from the failed test: the debounce-rollback logic added in #202's review pass fired exactly as designed — the marker was handed back (`last_sent_at` gone), so the retest can fire immediately instead of eating a 30-minute window.

`cdk synth` clean; infra `tsc` at baseline. Needs `cdk deploy` after merge, then the e2e retest (re-trigger the existing test photo via S3 self-copy).