### PR TITLE
chore: localstack community image (pinned to 4.x)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,25 @@
-# LocalStack for local development of the AWS-backed features (S3, RDS Data API,
-# Cognito). Requires a LocalStack Base+ subscription — set LOCALSTACK_AUTH_TOKEN
-# in your shell or a local .env file before `docker compose up`.
+# LocalStack for local development of the AWS-backed features (S3, DynamoDB).
+# Community image — no subscription/token needed. Cognito is a paid-tier
+# feature, so admin dashboard login isn't available locally; the guest flows
+# (gallery, uploads, invitation codes) work fully.
 #
-#   export LOCALSTACK_AUTH_TOKEN=ls-...
+# Pinned to the 4.x line: from 2026 the unified `latest` image demands an
+# auth token even for free usage (its setup_pro_infra hook exits with code
+# 55 when no LOCALSTACK_AUTH_TOKEN is set); 4.x is the last tokenless line.
+#
 #   npm run localstack:up
 #   npm run localstack:bootstrap
-#   npm run dev:local
+#   npm run dev
 services:
   localstack:
-    image: localstack/localstack-pro:latest
+    image: localstack/localstack:4
     container_name: wedding-localstack
     ports:
       - "4566:4566" # edge gateway (all services)
     environment:
-      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:?LOCALSTACK_AUTH_TOKEN must be set (LocalStack Base+ token)}
       - DEBUG=${LOCALSTACK_DEBUG:-0}
-      # Persist state across restarts so you don't have to re-bootstrap every time.
-      # Note: RDS persistence is "limited support" on LocalStack — if the DB looks
-      # empty after a restart, re-run `npm run localstack:bootstrap`.
-      - PERSISTENCE=1
+      # Persistence is a paid-tier feature: the community image starts empty
+      # every time, so re-run `npm run localstack:bootstrap` after a restart.
     volumes:
       - "./.localstack:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -2,29 +2,32 @@
 
 The app depends on three AWS services — **S3** (photo storage / presigned URLs),
 **DynamoDB** (all database access), and **Cognito** (admin
-auth). For local development these are emulated with [LocalStack](https://localstack.cloud),
-so you can run the full stack — including the photo gallery — without touching
-real AWS.
+auth). For local development S3 and DynamoDB are emulated with the free
+[LocalStack](https://localstack.cloud) **community image**, so the guest flows —
+gallery, uploads, invitation codes — run without touching real AWS.
+
+Cognito is a LocalStack paid-tier feature, so **admin dashboard login is not
+available locally** on the community image. Photo approval has a CLI stand-in
+(below); anything else admin-only needs the paid tier (the bootstrap script
+still provisions Cognito automatically when it's available).
 
 ## Prerequisites
 
-- **Docker** running (Docker Desktop or colima).
-- A **LocalStack Base+ subscription**. Cognito is a paid-tier feature (S3 and
-  DynamoDB are free-tier). After subscribing, copy your auth token from the
-  LocalStack dashboard.
+- **Docker** running (Docker Desktop or colima). No LocalStack account or
+  token needed.
 
-## One-time setup
+## Setup
 
 ```bash
-# 1. Make your LocalStack token available (shell, or a local .env for compose)
-export LOCALSTACK_AUTH_TOKEN=ls-...
-
-# 2. Start LocalStack
+# 1. Start LocalStack
 npm run localstack:up
 
-# 3. Provision resources and seed test data
+# 2. Provision resources and seed test data
 npm run localstack:bootstrap
 ```
+
+State does **not** persist across container restarts on the community image —
+re-run `npm run localstack:bootstrap` after every `localstack:up`.
 
 `bootstrap` is idempotent-ish and creates:
 
@@ -34,10 +37,11 @@ npm run localstack:bootstrap
   GSIs), and `wedding-photo-categories` — plus seed items:
   - invitation code **`TEST01`**
   - the seven photo categories
-- A Cognito user pool with a confirmed admin user
+- On the paid tier only: a Cognito user pool with a confirmed admin user
+  (skipped with a warning on the community image)
 
-It writes everything it discovers (table names, Cognito IDs/secret) to
-**`.env.localstack`** (git-ignored).
+It writes everything it discovers (table names, and Cognito IDs/secret when
+provisioned) to **`.env.localstack`** (git-ignored).
 
 ## Running the app
 
@@ -45,8 +49,9 @@ It writes everything it discovers (table names, Cognito IDs/secret) to
 npm run dev      # Next.js on http://localhost:3022, wired to LocalStack
 ```
 
-- **Admin login:** `admin@oneill.wedding` / `WeddingLocal123!`
 - **Invitation code (uploads):** `TEST01`
+- **Admin login:** unavailable on the community image (paid tier only:
+  `admin@oneill.wedding` / `WeddingLocal123!`)
 
 ## Photo gallery flow
 
@@ -55,13 +60,14 @@ on demand:
 
 ```bash
 # 1. Upload a photo at /gallery/upload using code TEST01
-# 2. Generate thumbnails (emulates the photo-processor Lambda)
-npm run localstack:process
-# 3. Approve it in /dashboard/photos
-# 4. View it in /gallery
+# 2. Generate thumbnails (emulates the photo-processor Lambda) and approve
+#    them in one go — there's no admin login locally to do it in the dashboard
+npm run localstack:process -- --approve
+# 3. View it in /gallery
 ```
 
-You can also approve a photo directly without logging in:
+Omit `--approve` to leave photos pending (e.g. to exercise the pending state).
+You can also approve a photo directly:
 
 ```bash
 # Find the pending photo's id
@@ -87,8 +93,8 @@ LocalStack stamps into its tokens. None of these affect production behaviour.
 ## Teardown
 
 ```bash
-npm run localstack:down    # stop the container (state persists in ./.localstack)
+npm run localstack:down    # stop the container
 ```
 
-If the DynamoDB tables look empty after a restart, just re-run
-`npm run localstack:bootstrap`.
+The community image doesn't persist state, so every fresh start needs
+`npm run localstack:bootstrap` again.

--- a/scripts/localstack/bootstrap.sh
+++ b/scripts/localstack/bootstrap.sh
@@ -141,24 +141,33 @@ seed_category "cat-rebecca-and-matthew" "Rebecca & Matthew"  "rebecca-and-matthe
 seed_category "cat-guest-photos"        "Guest Photos"       "guest-photos"        7
 
 # ----------------------------------------------------------------------------
-# Cognito — user pool, app client (with secret), confirmed admin user
+# Cognito — user pool, app client (with secret), confirmed admin user.
+# Paid-tier only: on the community image the calls fail and we skip admin
+# auth entirely (guest flows don't need it).
 # ----------------------------------------------------------------------------
 echo "→ Creating Cognito user pool + admin user (${ADMIN_EMAIL})..."
-POOL_ID="$(awsl cognito-idp create-user-pool --pool-name wedding-local \
-  --query 'UserPool.Id' --output text)"
+POOL_ID=""
+CLIENT_ID=""
+CLIENT_SECRET=""
+if POOL_ID="$(awsl cognito-idp create-user-pool --pool-name wedding-local \
+  --query 'UserPool.Id' --output text 2>/dev/null)"; then
+  CLIENT_JSON="$(awsl cognito-idp create-user-pool-client \
+    --user-pool-id "$POOL_ID" --client-name web --generate-secret \
+    --explicit-auth-flows ALLOW_USER_PASSWORD_AUTH ALLOW_REFRESH_TOKEN_AUTH ALLOW_USER_SRP_AUTH \
+    --output json)"
+  CLIENT_ID="$(printf '%s' "$CLIENT_JSON" | python3 -c 'import sys,json;print(json.load(sys.stdin)["UserPoolClient"]["ClientId"])')"
+  CLIENT_SECRET="$(printf '%s' "$CLIENT_JSON" | python3 -c 'import sys,json;print(json.load(sys.stdin)["UserPoolClient"]["ClientSecret"])')"
 
-CLIENT_JSON="$(awsl cognito-idp create-user-pool-client \
-  --user-pool-id "$POOL_ID" --client-name web --generate-secret \
-  --explicit-auth-flows ALLOW_USER_PASSWORD_AUTH ALLOW_REFRESH_TOKEN_AUTH ALLOW_USER_SRP_AUTH \
-  --output json)"
-CLIENT_ID="$(printf '%s' "$CLIENT_JSON" | python3 -c 'import sys,json;print(json.load(sys.stdin)["UserPoolClient"]["ClientId"])')"
-CLIENT_SECRET="$(printf '%s' "$CLIENT_JSON" | python3 -c 'import sys,json;print(json.load(sys.stdin)["UserPoolClient"]["ClientSecret"])')"
-
-awsl cognito-idp admin-create-user --user-pool-id "$POOL_ID" \
-  --username "$ADMIN_EMAIL" --message-action SUPPRESS \
-  --user-attributes Name=email,Value="$ADMIN_EMAIL" Name=email_verified,Value=true >/dev/null
-awsl cognito-idp admin-set-user-password --user-pool-id "$POOL_ID" \
-  --username "$ADMIN_EMAIL" --password "$ADMIN_PASSWORD" --permanent >/dev/null
+  awsl cognito-idp admin-create-user --user-pool-id "$POOL_ID" \
+    --username "$ADMIN_EMAIL" --message-action SUPPRESS \
+    --user-attributes Name=email,Value="$ADMIN_EMAIL" Name=email_verified,Value=true >/dev/null
+  awsl cognito-idp admin-set-user-password --user-pool-id "$POOL_ID" \
+    --username "$ADMIN_EMAIL" --password "$ADMIN_PASSWORD" --permanent >/dev/null
+else
+  POOL_ID=""
+  echo "  ⚠ Cognito unavailable (paid-tier feature — fine on the community image)."
+  echo "    Skipping admin auth: dashboard login won't work locally."
+fi
 
 # ----------------------------------------------------------------------------
 # Write .env.localstack
@@ -191,27 +200,38 @@ DDB_ARCHIVE_TABLE=${ARCHIVE_TABLE}
 DDB_PHOTOS_TABLE=${PHOTOS_TABLE}
 DDB_CATEGORIES_TABLE=${CATEGORIES_TABLE}
 
+# Don't throttle uploads locally
+DISABLE_RATE_LIMITING=true
+EOF
+
+if [ -n "$POOL_ID" ]; then
+cat >> "$ENV_FILE" <<EOF
+
 # Cognito (admin auth)
 COGNITO_USER_POOL_ID=${POOL_ID}
 COGNITO_CLIENT_ID=${CLIENT_ID}
 COGNITO_CLIENT_SECRET=${CLIENT_SECRET}
 COGNITO_ISSUER=${ISSUER_ENDPOINT}/${POOL_ID}
-
-# Don't throttle uploads locally
-DISABLE_RATE_LIMITING=true
 EOF
+fi
+
+if [ -n "$POOL_ID" ]; then
+  ADMIN_LINE="Admin login:     ${ADMIN_EMAIL} / ${ADMIN_PASSWORD}"
+else
+  ADMIN_LINE="Admin login:     unavailable (Cognito needs the paid LocalStack tier)"
+fi
 
 cat <<EOF
 
 ✅ LocalStack bootstrapped.
 
-   Admin login:     ${ADMIN_EMAIL} / ${ADMIN_PASSWORD}
+   ${ADMIN_LINE}
    Invitation code: ${SEED_CODE}
    Bucket:          ${BUCKET}
 
 Next:
    npm run dev                             # start Next.js against LocalStack
    # upload a photo at /gallery/upload using code ${SEED_CODE}
-   npm run localstack:process              # generate thumbnails (emulates the Lambda)
-   # approve it in /dashboard/photos, then view it in /gallery
+   npm run localstack:process -- --approve # thumbnails + approval (emulates Lambda + dashboard)
+   # then view it in /gallery
 EOF

--- a/scripts/localstack/process-photos.mjs
+++ b/scripts/localstack/process-photos.mjs
@@ -6,6 +6,10 @@
 // a 1200px JPEG thumbnail (EXIF stripped), upload it, and backfill the item.
 //
 // Run via: npm run localstack:process  (loads .env.localstack)
+//
+// Pass --approve to also mark the processed photos approved. The community
+// LocalStack image has no Cognito, so there's no admin session to approve
+// uploads in /dashboard/photos — this is the local stand-in for that step.
 
 import { S3Client, GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
@@ -19,6 +23,8 @@ const photosTable = process.env.DDB_PHOTOS_TABLE ?? "wedding-photos";
 
 const s3 = new S3Client({ region, endpoint, forcePathStyle: true });
 const docClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region, endpoint }));
+
+const approve = process.argv.includes("--approve");
 
 async function streamToBuffer(stream) {
     const chunks = [];
@@ -62,11 +68,20 @@ for (const { id, s3_key: key } of pending) {
             new UpdateCommand({
                 TableName: photosTable,
                 Key: { id },
-                UpdateExpression: "SET thumbnail_key = :thumb, width = :w, height = :h",
-                ExpressionAttributeValues: { ":thumb": thumbKey, ":w": info.width, ":h": info.height },
+                // "status" is a DynamoDB reserved word, hence the #st alias.
+                UpdateExpression: approve
+                    ? "SET thumbnail_key = :thumb, width = :w, height = :h, #st = :approved"
+                    : "SET thumbnail_key = :thumb, width = :w, height = :h",
+                ...(approve && { ExpressionAttributeNames: { "#st": "status" } }),
+                ExpressionAttributeValues: {
+                    ":thumb": thumbKey,
+                    ":w": info.width,
+                    ":h": info.height,
+                    ...(approve && { ":approved": "approved" }),
+                },
             })
         );
-        console.log(`✓ processed ${key} → ${thumbKey}`);
+        console.log(`✓ processed ${key} → ${thumbKey}${approve ? " (approved)" : ""}`);
     } catch (err) {
         console.error(`✗ failed ${key}:`, err.message);
     }


### PR DESCRIPTION
Following the LocalStack subscription downgrade (the paid tier was only needed for the RDBMS days plus Cognito), local development now runs on the free community image.

- **`localstack/localstack:4`** (pinned): the 2026 unified `latest` image exits with code 55 demanding an auth token even for free usage — its `setup_pro_infra` hook runs unconditionally. The 4.x line is the last that works anonymously; S3 and DynamoDB verified working on 4.14.0.
- **Bootstrap degrades gracefully without Cognito**: the pool/client/admin-user provisioning is attempted and skipped with a clear warning on the community image, and the Cognito block is omitted from `.env.localstack`. Admin dashboard login is therefore unavailable locally; guest flows (gallery, uploads, codes) are unaffected. Paid-tier users still get the full setup automatically.
- **`npm run localstack:process -- --approve`**: the thumbnail processor can now also mark photos approved, standing in for dashboard moderation since there's no local admin session.
- **No persistence** on the community image — compose drops `PERSISTENCE=1` and the docs now say to re-run bootstrap after each container start.
- `LOCAL_DEVELOPMENT.md` updated (no token/subscription prerequisite, new approval flow, persistence caveat).

Verified end-to-end: container starts with no token, bootstrap provisions S3 + all three DynamoDB tables + seeds, and skips Cognito with the warning.