### PR TITLE
fix: photo flow reflects who actually attended

### DIFF
--- a/src/app/api/photos/__tests__/route.test.ts
+++ b/src/app/api/photos/__tests__/route.test.ts
@@ -182,6 +182,17 @@ describe("GET /api/photos", () => {
         expect(mockListUploaderNames).not.toHaveBeenCalled();
     });
 
+    it("professional=1 excludes guest uploads (the gallery's All Photos tab)", async () => {
+        mockListPhotosByStatus.mockResolvedValue([
+            { ...mockPhoto, id: "guest-upload", invitation_code: "ABC123" },
+            { ...mockPhoto, id: "professional", invitation_code: undefined },
+        ]);
+        const req = new NextRequest("http://localhost/api/photos?code=ABC123&professional=1");
+        const data = await (await GET(req)).json();
+        expect(data.photos.map((p: { id: string }) => p.id)).toEqual(["professional"]);
+        expect(data.total).toBe(1);
+    });
+
     it("mine=1 returns only the caller's own uploads", async () => {
         mockListPhotosByStatus.mockResolvedValue([
             { ...mockPhoto, id: "mine-1", invitation_code: "ABC123" },

--- a/src/app/api/photos/route.ts
+++ b/src/app/api/photos/route.ts
@@ -76,6 +76,15 @@ export async function GET(request: NextRequest) {
             matching = matching.filter((p) => personPhotoIds.has(p.id));
         }
 
+        // Guest uploads belong on the Guest Photos tab only: the gallery's
+        // All Photos tab sends professional=1 to keep them out of the
+        // professional sets. Opt-in per request (not blanket) because the
+        // moderation dashboard hits this same endpoint and must always see
+        // guest uploads.
+        if (searchParams.get("professional") === "1") {
+            matching = matching.filter((p) => !p.invitation_code);
+        }
+
         // "My uploads": only photos uploaded under the caller's OWN code —
         // the same already-validated code that granted access, so there's no
         // new exposure and no way to view another household's uploads.

--- a/src/app/dashboard/invitations/page.tsx
+++ b/src/app/dashboard/invitations/page.tsx
@@ -58,7 +58,7 @@ export default function InvitationsPage() {
                     Photo Gallery Codes
                 </Title>
                 <Text size="lg" style={{ color: "#6c757d" }}>
-                    Photo upload access codes for each invitation
+                    Photo upload access codes for each invitation with attending guests
                 </Text>
             </Box>
 

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -185,6 +185,9 @@ function Gallery() {
             try {
                 const params = new URLSearchParams({ page: String(pg), limit: String(LIMIT) });
                 if (category) params.set("category", category);
+                // The All Photos tab shows the professional sets only —
+                // guest uploads live on the Guest Photos tab.
+                else params.set("professional", "1");
                 if (person) params.set("person", person);
                 if (mine) params.set("mine", "1");
                 if (invitationCode) params.set("code", invitationCode);

--- a/src/utils/db/__tests__/archive.test.ts
+++ b/src/utils/db/__tests__/archive.test.ts
@@ -11,8 +11,10 @@ import {
     isMasterCode,
     isValidInvitationCode,
     getInviteesByCode,
+    getInviteesWithIds,
     listAllInvitees,
     listUploaderNames,
+    listInvitationCodes,
 } from "../archive";
 
 const savedMaster = process.env.MASTER_INVITATION_CODE;
@@ -55,6 +57,33 @@ describe("master invitation code", () => {
         expect(await getInviteesByCode("LOCAL1")).toEqual(["Matthew", "Rebecca"]);
         expect(mockSend).not.toHaveBeenCalled();
     });
+
+    it("names only the attending invitees behind a guest code", async () => {
+        mockSend
+            .mockResolvedValueOnce({ Item: { entity: "code", code: "ABC123", invitation_id: 3 } })
+            .mockResolvedValueOnce({
+                Items: [
+                    { entity: "invitee", id: 7, invitation_id: 3, first_name: "Alice", last_name: "Byrne", coming: true },
+                    { entity: "invitee", id: 8, invitation_id: 3, first_name: "John", last_name: "Byrne", coming: false },
+                    { entity: "invitee", id: 9, invitation_id: 3, first_name: "Pat", last_name: "Byrne", coming: null },
+                ],
+            });
+        expect(await getInviteesByCode("ABC123")).toEqual(["Alice"]);
+    });
+});
+
+describe("getInviteesWithIds", () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it("returns only invitees who came", async () => {
+        mockSend.mockResolvedValue({
+            Items: [
+                { entity: "invitee", id: 7, invitation_id: 3, first_name: "Alice", last_name: "Byrne", coming: true },
+                { entity: "invitee", id: 8, invitation_id: 3, first_name: "John", last_name: "Byrne", coming: false },
+            ],
+        });
+        expect(await getInviteesWithIds(3)).toEqual([{ id: 7, first_name: "Alice" }]);
+    });
 });
 
 describe("listUploaderNames", () => {
@@ -67,15 +96,19 @@ describe("listUploaderNames", () => {
         else process.env.MASTER_INVITATION_CODE = savedMaster;
     });
 
-    it("maps codes to household first names, never exposing the code in values", async () => {
+    it("maps codes to attending first names, never exposing the code in values", async () => {
         mockSend.mockResolvedValue({
             Items: [
                 { entity: "code", code: "ABC123", invitation_id: 3 },
                 { entity: "code", code: "SOLO01", invitation_id: 4 },
                 { entity: "code", code: "EMPTY0", invitation_id: 5 }, // no invitees
-                { entity: "invitee", id: 7, invitation_id: 3, first_name: "Brian", last_name: "Byrne" },
-                { entity: "invitee", id: 8, invitation_id: 3, first_name: "Aoife", last_name: "Byrne" },
-                { entity: "invitee", id: 9, invitation_id: 4, first_name: "Cara", last_name: "Kelly" },
+                { entity: "code", code: "NOPE01", invitation_id: 6 }, // declined household
+                { entity: "invitee", id: 7, invitation_id: 3, first_name: "Brian", last_name: "Byrne", coming: true },
+                { entity: "invitee", id: 8, invitation_id: 3, first_name: "Aoife", last_name: "Byrne", coming: true },
+                // Declined their spot — must not appear in the attribution.
+                { entity: "invitee", id: 10, invitation_id: 3, first_name: "John", last_name: "Byrne", coming: false },
+                { entity: "invitee", id: 9, invitation_id: 4, first_name: "Cara", last_name: "Kelly", coming: true },
+                { entity: "invitee", id: 11, invitation_id: 6, first_name: "Derek", last_name: "Nolan", coming: false },
             ],
         });
 
@@ -84,6 +117,7 @@ describe("listUploaderNames", () => {
         expect(uploaders.get("ABC123")).toBe("Aoife & Brian");
         expect(uploaders.get("SOLO01")).toBe("Cara");
         expect(uploaders.has("EMPTY0")).toBe(false);
+        expect(uploaders.has("NOPE01")).toBe(false);
         expect(uploaders.get("LOCAL1")).toBe("Matthew & Rebecca");
         // Display values are names only — a code appearing in a value would
         // leak the site's access credential into public payloads.
@@ -96,6 +130,38 @@ describe("listUploaderNames", () => {
         delete process.env.MASTER_INVITATION_CODE;
         mockSend.mockResolvedValue({ Items: [] });
         expect((await listUploaderNames()).size).toBe(0);
+    });
+});
+
+describe("listInvitationCodes", () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it("lists only attending households, with attending names only", async () => {
+        mockSend.mockResolvedValue({
+            Items: [
+                { entity: "invitation", id: 3, is_matthew_side: true, sent: true, villa_offered: false },
+                { entity: "invitation", id: 6, is_matthew_side: false, sent: true, villa_offered: false },
+                { entity: "code", code: "ABC123", invitation_id: 3 },
+                { entity: "code", code: "NOPE01", invitation_id: 6 },
+                { entity: "invitee", id: 7, invitation_id: 3, first_name: "Alice", last_name: "Byrne", coming: true },
+                { entity: "invitee", id: 8, invitation_id: 3, first_name: "John", last_name: "Byrne", coming: false },
+                { entity: "invitee", id: 11, invitation_id: 6, first_name: "Derek", last_name: "Nolan", coming: false },
+                { entity: "invitee", id: 12, invitation_id: 6, first_name: "Ena", last_name: "Nolan", coming: null },
+            ],
+        });
+
+        const codes = await listInvitationCodes();
+
+        // Invitation 6 declined/never replied — no photo link row at all;
+        // invitation 3 shows only Alice, not John who didn't come.
+        expect(codes).toEqual([
+            {
+                code: "ABC123",
+                invitation_id: 3,
+                is_matthew_side: true,
+                invitee_names: ["Alice Byrne"],
+            },
+        ]);
     });
 });
 

--- a/src/utils/db/archive.ts
+++ b/src/utils/db/archive.ts
@@ -95,7 +95,9 @@ export async function getInvitationIdByCode(code: string): Promise<number | null
     return (result.Item as CodeItem | undefined)?.invitation_id ?? null;
 }
 
-// The invitees of an invitation with their ids, for face-match lookups.
+// The attending invitees of an invitation with their ids, for face-match
+// lookups. Invitees who didn't come have no faces in the photos and
+// shouldn't be named in the photo flow.
 export async function getInviteesWithIds(
     invitationId: number
 ): Promise<{ id: number; first_name: string }[]> {
@@ -110,13 +112,15 @@ export async function getInviteesWithIds(
         })
     );
     return ((result.Items ?? []) as InviteeItem[])
+        .filter((i) => i.coming === true)
         .map((i) => ({ id: i.id, first_name: i.first_name }))
         .sort((a, b) => a.first_name.localeCompare(b.first_name));
 }
 
-// First names of the invitees behind a code, or null when the code doesn't
-// exist. Returning names behind a valid code is fine — the code is the
-// guest's credential.
+// First names of the attending invitees behind a code, or null when the code
+// doesn't exist. Only guests who RSVP'd yes are named — "Alice & John"
+// becomes just "Alice" when John didn't come. Returning names behind a valid
+// code is fine — the code is the guest's credential.
 export async function getInviteesByCode(code: string): Promise<string[] | null> {
     if (isMasterCode(code)) return COUPLE_INVITEES.map((c) => c.name.split(" ")[0]);
     const codeResult = await docClient.send(
@@ -139,7 +143,10 @@ export async function getInviteesByCode(code: string): Promise<string[] | null> 
         })
     );
     const invitees = (result.Items ?? []) as InviteeItem[];
-    return invitees.map((i) => i.first_name).sort((a, b) => a.localeCompare(b));
+    return invitees
+        .filter((i) => i.coming === true)
+        .map((i) => i.first_name)
+        .sort((a, b) => a.localeCompare(b));
 }
 
 async function scanArchive(): Promise<ArchiveItem[]> {
@@ -211,15 +218,17 @@ function joinFirstNames(names: string[]): string {
 }
 
 // Upload attribution: display names for the household behind each invitation
-// code ("Aoife & Brian"), plus the master code mapped to the couple. Guest
-// uploads carry their code on the photo row; photos without a code (the
-// professional imports) simply aren't in this map. One archive scan.
+// code ("Aoife & Brian"), plus the master code mapped to the couple. Only
+// guests who actually came are named — an invitee who declined shouldn't
+// appear in photo captions. Guest uploads carry their code on the photo row;
+// photos without a code (the professional imports) simply aren't in this
+// map. One archive scan.
 export async function listUploaderNames(): Promise<Map<string, string>> {
     const items = await scanArchive();
 
     const firstNamesByInvitation = new Map<number, string[]>();
     for (const item of items) {
-        if (item.entity !== "invitee") continue;
+        if (item.entity !== "invitee" || item.coming !== true) continue;
         const names = firstNamesByInvitation.get(item.invitation_id) ?? [];
         names.push(item.first_name);
         firstNamesByInvitation.set(item.invitation_id, names);
@@ -280,9 +289,14 @@ export async function listInvitationCodes(): Promise<InvitationCodeSummary[]> {
         }
     }
 
+    // Only households with at least one attending guest get a row — there's
+    // no point handing a photo link to an invitation that declined (or never
+    // replied), and the names shown are the attending guests only.
     return codes
         .map((c) => {
-            const invitees = inviteesByInvitation.get(c.invitation_id) ?? [];
+            const invitees = (inviteesByInvitation.get(c.invitation_id) ?? []).filter(
+                (i) => i.coming === true
+            );
             invitees.sort((a, b) => a.first_name.localeCompare(b.first_name));
             return {
                 code: c.code,
@@ -291,5 +305,6 @@ export async function listInvitationCodes(): Promise<InvitationCodeSummary[]> {
                 invitee_names: invitees.map((i) => `${i.first_name} ${i.last_name}`),
             };
         })
+        .filter((c) => c.invitee_names.length > 0)
         .sort((a, b) => a.invitation_id - b.invitation_id);
 }


### PR DESCRIPTION
## Problems

1. Photo upload attribution used every invitee on an invitation, so a household where only Alice RSVP'd yes still uploaded as "Alice & John".
2. The dashboard invitations tab listed a photo link for every invitation, including ones that declined or never replied.
3. Guest uploads appeared on the gallery's All Photos tab alongside the professional sets.

## Changes

- `archive.ts`: `getInviteesByCode`, `getInviteesWithIds`, and `listUploaderNames` now include only invitees with `coming = true`. This covers the upload-page greeting, photo captions (`uploaded_by`), and the Find My Photos household list.
- `listInvitationCodes` drops households with no attending guests and lists attending names only, so the dashboard tab shows photo links just for invitations that accepted.
- `/api/photos` gains a `professional=1` param that filters out rows carrying an invitation code; the gallery's All Photos tab sends it. It is opt-in per request because the moderation dashboard uses the same endpoint and must keep seeing guest uploads.
- Tests: new coverage for attendance filtering in all four archive functions and for `professional=1`; existing fixtures updated with `coming` flags.

Invitees with `coming = null` (never replied) are treated as not attending throughout.