### PR TITLE
feat: click tracking for all guest-facing CTAs

### DIFF
--- a/src/app/gallery/my-photos/page.tsx
+++ b/src/app/gallery/my-photos/page.tsx
@@ -17,7 +17,7 @@ import {
 } from "@mantine/core";
 import { IconAlertCircle, IconDownload } from "@tabler/icons-react";
 import { useSession } from "@/hooks/useSession";
-import { useTracking, GalleryEvents } from "@/hooks/useTracking";
+import { useTracking, GalleryEvents, SiteEvents } from "@/hooks/useTracking";
 import { RowsPhotoAlbum } from "react-photo-album";
 import "react-photo-album/rows.css";
 import Lightbox from "yet-another-react-lightbox";
@@ -64,6 +64,14 @@ export default function MyPhotosPage() {
     const hasAccess = !!invitationCode || isAdmin;
     const showCodeGate = codeChecked && !invitationCode && sessionStatus === "unauthenticated";
 
+    // One event for every CTA on the page, keyed by the `cta` slug.
+    const trackCta = (cta: string) =>
+        trackEvent(SiteEvents.CTA_CLICK, {
+            cta,
+            page: "my-photos",
+            ...(invitationCode && { invitation_code: invitationCode }),
+        });
+
     // Same storage key as the main gallery: guests who've been through the
     // gate once are already recognised here.
     useEffect(() => {
@@ -78,7 +86,9 @@ export default function MyPhotosPage() {
         setInvitationCode(masterCode);
     }, [isAdmin, invitationCode, masterCode]);
 
+    // Tracked here rather than on the button so Enter-key submits count too.
     const handleCodeSubmit = async () => {
+        trackCta("code_submit");
         const trimmed = codeInput.trim().toUpperCase();
         if (!/^[A-Z0-9]{6}$/.test(trimmed)) {
             setCodeError("Please enter your 6-character invitation code");
@@ -188,7 +198,13 @@ export default function MyPhotosPage() {
                                     : "Every photo from the day that you appear in"}
                             </Text>
                         </Box>
-                        <Button component={Link} href="/gallery" variant="light" color="yellow">
+                        <Button
+                            component={Link}
+                            href="/gallery"
+                            variant="light"
+                            color="yellow"
+                            onClick={() => trackCta("full_gallery")}
+                        >
                             Full Gallery
                         </Button>
                     </Flex>

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -30,7 +30,7 @@ import {
     IconChevronLeft,
 } from "@tabler/icons-react";
 import { useSession } from "@/hooks/useSession";
-import { useTracking, GalleryEvents } from "@/hooks/useTracking";
+import { useTracking, GalleryEvents, SiteEvents } from "@/hooks/useTracking";
 import { useCategoryCardsFlag } from "@/hooks/useCategoryCardsFlag";
 import { FaceCrop } from "@/components/FaceCrop";
 import type { GalleryPerson } from "@/types/faces";
@@ -101,6 +101,14 @@ function Gallery() {
     const hasAccess = !!invitationCode || isAdmin;
     const showCodeGate = codeChecked && !invitationCode && sessionStatus === "unauthenticated";
 
+    // One event for every CTA on the page, keyed by the `cta` slug.
+    const trackCta = (cta: string) =>
+        trackEvent(SiteEvents.CTA_CLICK, {
+            cta,
+            page: "gallery",
+            ...(invitationCode && { invitation_code: invitationCode }),
+        });
+
     // The photo list as of the latest render — rejectCurrent reads it after
     // an await, by which point the closed-over `photos` may be stale (e.g.
     // infinite scroll appended a page while the PATCH was in flight).
@@ -160,8 +168,10 @@ function Gallery() {
         setInvitationCode(masterCode);
     }, [isAdmin, invitationCode, masterCode]);
 
-    // Manual entry on the code gate.
+    // Manual entry on the code gate. Tracked here rather than on the button
+    // so Enter-key submits count too.
     const handleCodeSubmit = async () => {
+        trackCta("code_submit");
         const trimmed = codeInput.trim().toUpperCase();
         if (!/^[A-Z0-9]{6}$/.test(trimmed)) {
             setCodeError("Please enter your 6-character invitation code");
@@ -345,10 +355,17 @@ function Gallery() {
                                     href="/gallery/my-photos"
                                     variant="light"
                                     color="yellow"
+                                    onClick={() => trackCta("find_my_photos")}
                                 >
                                     Find My Photos
                                 </Button>
-                                <Button component={Link} href="/gallery/upload" variant="light" color="yellow">
+                                <Button
+                                    component={Link}
+                                    href="/gallery/upload"
+                                    variant="light"
+                                    color="yellow"
+                                    onClick={() => trackCta("upload_photos")}
+                                >
                                     Upload Photos
                                 </Button>
                             </Group>

--- a/src/app/gallery/upload/page.tsx
+++ b/src/app/gallery/upload/page.tsx
@@ -21,6 +21,7 @@ import {
 } from "@mantine/core";
 import { IconAlertCircle, IconUpload, IconX, IconCheck } from "@tabler/icons-react";
 import { useSession } from "@/hooks/useSession";
+import { useTracking, SiteEvents } from "@/hooks/useTracking";
 import type { UploadUrlResponse } from "@/types/photos";
 
 interface FileUploadState {
@@ -69,6 +70,7 @@ export default function UploadPage() {
     const fileInputRef = useRef<HTMLInputElement>(null);
 
     const { masterCode } = useSession();
+    const { trackEvent } = useTracking();
 
     // Logged-in admins get the bride & groom's master code auto-filled, same
     // as on the gallery page (useSession resolves it; guests get null).
@@ -102,7 +104,16 @@ export default function UploadPage() {
             .catch(() => {}); // greeting falls back to the code itself
     }, [code]);
 
+    // One event for every CTA on the page, keyed by the `cta` slug.
+    const trackCta = (cta: string) =>
+        trackEvent(SiteEvents.CTA_CLICK, {
+            cta,
+            page: "upload",
+            ...(code && { invitation_code: code }),
+        });
+
     const validateCode = async () => {
+        trackCta("code_submit");
         const trimmed = codeInput.trim().toUpperCase();
         if (trimmed.length !== 6) {
             setCodeError("Please enter your 6-character invitation code");
@@ -315,10 +326,22 @@ export default function UploadPage() {
                                     justify="center"
                                     w="100%"
                                 >
-                                    <Button color="yellow" onClick={resetForMoreUploads}>
+                                    <Button
+                                        color="yellow"
+                                        onClick={() => {
+                                            trackCta("upload_more");
+                                            resetForMoreUploads();
+                                        }}
+                                    >
                                         Upload more photos
                                     </Button>
-                                    <Button component={Link} href="/gallery" variant="light" color="yellow">
+                                    <Button
+                                        component={Link}
+                                        href="/gallery"
+                                        variant="light"
+                                        color="yellow"
+                                        onClick={() => trackCta("view_gallery")}
+                                    >
                                         View the gallery
                                     </Button>
                                 </Flex>
@@ -350,7 +373,15 @@ export default function UploadPage() {
                                 <Text size="sm" c="dimmed">
                                     Uploading as <strong>{names.length > 0 ? formatNames(names) : code}</strong>
                                 </Text>
-                                <Button size="xs" variant="subtle" color="gray" onClick={() => setCodeValidated(false)}>
+                                <Button
+                                    size="xs"
+                                    variant="subtle"
+                                    color="gray"
+                                    onClick={() => {
+                                        trackCta("change_code");
+                                        setCodeValidated(false);
+                                    }}
+                                >
                                     Change code
                                 </Button>
                             </Group>
@@ -368,7 +399,10 @@ export default function UploadPage() {
                                 leftSection={<IconUpload size={16} />}
                                 variant="outline"
                                 color="yellow"
-                                onClick={() => fileInputRef.current?.click()}
+                                onClick={() => {
+                                    trackCta("choose_photos");
+                                    fileInputRef.current?.click();
+                                }}
                                 disabled={uploading}
                             >
                                 Choose photos {files.length > 0 && `(${files.length} selected)`}
@@ -414,7 +448,10 @@ export default function UploadPage() {
                             {files.filter((f) => f.status === "pending").length > 0 && (
                                 <Button
                                     color="yellow"
-                                    onClick={handleUpload}
+                                    onClick={() => {
+                                        trackCta("upload_submit");
+                                        handleUpload();
+                                    }}
                                     loading={uploading}
                                 >
                                     Upload {files.filter((f) => f.status === "pending").length} photo

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useGalleryFlag } from "@/hooks/useGalleryFlag";
 import { useSession } from "@/hooks/useSession";
+import { useTracking, SiteEvents } from "@/hooks/useTracking";
 import classes from "./Navigation.module.css";
 
 const navLinkStyle = {
@@ -18,6 +19,8 @@ const navLinkStyle = {
 export function Navigation() {
     const galleryFlag = useGalleryFlag();
     const { status, refresh } = useSession();
+    const { trackEvent } = useTracking();
+    const trackNav = (target: string) => trackEvent(SiteEvents.NAV_CLICK, { target });
     const router = useRouter();
     const pathname = usePathname();
     const [loggingOut, setLoggingOut] = useState(false);
@@ -68,12 +71,20 @@ export function Navigation() {
                         letterSpacing: "0.02em",
                         transition: "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
                     }}
+                    onClick={() => trackNav("home")}
                 >
                     Rebecca & Matthew
                 </Anchor>
                 <Group gap="md" wrap="nowrap">
                     {galleryFlag === "on" && (
-                        <Anchor component={Link} href="/gallery" size="sm" fw={400} style={navLinkStyle}>
+                        <Anchor
+                            component={Link}
+                            href="/gallery"
+                            size="sm"
+                            fw={400}
+                            style={navLinkStyle}
+                            onClick={() => trackNav("gallery")}
+                        >
                             Gallery
                         </Anchor>
                     )}
@@ -84,14 +95,24 @@ export function Navigation() {
                                     {logoutError}
                                 </Text>
                             )}
-                            <Anchor component={Link} href="/dashboard" size="sm" fw={400} style={navLinkStyle}>
+                            <Anchor
+                                component={Link}
+                                href="/dashboard"
+                                size="sm"
+                                fw={400}
+                                style={navLinkStyle}
+                                onClick={() => trackNav("dashboard")}
+                            >
                                 Dashboard
                             </Anchor>
                             <Button
                                 variant="subtle"
                                 color="gray"
                                 size="compact-sm"
-                                onClick={handleLogout}
+                                onClick={() => {
+                                    trackNav("logout");
+                                    handleLogout();
+                                }}
                                 loading={loggingOut}
                             >
                                 Logout

--- a/src/hooks/useTracking.ts
+++ b/src/hooks/useTracking.ts
@@ -161,6 +161,10 @@ export const SiteEvents = {
     NAV_CLICK: 'nav_click',
     EXTERNAL_LINK_CLICK: 'external_link_click',
 
+    // Any call-to-action button; distinguished by the `cta` property
+    // (plus `page`, and `invitation_code` when the caller has one).
+    CTA_CLICK: 'cta_click',
+
     // Pages
     PAGE_404: 'page_404',
 


### PR DESCRIPTION
Adds a single `cta_click` PostHog event for every guest-facing call-to-action, distinguished by properties rather than one event name per button:

- `cta` — stable slug (`find_my_photos`, `upload_photos`, `code_submit`, `full_gallery`, `choose_photos`, `upload_submit`, `upload_more`, `view_gallery`, `change_code`)
- `page` — `gallery`, `my-photos`, or `upload`
- `invitation_code` — included whenever the caller has one (admins report the master code)

Coverage:
- **Gallery**: Find My Photos, Upload Photos, code-gate submit
- **Find My Photos**: Full Gallery, code-gate submit
- **Upload**: Continue (code submit), Change code, Choose photos, Upload N photos, Upload more photos, View the gallery

Code-gate submits are tracked inside the submit handler rather than on the button so Enter-key submissions count as well. Download clicks already have their own event from #209.

Also wires the previously-defined-but-unused `nav_click` event onto the site nav (home / gallery / dashboard / logout).

Admin dashboard buttons are deliberately untracked. Lint, typecheck, and all 220 tests pass.