### PR TITLE
feat: click tracking on the gallery download button

### DIFF
--- a/src/app/gallery/my-photos/page.tsx
+++ b/src/app/gallery/my-photos/page.tsx
@@ -243,18 +243,7 @@ export default function MyPhotosPage() {
                         <RowsPhotoAlbum
                             photos={photos}
                             targetRowHeight={240}
-                            onClick={({ index }) => {
-                                setLightboxIndex(index);
-                                // Opening the lightbox is the download
-                                // button's impression — it only renders
-                                // there, and only with a code present.
-                                if (invitationCode) {
-                                    trackEvent(GalleryEvents.DOWNLOAD_BUTTON_IMPRESSION, {
-                                        invitation_code: invitationCode,
-                                        page: "my-photos",
-                                    });
-                                }
-                            }}
+                            onClick={({ index }) => setLightboxIndex(index)}
                         />
                     )}
                 </Stack>
@@ -265,7 +254,15 @@ export default function MyPhotosPage() {
                 close={() => setLightboxIndex(-1)}
                 slides={lightboxSlides}
                 index={lightboxIndex}
-                on={{ view: ({ index }) => setLightboxIndex(index) }}
+                on={{
+                    view: ({ index }) => setLightboxIndex(index),
+                    download: ({ index }) =>
+                        trackEvent(GalleryEvents.DOWNLOAD_CLICKED, {
+                            invitation_code: invitationCode,
+                            photo_id: photos[index]?.id,
+                            page: "my-photos",
+                        }),
+                }}
                 plugins={invitationCode ? [Captions, Download, Zoom] : [Captions, Zoom]}
                 zoom={{ maxZoomPixelRatio: 2 }}
                 render={{

--- a/src/app/gallery/my-photos/page.tsx
+++ b/src/app/gallery/my-photos/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "@mantine/core";
 import { IconAlertCircle, IconDownload } from "@tabler/icons-react";
 import { useSession } from "@/hooks/useSession";
+import { useTracking, GalleryEvents } from "@/hooks/useTracking";
 import { RowsPhotoAlbum } from "react-photo-album";
 import "react-photo-album/rows.css";
 import Lightbox from "yet-another-react-lightbox";
@@ -57,6 +58,7 @@ export default function MyPhotosPage() {
     const [validatingCode, setValidatingCode] = useState(false);
     const [loaded, setLoaded] = useState(false);
     const { status: sessionStatus, masterCode } = useSession();
+    const { trackEvent } = useTracking();
     const isAdmin = sessionStatus === "authenticated";
 
     const hasAccess = !!invitationCode || isAdmin;
@@ -241,7 +243,18 @@ export default function MyPhotosPage() {
                         <RowsPhotoAlbum
                             photos={photos}
                             targetRowHeight={240}
-                            onClick={({ index }) => setLightboxIndex(index)}
+                            onClick={({ index }) => {
+                                setLightboxIndex(index);
+                                // Opening the lightbox is the download
+                                // button's impression — it only renders
+                                // there, and only with a code present.
+                                if (invitationCode) {
+                                    trackEvent(GalleryEvents.DOWNLOAD_BUTTON_IMPRESSION, {
+                                        invitation_code: invitationCode,
+                                        page: "my-photos",
+                                    });
+                                }
+                            }}
                         />
                     )}
                 </Stack>

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -606,18 +606,7 @@ function Gallery() {
                         <RowsPhotoAlbum
                             photos={photos}
                             targetRowHeight={240}
-                            onClick={({ index }) => {
-                                setLightboxIndex(index);
-                                // Opening the lightbox is the download
-                                // button's impression — it only renders
-                                // there, and only with a code present.
-                                if (invitationCode) {
-                                    trackEvent(GalleryEvents.DOWNLOAD_BUTTON_IMPRESSION, {
-                                        invitation_code: invitationCode,
-                                        page: "gallery",
-                                    });
-                                }
-                            }}
+                            onClick={({ index }) => setLightboxIndex(index)}
                         />
                     )}
 
@@ -639,7 +628,15 @@ function Gallery() {
                 close={() => setLightboxIndex(-1)}
                 slides={lightboxSlides}
                 index={lightboxIndex}
-                on={{ view: ({ index }) => setLightboxIndex(index) }}
+                on={{
+                    view: ({ index }) => setLightboxIndex(index),
+                    download: ({ index }) =>
+                        trackEvent(GalleryEvents.DOWNLOAD_CLICKED, {
+                            invitation_code: invitationCode,
+                            photo_id: photos[index]?.id,
+                            page: "gallery",
+                        }),
+                }}
                 plugins={invitationCode ? [Captions, Download, Zoom] : [Captions, Zoom]}
                 zoom={{ maxZoomPixelRatio: 2 }}
                 render={{

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -30,6 +30,7 @@ import {
     IconChevronLeft,
 } from "@tabler/icons-react";
 import { useSession } from "@/hooks/useSession";
+import { useTracking, GalleryEvents } from "@/hooks/useTracking";
 import { useCategoryCardsFlag } from "@/hooks/useCategoryCardsFlag";
 import { FaceCrop } from "@/components/FaceCrop";
 import type { GalleryPerson } from "@/types/faces";
@@ -90,6 +91,7 @@ function Gallery() {
     const [myUploadsOnly, setMyUploadsOnly] = useState(false);
     const sentinelRef = useRef<HTMLDivElement | null>(null);
     const { status: sessionStatus, masterCode } = useSession();
+    const { trackEvent } = useTracking();
     const isAdmin = sessionStatus === "authenticated";
     const LIMIT = 40;
 
@@ -604,7 +606,18 @@ function Gallery() {
                         <RowsPhotoAlbum
                             photos={photos}
                             targetRowHeight={240}
-                            onClick={({ index }) => setLightboxIndex(index)}
+                            onClick={({ index }) => {
+                                setLightboxIndex(index);
+                                // Opening the lightbox is the download
+                                // button's impression — it only renders
+                                // there, and only with a code present.
+                                if (invitationCode) {
+                                    trackEvent(GalleryEvents.DOWNLOAD_BUTTON_IMPRESSION, {
+                                        invitation_code: invitationCode,
+                                        page: "gallery",
+                                    });
+                                }
+                            }}
                         />
                     )}
 

--- a/src/hooks/useTracking.ts
+++ b/src/hooks/useTracking.ts
@@ -148,6 +148,14 @@ export const InvitationEvents = {
     INVALID_LINK: 'invitation_invalid_link',
 } as const;
 
+// Gallery tracking events
+export const GalleryEvents = {
+    // The lightbox toolbar is the only place the download button renders,
+    // and only for callers with an invitation code — so one impression per
+    // lightbox open, carrying the code.
+    DOWNLOAD_BUTTON_IMPRESSION: 'gallery_download_button_impression',
+} as const;
+
 // Site-wide tracking events
 export const SiteEvents = {
     // Navigation

--- a/src/hooks/useTracking.ts
+++ b/src/hooks/useTracking.ts
@@ -150,10 +150,9 @@ export const InvitationEvents = {
 
 // Gallery tracking events
 export const GalleryEvents = {
-    // The lightbox toolbar is the only place the download button renders,
-    // and only for callers with an invitation code — so one impression per
-    // lightbox open, carrying the code.
-    DOWNLOAD_BUTTON_IMPRESSION: 'gallery_download_button_impression',
+    // Fired when the lightbox download button is pressed; carries the
+    // guest's invitation code and the photo id.
+    DOWNLOAD_CLICKED: 'gallery_download_clicked',
 } as const;
 
 // Site-wide tracking events


### PR DESCRIPTION
Adds a `gallery_download_clicked` PostHog event, fired only when the lightbox download button is actually pressed (the Download plugin's `on.download` callback).

- Properties: `invitation_code` (the guest's code; admins report the master code), `photo_id`, and `page` (`gallery` or `my-photos`).
- New `GalleryEvents` constant group in `useTracking`, following the existing `RSVPEvents`/`SiteEvents` pattern.
- Nothing fires on lightbox open or slide navigation; codeless visitors have no download button and produce no events.