### PR TITLE
feat: My uploads sub-filter on the Guest Photos tab

### DIFF
--- a/src/app/api/photos/__tests__/route.test.ts
+++ b/src/app/api/photos/__tests__/route.test.ts
@@ -182,6 +182,27 @@ describe("GET /api/photos", () => {
         expect(mockListUploaderNames).not.toHaveBeenCalled();
     });
 
+    it("mine=1 returns only the caller's own uploads", async () => {
+        mockListPhotosByStatus.mockResolvedValue([
+            { ...mockPhoto, id: "mine-1", invitation_code: "ABC123" },
+            { ...mockPhoto, id: "theirs", invitation_code: "XYZ789" },
+            { ...mockPhoto, id: "professional", invitation_code: undefined },
+        ]);
+        const req = new NextRequest("http://localhost/api/photos?code=ABC123&mine=1");
+        const data = await (await GET(req)).json();
+        expect(data.photos.map((p: { id: string }) => p.id)).toEqual(["mine-1"]);
+        expect(data.total).toBe(1);
+    });
+
+    it("mine=1 without a code returns nothing (admin session, no code)", async () => {
+        mockRequireAuth.mockResolvedValue({ success: true, payload: { email: "admin@test.com" } });
+        mockListPhotosByStatus.mockResolvedValue([mockPhoto]);
+        const req = new NextRequest("http://localhost/api/photos?mine=1");
+        const data = await (await GET(req)).json();
+        expect(data.photos).toEqual([]);
+        expect(data.total).toBe(0);
+    });
+
     it("does not expose sensitive fields to public callers", async () => {
         mockListPhotosByStatus.mockResolvedValue([mockPhoto]);
         const req = new NextRequest("http://localhost/api/photos?code=ABC123");

--- a/src/app/api/photos/route.ts
+++ b/src/app/api/photos/route.ts
@@ -76,6 +76,14 @@ export async function GET(request: NextRequest) {
             matching = matching.filter((p) => personPhotoIds.has(p.id));
         }
 
+        // "My uploads": only photos uploaded under the caller's OWN code —
+        // the same already-validated code that granted access, so there's no
+        // new exposure and no way to view another household's uploads.
+        if (searchParams.get("mine") === "1") {
+            const ownCode = searchParams.get("code")?.trim().toUpperCase();
+            matching = ownCode ? matching.filter((p) => p.invitation_code === ownCode) : [];
+        }
+
         const total = matching.length;
         const rows = matching.slice(offset, offset + limit);
 

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -18,6 +18,7 @@ import {
     Paper,
     TextInput,
     Select,
+    SegmentedControl,
 } from "@mantine/core";
 import { IconAlertCircle, IconDownload, IconTrash, IconSearch } from "@tabler/icons-react";
 import { useSession } from "@/hooks/useSession";
@@ -45,6 +46,9 @@ interface GalleryPhoto {
 }
 
 const FALLBACK_ASPECT = { width: 4, height: 3 };
+
+// The category tab that gets the "My uploads" sub-filter.
+const GUEST_PHOTOS_SLUG = "guest-photos";
 
 // useSearchParams requires a Suspense boundary in App Router client pages.
 export default function GalleryPage() {
@@ -74,6 +78,7 @@ function Gallery() {
     const [rejecting, setRejecting] = useState(false);
     const [people, setPeople] = useState<GalleryPerson[]>([]);
     const [personFilter, setPersonFilter] = useState<string | null>(null);
+    const [myUploadsOnly, setMyUploadsOnly] = useState(false);
     const sentinelRef = useRef<HTMLDivElement | null>(null);
     const { status: sessionStatus, masterCode } = useSession();
     const isAdmin = sessionStatus === "authenticated";
@@ -174,13 +179,14 @@ function Gallery() {
     };
 
     const fetchPhotos = useCallback(
-        async (category: string | null, pg: number, person: string | null) => {
+        async (category: string | null, pg: number, person: string | null, mine: boolean) => {
             setLoading(true);
             setError(null);
             try {
                 const params = new URLSearchParams({ page: String(pg), limit: String(LIMIT) });
                 if (category) params.set("category", category);
                 if (person) params.set("person", person);
+                if (mine) params.set("mine", "1");
                 if (invitationCode) params.set("code", invitationCode);
                 const res = await fetch(`/api/photos?${params}`);
                 if (res.status === 401) {
@@ -231,14 +237,18 @@ function Gallery() {
             .catch(() => {});
     }, [codeChecked, invitationCode, sessionStatus]);
 
+    // The sub-filter only applies on the Guest Photos tab (its state is kept
+    // so flipping tabs and back doesn't lose the selection).
+    const mineActive = myUploadsOnly && activeCategory === GUEST_PHOTOS_SLUG;
+
     useEffect(() => {
         // Don't fetch until code resolution has run, and never fetch without
         // access — the API would just 401.
         if (!codeChecked || (!invitationCode && sessionStatus !== "authenticated")) return;
         setPage(1);
         setPhotos([]);
-        fetchPhotos(activeCategory, 1, personFilter);
-    }, [activeCategory, personFilter, fetchPhotos, codeChecked, invitationCode, sessionStatus]);
+        fetchPhotos(activeCategory, 1, personFilter, mineActive);
+    }, [activeCategory, personFilter, mineActive, fetchPhotos, codeChecked, invitationCode, sessionStatus]);
 
     // Infinite scroll: load the next page when the sentinel scrolls into view.
     // The effect re-runs on every relevant state change so the observer always
@@ -251,14 +261,14 @@ function Gallery() {
                 if (entries[0].isIntersecting) {
                     const next = page + 1;
                     setPage(next);
-                    fetchPhotos(activeCategory, next, personFilter);
+                    fetchPhotos(activeCategory, next, personFilter, mineActive);
                 }
             },
             { rootMargin: "400px" }
         );
         observer.observe(el);
         return () => observer.disconnect();
-    }, [hasMore, loading, page, activeCategory, personFilter, fetchPhotos]);
+    }, [hasMore, loading, page, activeCategory, personFilter, mineActive, fetchPhotos]);
 
     const lightboxSlides = photos.map((p) => ({
         src: p.src,
@@ -418,6 +428,19 @@ function Gallery() {
                         </Tabs.List>
                     </Tabs>
 
+                    {activeCategory === GUEST_PHOTOS_SLUG && (
+                        <SegmentedControl
+                            value={myUploadsOnly ? "mine" : "all"}
+                            onChange={(v) => setMyUploadsOnly(v === "mine")}
+                            data={[
+                                { label: "All guest photos", value: "all" },
+                                { label: "My uploads", value: "mine" },
+                            ]}
+                            size="xs"
+                            w="fit-content"
+                        />
+                    )}
+
                     {loading && photos.length === 0 ? (
                         <Center py="xl">
                             <Loader color="yellow" />
@@ -425,9 +448,11 @@ function Gallery() {
                     ) : photos.length === 0 ? (
                         <Center py="xl">
                             <Text c="dimmed">
-                                {personFilter
-                                    ? "No photos of them here — try All Photos or another section."
-                                    : "No photos yet — be the first to share!"}
+                                {mineActive
+                                    ? "You haven't uploaded any photos yet — tap Upload Photos to share some!"
+                                    : personFilter
+                                      ? "No photos of them here — try All Photos or another section."
+                                      : "No photos yet — be the first to share!"}
                             </Text>
                         </Center>
                     ) : (


### PR DESCRIPTION
On the gallery's **Guest Photos** tab, a small segmented control now offers **All guest photos / My uploads** — the latter shows only photos uploaded under the visitor's own invitation code (their household).

## How it works

- **`mine=1` on `/api/photos`** filters to rows whose `invitation_code` equals the caller's **own, already-validated code** — the same credential that granted gallery access. There is no way to request another household's uploads (the parameter takes no value of its own), and with no code present (an admin session before the master code auto-fills) it returns empty rather than everything. Composes with the category filter as expected.
- **UI**: the control renders only on the Guest Photos tab; the selection threads through pagination and infinite scroll, survives switching tabs and back (it simply doesn't apply elsewhere), and an empty "My uploads" view says "You haven't uploaded any photos yet — tap Upload Photos to share some!" instead of the generic message.
- For the couple, the master code's "My uploads" shows their own uploads — consistent semantics for free.

## Testing

2 new route tests: own-code filtering (other codes and code-less professional rows excluded, `total` correct) and the no-code empty case. Suite: 214 passed; `tsc` + `eslint` clean. Amplify deploys on merge — no infra.