### PR TITLE
fix: category card covers, highlight, and person-search interplay

### DIFF
--- a/src/app/api/gallery/categories/__tests__/route.test.ts
+++ b/src/app/api/gallery/categories/__tests__/route.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { GET } from "../route";
+
+const mockListCategories = vi.fn();
+const mockGetPhotoById = vi.fn();
+const mockListPhotosByStatus = vi.fn();
+
+vi.mock("@/utils/db/categories", () => ({
+    listCategories: (...args: unknown[]) => mockListCategories(...args),
+    createCategory: vi.fn(),
+}));
+
+vi.mock("@/utils/db/photos", () => ({
+    getPhotoById: (...args: unknown[]) => mockGetPhotoById(...args),
+    listPhotosByStatus: (...args: unknown[]) => mockListPhotosByStatus(...args),
+}));
+
+vi.mock("@/utils/auth/requireAuth", () => ({
+    requireAuth: vi.fn(),
+}));
+
+vi.mock("@/utils/storage", () => ({
+    cdnUrl: (k: string) => `https://cdn/${k}`,
+}));
+
+const category = (id: string, cover_photo_id: string | null = null) => ({
+    id,
+    name: id,
+    slug: id,
+    description: null,
+    event_day: null,
+    cover_photo_id,
+    sort_order: 1,
+});
+
+describe("GET /api/gallery/categories", () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it("uses the curated cover photo when set", async () => {
+        mockListCategories.mockResolvedValue([category("cat-1", "photo-9")]);
+        mockGetPhotoById.mockResolvedValue({ id: "photo-9", thumbnail_key: "thumb/9.jpg" });
+
+        const data = await (await GET()).json();
+
+        expect(data.categories[0].cover_thumbnail_url).toBe("https://cdn/thumb/9.jpg");
+        // Every category has a curated cover — no fallback query needed.
+        expect(mockListPhotosByStatus).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the newest approved photo when no cover is curated", async () => {
+        mockListCategories.mockResolvedValue([category("cat-1"), category("cat-2")]);
+        // uploaded_at DESC, as listPhotosByStatus returns them.
+        mockListPhotosByStatus.mockResolvedValue([
+            { id: "p3", category_id: "cat-1", thumbnail_key: "thumb/newest.jpg" },
+            { id: "p2", category_id: "cat-1", thumbnail_key: "thumb/older.jpg" },
+            { id: "p1", category_id: "cat-2", thumbnail_key: null }, // unprocessed
+        ]);
+
+        const data = await (await GET()).json();
+
+        const byId = Object.fromEntries(
+            data.categories.map((c: { id: string; cover_thumbnail_url: string | null }) => [
+                c.id,
+                c.cover_thumbnail_url,
+            ])
+        );
+        expect(byId["cat-1"]).toBe("https://cdn/thumb/newest.jpg");
+        // No approved processed photo in the category → still no cover.
+        expect(byId["cat-2"]).toBeNull();
+        expect(mockListPhotosByStatus).toHaveBeenCalledWith("approved");
+    });
+});

--- a/src/app/api/gallery/categories/route.ts
+++ b/src/app/api/gallery/categories/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { listCategories, createCategory } from "@/utils/db/categories";
-import { getPhotoById } from "@/utils/db/photos";
+import { getPhotoById, listPhotosByStatus } from "@/utils/db/photos";
 import { requireAuth } from "@/utils/auth/requireAuth";
 import { cdnUrl } from "@/utils/storage";
 import type { PhotoCategory } from "@/types/photos";
@@ -9,11 +9,24 @@ export async function GET() {
     try {
         const rows = await listCategories();
 
+        // Categories without a curated cover fall back to their newest
+        // approved photo, so the gallery's category cards never render blank.
+        const fallbackByCategory = new Map<string, string>();
+        if (rows.some((r) => !r.cover_photo_id)) {
+            for (const p of await listPhotosByStatus("approved")) {
+                // First hit wins — photos arrive uploaded_at DESC.
+                if (p.category_id && p.thumbnail_key && !fallbackByCategory.has(p.category_id)) {
+                    fallbackByCategory.set(p.category_id, p.thumbnail_key);
+                }
+            }
+        }
+
         // Resolve cover thumbnails from the photos table (few categories, so
         // per-cover lookups are fine).
         const categories: PhotoCategory[] = await Promise.all(
             rows.map(async (r) => {
                 const cover = r.cover_photo_id ? await getPhotoById(r.cover_photo_id) : null;
+                const thumbKey = cover?.thumbnail_key ?? fallbackByCategory.get(r.id) ?? null;
                 return {
                     id: r.id,
                     name: r.name,
@@ -22,7 +35,7 @@ export async function GET() {
                     event_day: r.event_day,
                     cover_photo_id: r.cover_photo_id,
                     sort_order: r.sort_order,
-                    cover_thumbnail_url: cover?.thumbnail_key ? cdnUrl(cover.thumbnail_key) : null,
+                    cover_thumbnail_url: thumbKey ? cdnUrl(thumbKey) : null,
                 };
             })
         );

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -195,8 +195,9 @@ function Gallery() {
                 const params = new URLSearchParams({ page: String(pg), limit: String(LIMIT) });
                 if (category) params.set("category", category);
                 // The All Photos tab shows the professional sets only —
-                // guest uploads live on the Guest Photos tab.
-                else params.set("professional", "1");
+                // guest uploads live on the Guest Photos tab. A person search
+                // is the exception: it spans everything, guest uploads too.
+                else if (!person) params.set("professional", "1");
                 if (person) params.set("person", person);
                 if (mine) params.set("mine", "1");
                 if (invitationCode) params.set("code", invitationCode);
@@ -426,7 +427,13 @@ function Gallery() {
                             w="100%"
                             maw={{ base: "100%", sm: 340 }}
                             value={personFilter}
-                            onChange={setPersonFilter}
+                            onChange={(v) => {
+                                setPersonFilter(v);
+                                // A person search spans the whole gallery —
+                                // drop any category selection so results
+                                // aren't hidden by the current tab/card.
+                                if (v) setActiveCategory(null);
+                            }}
                         />
                     )}
 
@@ -467,9 +474,7 @@ function Gallery() {
                                                             height: 104,
                                                             borderRadius: 12,
                                                             overflow: "hidden",
-                                                            border: isGuest
-                                                                ? "2px solid var(--gold-dark)"
-                                                                : "1px solid #e9ecef",
+                                                            border: "1px solid #e9ecef",
                                                             backgroundColor: "#f1f3f5",
                                                         }}
                                                     >
@@ -490,6 +495,26 @@ function Gallery() {
                                                                     "linear-gradient(to top, rgba(0,0,0,0.55), rgba(0,0,0,0) 55%)",
                                                             }}
                                                         />
+                                                        {/* A chip, not a border — a gold outline
+                                                            reads as a selected state. */}
+                                                        {isGuest && (
+                                                            <Text
+                                                                style={{
+                                                                    position: "absolute",
+                                                                    top: 6,
+                                                                    left: 6,
+                                                                    backgroundColor: "var(--gold-dark)",
+                                                                    color: "#fff",
+                                                                    fontWeight: 600,
+                                                                    fontSize: 10,
+                                                                    lineHeight: 1,
+                                                                    padding: "4px 8px",
+                                                                    borderRadius: 999,
+                                                                }}
+                                                            >
+                                                                Share yours
+                                                            </Text>
+                                                        )}
                                                         <Text
                                                             style={{
                                                                 position: "absolute",


### PR DESCRIPTION
Follow-ups to #206 from testing the cards on the live site:

- **Blank covers**: no category has a curated `cover_photo_id`, so every card rendered grey. `/api/gallery/categories` now falls back to the newest approved photo in each category (only queried when at least one category lacks a cover); categories with no photos keep the placeholder. Covered by new route tests.
- **Guest Photos looked selected**: the gold border read as an active state next to the actually-selected All Photos. All cards now share the neutral border and Guest Photos gets a small gold "Share yours" chip instead.
- **Person search resets the category**: picking a name clears the current category so results span the whole gallery — including guest uploads (`professional=1` is skipped for person searches). The card strip stays visible, so tapping a category afterwards narrows the person's results to it (the API already composes `person` + `category`). Clearing the search returns to normal browsing.

Verified against LocalStack: fallback covers resolve for categories with photos, All Photos excludes the seeded guest upload, person-search view includes it, and the Guest Photos category shows it.